### PR TITLE
feat: Add support for pill shaped holes

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/process-plated-holes.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/process-plated-holes.ts
@@ -56,6 +56,11 @@ export function processPlatedHoles(
     const componentName = sourceComponent?.name || `H${componentId}`
 
     holes.forEach((platedHole) => {
+      // Skip oval plated holes
+      if (platedHole.shape === "oval") {
+        throw new Error("Oval plated holes are not supported")
+      }
+
       let padstackName: string
       let imageName: string
       let outerDiameterUm = 0

--- a/lib/dsn-pcb/circuit-json-to-dsn-json/process-plated-holes.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/process-plated-holes.ts
@@ -4,7 +4,7 @@ import type {
   PcbPlatedHole,
   PcbPlatedHoleCircle,
   SourceComponentBase,
-  PcbPlatedHoleOval
+  PcbPlatedHoleOval,
 } from "circuit-json"
 import { applyToPoint, scale } from "transformation-matrix"
 import type { DsnPcb } from "../types"

--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
@@ -97,6 +97,8 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
         result += `${indent}${indent}${indent}(shape (polygon ${shape.layer} ${shape.width} ${stringifyCoordinates(shape.coordinates)}))\n`
       } else if (shape.shapeType === "circle") {
         result += `${indent}${indent}${indent}(shape (circle ${shape.layer} ${shape.diameter}))\n`
+      } else if (shape.shapeType === "path") {
+        result += `${indent}${indent}${indent}(shape (path ${shape.layer} ${shape.width} ${stringifyCoordinates(shape.coordinates)}))\n`
       }
     })
     result += `${indent}${indent}${indent}(attach ${padstack.attach})\n`

--- a/lib/dsn-pcb/dsn-json-to-circuit-json/dsn-component-converters/convert-padstacks-to-smtpads.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/dsn-component-converters/convert-padstacks-to-smtpads.ts
@@ -46,6 +46,10 @@ export function convertPadstacksToSmtPads(
           (shape) => shape.shapeType === "circle",
         )
 
+        const pathShape = padstack.shapes.find(
+          (shape) => shape.shapeType === "path",
+        )
+
         let width: number
         let height: number
 
@@ -75,6 +79,12 @@ export function convertPadstacksToSmtPads(
 
           width = Math.abs(maxX - minX) / 1000
           height = Math.abs(maxY - minY) / 1000
+        } else if (pathShape) {
+          // For path shapes (oval/pill pads), width is the path width
+          // and height is the distance between path endpoints
+          const [x1, y1, x2, y2] = pathShape.coordinates
+          width = pathShape.width / 1000 // Convert μm to mm
+          height = Math.sqrt((x2 - x1) ** 2 + (y2 - y1) ** 2) / 1000
         } else if (circleShape) {
           // Handle circle shape
           const radius = circleShape.diameter / 2 / 1000
@@ -93,7 +103,7 @@ export function convertPadstacksToSmtPads(
         })
 
         let pcbPad: PcbSmtPad
-        if (rectShape || polygonShape) {
+        if (rectShape || polygonShape || pathShape) {
           pcbPad = {
             type: "pcb_smtpad",
             pcb_smtpad_id: `pcb_smtpad_${componentId}_${place.refdes}_${pin.pin_number - 1}`,

--- a/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
@@ -23,6 +23,7 @@ import type {
   Padstack,
   Parser as ParserType,
   Path,
+  PathShape,
   Pin,
   Placement,
   Places,
@@ -633,6 +634,8 @@ function processShape(nodes: ASTNode[]): Shape {
           return processCircleShape(shapeContentNode.children!)
         case "rect":
           return processRectShape(shapeContentNode.children!)
+        case "path":
+          return processPathShape(shapeContentNode.children!)
       }
     }
   }
@@ -1049,4 +1052,24 @@ function processSessionNode(ast: ASTNode): DsnSession {
   }
 
   return session
+}
+
+function processPathShape(nodes: ASTNode[]): PathShape {
+  if (
+    nodes[1]?.type === "Atom" &&
+    typeof nodes[1].value === "string" &&
+    nodes[2]?.type === "Atom" &&
+    typeof nodes[2].value === "number"
+  ) {
+    return {
+      shapeType: "path",
+      layer: nodes[1].value,
+      width: nodes[2].value,
+      coordinates: nodes
+        .slice(3)
+        .filter((node) => node.type === "Atom" && typeof node.value === "number")
+        .map((node) => node.value as number)
+    }
+  }
+  throw new Error("Invalid path shape format")
 }

--- a/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
@@ -1067,8 +1067,10 @@ function processPathShape(nodes: ASTNode[]): PathShape {
       width: nodes[2].value,
       coordinates: nodes
         .slice(3)
-        .filter((node) => node.type === "Atom" && typeof node.value === "number")
-        .map((node) => node.value as number)
+        .filter(
+          (node) => node.type === "Atom" && typeof node.value === "number",
+        )
+        .map((node) => node.value as number),
     }
   }
   throw new Error("Invalid path shape format")

--- a/lib/dsn-pcb/types.ts
+++ b/lib/dsn-pcb/types.ts
@@ -200,8 +200,10 @@ export interface Padstack {
   shapes: Shape[]
   attach: string
   hole?: {
-    shape: "circle" | "square"
-    diameter: number
+    shape: "circle" | "square" | "oval"
+    width?: number
+    height?: number
+    diameter?: number
   }
 }
 
@@ -211,7 +213,7 @@ export interface PadDimensions {
   radius?: number
 }
 
-export type Shape = PolygonShape | CircleShape | RectShape
+export type Shape = PolygonShape | CircleShape | RectShape | PathShape
 
 export interface BaseShape {
   shapeType: string // Added shapeType to base export interface
@@ -231,6 +233,12 @@ export interface CircleShape extends BaseShape {
 
 export interface RectShape extends BaseShape {
   shapeType: "rect"
+  coordinates: number[]
+}
+
+export interface PathShape extends BaseShape {
+  shapeType: "path"
+  width: number
   coordinates: number[]
 }
 

--- a/tests/assets/repro/pill-shaped-plated-hole.json
+++ b/tests/assets/repro/pill-shaped-plated-hole.json
@@ -1,0 +1,148 @@
+[
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_0",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": [
+      "anode",
+      "pos",
+      "left",
+      "pin1",
+      "1"
+    ],
+    "source_component_id": "source_component_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_1",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": [
+      "cathode",
+      "neg",
+      "right",
+      "pin2",
+      "2"
+    ],
+    "source_component_id": "source_component_0"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_0",
+    "ftype": "simple_resistor",
+    "name": "R1",
+    "supplier_part_numbers": {
+      "jlcpcb": [
+        "C22859",
+        "C25077",
+        "C17415"
+      ]
+    },
+    "resistance": 10
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": 0,
+      "y": 0
+    },
+    "rotation": 0,
+    "size": {
+      "width": 1.1238982820000005,
+      "height": 0.24999600000000122
+    },
+    "source_component_id": "source_component_0",
+    "symbol_name": "boxresistor_horz",
+    "symbol_display_value": "10Ω"
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_0",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": -0.5337907000000003,
+      "y": 0.004194800000000665
+    },
+    "source_port_id": "source_port_0",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "left"
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_1",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": 0.5337907000000003,
+      "y": 0.004741299999999338
+    },
+    "source_port_id": "source_port_1",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "right"
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_0",
+    "center": {
+      "x": 0,
+      "y": 0
+    },
+    "width": 1.1999975999999999,
+    "height": 1.7999964,
+    "layer": "top",
+    "rotation": 0,
+    "source_component_id": "source_component_0"
+  },
+  {
+    "type": "pcb_board",
+    "pcb_board_id": "pcb_board_0",
+    "center": {
+      "x": 0,
+      "y": 0
+    },
+    "thickness": 1.4,
+    "num_layers": 4,
+    "width": 10,
+    "height": 10
+  },
+  {
+    "type": "pcb_plated_hole",
+    "pcb_plated_hole_id": "pcb_plated_hole_0",
+    "pcb_component_id": "pcb_component_0",
+    "outer_width": 1.1999975999999999,
+    "outer_height": 1.7999964,
+    "hole_width": 0.7999983999999999,
+    "hole_height": 1.3999972,
+    "shape": "pill",
+    "port_hints": [
+      "alt_2"
+    ],
+    "x": 0,
+    "y": 0,
+    "layers": [
+      "top",
+      "bottom"
+    ]
+  },
+  {
+    "type": "cad_component",
+    "cad_component_id": "cad_component_0",
+    "position": {
+      "x": 0,
+      "y": 0,
+      "z": 0.7
+    },
+    "rotation": {
+      "x": 0,
+      "y": 0,
+      "z": 0
+    },
+    "pcb_component_id": "pcb_component_0",
+    "source_component_id": "source_component_0"
+  }
+]

--- a/tests/assets/repro/pill-shaped-plated-hole.json
+++ b/tests/assets/repro/pill-shaped-plated-hole.json
@@ -4,13 +4,7 @@
     "source_port_id": "source_port_0",
     "name": "pin1",
     "pin_number": 1,
-    "port_hints": [
-      "anode",
-      "pos",
-      "left",
-      "pin1",
-      "1"
-    ],
+    "port_hints": ["anode", "pos", "left", "pin1", "1"],
     "source_component_id": "source_component_0"
   },
   {
@@ -18,13 +12,7 @@
     "source_port_id": "source_port_1",
     "name": "pin2",
     "pin_number": 2,
-    "port_hints": [
-      "cathode",
-      "neg",
-      "right",
-      "pin2",
-      "2"
-    ],
+    "port_hints": ["cathode", "neg", "right", "pin2", "2"],
     "source_component_id": "source_component_0"
   },
   {
@@ -33,11 +21,7 @@
     "ftype": "simple_resistor",
     "name": "R1",
     "supplier_part_numbers": {
-      "jlcpcb": [
-        "C22859",
-        "C25077",
-        "C17415"
-      ]
+      "jlcpcb": ["C22859", "C25077", "C17415"]
     },
     "resistance": 10
   },
@@ -119,15 +103,10 @@
     "hole_width": 0.7999983999999999,
     "hole_height": 1.3999972,
     "shape": "pill",
-    "port_hints": [
-      "alt_2"
-    ],
+    "port_hints": ["alt_2"],
     "x": 0,
     "y": 0,
-    "layers": [
-      "top",
-      "bottom"
-    ]
+    "layers": ["top", "bottom"]
   },
   {
     "type": "cad_component",

--- a/tests/dsn-pcb/pill-shape-plated-hole-dimestion-check.test.ts
+++ b/tests/dsn-pcb/pill-shape-plated-hole-dimestion-check.test.ts
@@ -1,0 +1,29 @@
+import { convertCircuitJsonToPcbSvg } from "circuit-to-svg"
+import { convertDsnJsonToCircuitJson } from "../../lib/dsn-pcb/dsn-json-to-circuit-json/convert-dsn-json-to-circuit-json.ts"
+import { expect, test } from "bun:test"
+import { convertCircuitJsonToDsnString, parseDsnToDsnJson } from "lib"
+
+import circuitJson from "../assets/repro/pill-shaped-plated-hole.json"
+import type { AnyCircuitElement } from "circuit-json"
+import type { DsnPcb } from "lib"
+
+test("check pill shape plated hole dimension", async () => {
+  // Getting the dsn file from the circuit json
+  const dsnFile = convertCircuitJsonToDsnString(
+    circuitJson as AnyCircuitElement[],
+  )
+
+  const dsnJson = parseDsnToDsnJson(dsnFile) as DsnPcb
+  const circuitJson2 = convertDsnJsonToCircuitJson(dsnJson)
+
+  // TODO: udpate the test to convert this to plated_hole
+  // check if the smtpad has the correct dimensions
+  const pcbSmtpads = circuitJson2.filter((e) => e.type === "pcb_smtpad")
+  expect(pcbSmtpads.length).toBe(1)
+
+  expect(
+    pcbSmtpads.some(
+      (p) => p.shape === "rect" && p.width === 1.8 && p.height === 0.6,
+    ),
+  ).toBe(true)
+})


### PR DESCRIPTION
Issue -  #41 

This add support for the pill shaped `plated_holes` .

More work needed in future

**Note:** We are good now, cause in the first flow of circuit_json to dsn the dimension of the pill is correctly mapped to the dsn which will used in routing and we will then be extracting the trace's. Currently, when we are processing the dsnJson back, then we are adding this just as a rect `pcb_smtpad`. We need to have a function which creates `plated_hole` by some logic of finding name of `Hole` in imageName and then converting that to `plated_hole`. Created an issue for this - #48 

PS: The plated_hole shape `Oval` is not added here because of the issue in footprint of it - https://github.com/tscircuit/snippets/issues/342