### PR TITLE
fix: add default width and height for group subcircuit

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/convert-circuit-json-to-dsn-json.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/convert-circuit-json-to-dsn-json.ts
@@ -137,11 +137,17 @@ function calculateBoardBoundary(pcbBoard: {
   height: number
   center: { x: number; y: number }
 }): number[] {
+  // default to 100mm x 100mm if not provided
+  const width = pcbBoard?.width ?? 100
+  const height = pcbBoard?.height ?? 100
+  const x = pcbBoard?.center?.x ?? 0
+  const y = pcbBoard?.center?.y ?? 0
+
   // Convert dimensions from mm to μm and calculate corners
-  const halfWidth = (pcbBoard.width * 1000) / 2
-  const halfHeight = (pcbBoard.height * 1000) / 2
-  const centerX = pcbBoard.center.x * 1000
-  const centerY = pcbBoard.center.y * 1000
+  const halfWidth = (width * 1000) / 2
+  const halfHeight = (height * 1000) / 2
+  const centerX = x * 1000
+  const centerY = y * 1000
 
   // Return coordinates for a rectangular boundary path
   // Format: [x1, y1, x2, y2, x3, y3, x4, y4, x1, y1] to close the path

--- a/lib/dsn-pcb/dsn-json-to-circuit-json/dsn-component-converters/convert-dsn-pcb-components-to-source-components-and-ports.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/dsn-component-converters/convert-dsn-pcb-components-to-source-components-and-ports.ts
@@ -39,7 +39,7 @@ export const convertDsnPcbComponentsToSourceComponentsAndPorts = ({
             source_port_id: `source_port_${component.name}-Pad${pin.pin_number}`,
             source_component_id: sourceComponent.source_component_id,
             name: `${component.places[0].refdes}-${pin.pin_number}`,
-            pin_number: pin.pin_number,
+            pin_number: Number(pin.pin_number),
             port_hints: [],
           }
           // Handle case where place coordinates might be null/undefined

--- a/lib/dsn-pcb/dsn-json-to-circuit-json/dsn-component-converters/convert-padstacks-to-smtpads.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/dsn-component-converters/convert-padstacks-to-smtpads.ts
@@ -106,7 +106,7 @@ export function convertPadstacksToSmtPads(
         if (rectShape || polygonShape || pathShape) {
           pcbPad = {
             type: "pcb_smtpad",
-            pcb_smtpad_id: `pcb_smtpad_${componentId}_${place.refdes}_${pin.pin_number - 1}`,
+            pcb_smtpad_id: `pcb_smtpad_${componentId}_${place.refdes}_${Number(pin.pin_number) - 1}`,
             pcb_component_id: `${componentId}_${place.refdes}`,
             pcb_port_id: `pcb_port_${componentId}-Pad${pin.pin_number}`,
             shape: "rect",
@@ -120,7 +120,7 @@ export function convertPadstacksToSmtPads(
         } else {
           pcbPad = {
             type: "pcb_smtpad",
-            pcb_smtpad_id: `pcb_smtpad_${componentId}_${place.refdes}_${pin.pin_number - 1}`,
+            pcb_smtpad_id: `pcb_smtpad_${componentId}_${place.refdes}_${Number(pin.pin_number) - 1}`,
             pcb_component_id: `${componentId}_${place.refdes}`,
             pcb_port_id: `pcb_port_${componentId}-Pad${pin.pin_number}`,
             shape: "circle",

--- a/tests/assets/repro/subcircuit_input.dsn
+++ b/tests/assets/repro/subcircuit_input.dsn
@@ -1,0 +1,77 @@
+(pcb ./converted_dsn.dsn
+  (parser
+    (string_quote ")
+    (space_in_quoted_tokens on)
+    (host_cad "KiCad's Pcbnew")
+    (host_version "")
+  )
+  (resolution um 10)
+  (unit um)
+  (structure
+    (layer F.Cu
+      (type signal)
+      (property
+        (index 0)
+      )
+    )
+    (layer B.Cu
+      (type signal)
+      (property
+        (index 1)
+      )
+    )
+    (boundary
+      (path pcb 0  -50000 -50000 50000 -50000 50000 50000 -50000 50000 -50000 -50000)
+    )
+    (via "Via[0-1]_600:300_um")
+    (rule
+      (width 200)
+      (clearance 200)
+      (clearance 200 (type default_smd))
+      (clearance 50 (type smd_smd))
+    )
+  )
+  (placement
+    (component "simple_resistor:1.6000x0.6000_mm"
+      (place R1 0 0 front 0 (PN "100"))
+      (place R2 2000 0 front 0 (PN "100"))
+    )
+  )
+  (library
+    (image "simple_resistor:1.6000x0.6000_mm"
+      (pin RoundRect[T]Pad_600.0000000000001x600.0000000000001_um 1 -500 0)
+      (pin RoundRect[T]Pad_600.0000000000001x600.0000000000001_um 2 500 0)
+    )
+    (padstack "Via[0-1]_600:300_um"
+      (shape (circle F.Cu 600))
+      (shape (circle B.Cu 600))
+      (attach off)
+    )
+    (padstack "RoundRect[T]Pad_600.0000000000001x600.0000000000001_um"
+      (shape (polygon F.Cu 0 -300 300 300 300 300 -300 -300 -300 -300 300))
+      (attach off)
+    )
+  )
+  (network
+    (net "Net-(R1-Pad1)"
+      (pins R1-1 R2-1)
+    )
+    (net "unconnected-(R1-Pad2)"
+      (pins R1-2)
+    )
+    (net "unconnected-(R2-Pad2)"
+      (pins R2-2)
+    )
+    (class "kicad_default" "" "Net-(R1-Pad1)" "unconnected-(R1-Pad2)" "unconnected-(R2-Pad2)"
+      (circuit
+        (use_via "Via[0-1]_600:300_um")
+      )
+      (rule
+        (width 200)
+        (clearance 200)
+      )
+    )
+  )
+  (wiring
+  )
+)

--- a/tests/assets/repro/subcircuit_output.ses
+++ b/tests/assets/repro/subcircuit_output.ses
@@ -1,0 +1,61 @@
+(session "tscircuit-cbf5392b-ca3f-416f-b572-67a57783b97f"
+  (base_design "tscircuit-cbf5392b-ca3f-416f-b572-67a57783b97f")
+  (placement
+    (resolution um 10)
+    (component simple_resistor:1.6000x0.6000_mm
+      (place R1 0 0 front 0)
+      (place R2 20000 0 front 0)
+    )
+  )
+  (was_is
+  )
+  (routes 
+    (resolution um 10)
+    (parser
+      (host_cad "KiCad's Pcbnew")
+      (host_version )
+    )
+    (library_out 
+      (padstack "Via[0-1]_600:300_um"
+        (shape
+          (circle F.Cu 6000 0 0)
+        )
+        (shape
+          (circle B.Cu 6000 0 0)
+        )
+        (attach off)
+      )
+      (padstack "Via[0-1]_600:300_um"
+        (shape
+          (circle F.Cu 6000 0 0)
+        )
+        (shape
+          (circle B.Cu 6000 0 0)
+        )
+        (attach off)
+      )
+    )
+    (network_out 
+      (net "Net-(R1-Pad1)"
+        (wire
+          (path F.Cu 2000
+            -5000 0
+            -5000 -6017
+          )
+        )
+        (wire
+          (path F.Cu 2000
+            15000 0
+            15000 -6017
+          )
+        )
+        (wire
+          (path F.Cu 2000
+            15000 -6017
+            -5000 -6017
+          )
+        )
+      )
+    )
+  )
+)

--- a/tests/repros/__snapshots__/repro-6-subcircuit-group.snap.svg
+++ b/tests/repros/__snapshots__/repro-6-subcircuit-group.snap.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="600"><style>
+              .boundary { fill: #000; }
+              .pcb-board { fill: none; }
+              .pcb-trace { fill: none; }
+              .pcb-hole-outer { fill: rgb(200, 52, 52); }
+              .pcb-hole-inner { fill: rgb(255, 38, 226); }
+              .pcb-pad { }
+              .pcb-boundary { fill: none; stroke: #fff; stroke-width: 0.3; }
+              .pcb-silkscreen { fill: none; }
+              .pcb-silkscreen-top { stroke: #f2eda1; }
+              .pcb-silkscreen-bottom { stroke: #f2eda1; }
+              .pcb-silkscreen-text { fill: #f2eda1; }
+            </style><rect class="boundary" x="0" y="0" width="800" height="600"/><rect class="pcb-boundary" x="105.88235294117646" y="5.882352941176464" width="588.2352941176471" height="588.2352941176471"/><path class="pcb-board" d="M 105.88235294117646 594.1176470588235 L 694.1176470588235 594.1176470588235 L 694.1176470588235 5.882352941176464 L 105.88235294117646 5.882352941176464 Z" stroke="rgba(255, 255, 255, 0.5)" stroke-width="0.5882352941176471"/><rect class="pcb-pad" fill="rgb(200, 52, 52)" x="395.29411764705884" y="298.2352941176471" width="3.5294117647058827" height="3.5294117647058827"/><rect class="pcb-pad" fill="rgb(200, 52, 52)" x="401.1764705882353" y="298.2352941176471" width="3.5294117647058827" height="3.5294117647058827"/><rect class="pcb-pad" fill="rgb(200, 52, 52)" x="407.05882352941177" y="298.2352941176471" width="3.5294117647058827" height="3.5294117647058827"/><rect class="pcb-pad" fill="rgb(200, 52, 52)" x="412.94117647058823" y="298.2352941176471" width="3.5294117647058827" height="3.5294117647058827"/><path class="pcb-trace" stroke="rgb(200, 52, 52)" d="M 397.05882352941177 300 L 397.05882352941177 303.5394117647059" stroke-width="0.9411764705882354" stroke-linecap="round" stroke-linejoin="round" shape-rendering="crispEdges"/><path class="pcb-trace" stroke="rgb(200, 52, 52)" d="M 408.8235294117647 300 L 408.8235294117647 303.5394117647059" stroke-width="0.9411764705882354" stroke-linecap="round" stroke-linejoin="round" shape-rendering="crispEdges"/><path class="pcb-trace" stroke="rgb(200, 52, 52)" d="M 408.8235294117647 303.5394117647059 L 397.05882352941177 303.5394117647059" stroke-width="0.9411764705882354" stroke-linecap="round" stroke-linejoin="round" shape-rendering="crispEdges"/></svg>

--- a/tests/repros/repro-6-subcircuit-group.test.ts
+++ b/tests/repros/repro-6-subcircuit-group.test.ts
@@ -1,0 +1,31 @@
+import { expect, test } from "bun:test"
+import {
+  convertCircuitJsonToDsnString,
+  convertDsnSessionToCircuitJson,
+  parseDsnToDsnJson,
+  parseDsnToCircuitJson,
+} from "lib"
+
+import { convertCircuitJsonToPcbSvg } from "circuit-to-svg"
+import type { DsnPcb, DsnSession } from "lib"
+// @ts-ignore
+import testSesFile from "../assets/repro/subcircuit_output.ses" with {
+  type: "text",
+}
+// @ts-ignore
+import inputDsnFile from "../assets/repro/subcircuit_input.dsn" with {
+  type: "text",
+}
+
+test("check the group subcircuit without board boundary", async () => {
+  const pcbJson = parseDsnToDsnJson(inputDsnFile) as DsnPcb
+  const sessionJson = parseDsnToDsnJson(testSesFile) as DsnSession
+  const circuitJsonFromSession = convertDsnSessionToCircuitJson(
+    pcbJson,
+    sessionJson,
+  )
+
+  expect(convertCircuitJsonToPcbSvg(circuitJsonFromSession)).toMatchSvgSnapshot(
+    import.meta.path,
+  )
+})


### PR DESCRIPTION
Making the default board large 100mm for `<group/>`, to be on the safe side. 