### PR TITLE
fix: trace width used in freerouting

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/convert-circuit-json-to-dsn-json.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/convert-circuit-json-to-dsn-json.ts
@@ -114,7 +114,7 @@ export function convertCircuitJsonToDsnJson(
                 type: "",
               },
             ],
-            width: 200,
+            width: 100, // trace width used in freerouting
           },
         },
       ],


### PR DESCRIPTION
The trace width were bigger than the component width, because of that freerouting was not routing to the smtpads

![image](https://github.com/user-attachments/assets/bbbceaaf-5ccf-49c8-a510-3b8efe2b41ca)
