### PR TITLE
fix merge dsn session to have SVG parity

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/process-pcb-traces/DsnTraceOperationsWrapper.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/process-pcb-traces/DsnTraceOperationsWrapper.ts
@@ -1,0 +1,52 @@
+import type { DsnPcb, DsnSession, Wire } from "lib/dsn-pcb/types"
+
+export interface DsnTraceOperationsWrapper {
+  getNextNetId(): string
+  addWire(wire: Wire): void
+  getLibrary(): DsnPcb["library"]
+  getStructure(): DsnPcb["structure"] | null
+}
+
+/**
+ * This operations wrapper allows you to operate on either DSN PCB or DSN
+ * Session objects, increasing code reusability when working with traces.
+ *
+ * Please add more methods to this as you need them!
+ */
+export const getDsnTraceOperationsWrapper = (
+  dsnObj: DsnPcb | DsnSession,
+): DsnTraceOperationsWrapper => {
+  if (dsnObj.is_dsn_pcb) {
+    return {
+      getNextNetId: () => `Net-${dsnObj.network.nets.length + 1}`,
+      addWire: (wire: Wire) => {
+        dsnObj.wiring.wires.push(wire as any)
+      },
+      getStructure: () => dsnObj.structure,
+      getLibrary: () => dsnObj.library,
+    }
+  }
+
+  if (dsnObj.is_dsn_session) {
+    return {
+      getNextNetId: () => `Net-${dsnObj.routes.network_out.nets.length + 1}`,
+      getLibrary: () => dsnObj.routes.library_out!,
+      getStructure: () => null,
+      addWire: (wire: Wire) => {
+        let net = dsnObj.routes.network_out.nets.find(
+          (net) => net.name === wire.net,
+        )
+        if (!net) {
+          net = {
+            name: wire.net!,
+            wires: [],
+          }
+          dsnObj.routes.network_out.nets.push(net)
+        }
+        net.wires.push(wire)
+      },
+    }
+  }
+
+  throw new Error("Invalid DSN object")
+}

--- a/lib/dsn-pcb/circuit-json-to-dsn-json/process-pcb-traces/findOrCreateViaPadstack.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/process-pcb-traces/findOrCreateViaPadstack.ts
@@ -1,14 +1,17 @@
 import type { DsnPcb, Padstack } from "lib/dsn-pcb/types"
+import type { DsnTraceOperationsWrapper } from "./DsnTraceOperationsWrapper"
 
 export function findOrCreateViaPadstack(
-  pcb: DsnPcb,
+  pcb: DsnTraceOperationsWrapper,
   outerDiameter: number,
   holeDiameter: number,
 ): string {
   const viaName = `Via[0-1]_${outerDiameter}:${holeDiameter}_um`
 
+  const library = pcb.getLibrary()
+
   // Check if padstack already exists
-  const existingPadstack = pcb.library.padstacks.find((p) => p.name === viaName)
+  const existingPadstack = library.padstacks.find((p) => p.name === viaName)
 
   if (existingPadstack) {
     return viaName
@@ -36,6 +39,6 @@ export function findOrCreateViaPadstack(
     },
   }
 
-  pcb.library.padstacks.push(viaPadstack)
+  library.padstacks.push(viaPadstack)
   return viaName
 }

--- a/lib/dsn-pcb/dsn-json-to-circuit-json/merge-dsn-session-into-dsn-pcb.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/merge-dsn-session-into-dsn-pcb.ts
@@ -33,7 +33,7 @@ export function mergeDsnSessionIntoDsnPcb(
                 coordinates: wire.path.coordinates.map((c) => c / 10),
               },
               net: sessionNet.name,
-              type: "route",
+              type: wire.type ?? "route",
             })
           }
         })

--- a/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
@@ -1098,6 +1098,7 @@ function processSessionNode(ast: ASTNode): DsnSession {
     )
     if (libraryNode) {
       session.routes.library_out = {
+        images: [],
         padstacks: libraryNode
           .children!.filter(
             (child) =>

--- a/lib/dsn-pcb/types.ts
+++ b/lib/dsn-pcb/types.ts
@@ -301,6 +301,7 @@ export interface DsnSession {
     resolution: Resolution
     parser: Parser
     library_out?: {
+      images: Image[]
       padstacks: Padstack[]
     }
     network_out: {

--- a/tests/dsn-pcb/merge-dsn-session-with-conversion.test.tsx
+++ b/tests/dsn-pcb/merge-dsn-session-with-conversion.test.tsx
@@ -116,5 +116,5 @@ test("merge-dsn-session-with-conversion", async () => {
   )
   // TODO requires fix inside convertCircuitJsonToDsnSession, currently the vias
   // aren't converted properly- reference or adapt the code in processPcbTraces
-  // expect(looksSameResult.equal).toBe(true) // Should be identical after merge
+  expect(looksSameResult.equal).toBe(true) // Should be identical after merge
 })


### PR DESCRIPTION
The main idea behind this work is to make sure that converting Circuit JSON to DsnPcb AND DsnSession can successfully be converted BACK into an identical-looking Circuit JSON. We can use this test to make sure the ids stay consistent!!!

Prior to this test and the last two PRs, the dsn-converter could not convert Circuit JSON to DsnPcb and DsnSession then back again without changing the circuit. Something was always lost or changed, e.g. missing vias or flipped traces

This type of test can be written for other examples to make sure we can successfully convert things back and forth, for example it could be used to "recreate" oval shaped holes or multi-layer traces (traces with inner layers) etc.

![image](https://github.com/user-attachments/assets/88e0a71a-22dd-46f2-8507-c123fec5e47c)
