### PR TITLE
feat: handle multi-layer boards and power planes (fixes #54)

### DIFF
--- a/lib/dsn-pcb/dsn-json-to-circuit-json/convert-dsn-pcb-to-circuit-json.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/convert-dsn-pcb-to-circuit-json.ts
@@ -3,6 +3,7 @@ import { applyToPoint, fromTriangles, scale } from "transformation-matrix"
 import { su } from "@tscircuit/soup-util"
 import type { AnyCircuitElement, PcbBoard } from "circuit-json"
 import { pairs } from "lib/utils/pairs"
+import { getLayerName } from "lib/utils/get-layer-name"
 import type { DsnPcb } from "../types"
 import { convertDsnPcbComponentsToSourceComponentsAndPorts } from "./dsn-component-converters/convert-dsn-pcb-components-to-source-components-and-ports"
 import { convertNetsToSourceNetsAndTraces } from "./dsn-component-converters/convert-nets-to-source-nets-and-traces"
@@ -28,7 +29,7 @@ export function convertDsnPcbToCircuitJson(
     height: 10,
     thickness: 1.4,
     material: "fr4",
-    num_layers: 4,
+    num_layers: dsnPcb.structure.layers.length,
   }
   if (dsnPcb.structure.boundary.path) {
     const boundaryPath = pairs(dsnPcb.structure.boundary.path.coordinates)
@@ -60,9 +61,25 @@ export function convertDsnPcbToCircuitJson(
         dsnPcb.wiring,
         dsnPcb.network,
         transformDsnUnitToMm,
+        dsnPcb,
         fromSessionSpace,
       ),
     )
+  }
+
+  // Convert planes to pcb_polygon elements
+  if (dsnPcb.structure.planes) {
+    for (const plane of dsnPcb.structure.planes) {
+      const layerName = getLayerName(plane.polygon.layer, dsnPcb)
+      const polygon = {
+        type: "pcb_polygon",
+        layer: layerName,
+        points: pairs(plane.polygon.coordinates).map(([x, y]) =>
+          applyToPoint(transformDsnUnitToMm, { x, y })
+        ),
+      }
+      elements.push(polygon as any)
+    }
   }
 
   elements.push(

--- a/lib/dsn-pcb/types.ts
+++ b/lib/dsn-pcb/types.ts
@@ -112,6 +112,16 @@ export interface Structure {
   boundary: Boundary
   via: string
   rule: Rule
+  planes?: Plane[]
+}
+
+export interface Plane {
+  name: string
+  polygon: {
+    layer: string
+    width: number
+    coordinates: number[]
+  }
 }
 
 export interface Layer {

--- a/lib/utils/get-layer-name.ts
+++ b/lib/utils/get-layer-name.ts
@@ -1,0 +1,41 @@
+import type { DsnPcb, DsnSession } from "lib/dsn-pcb/types"
+
+export function getLayerName(
+  dsnLayerName: string,
+  dsnPcb?: DsnPcb | DsnSession,
+): string {
+  if (!dsnPcb || !("structure" in dsnPcb) || !dsnPcb.structure?.layers) {
+    if (
+      dsnLayerName.toLowerCase().includes("top") ||
+      dsnLayerName.includes("F.")
+    )
+      return "top"
+    if (
+      dsnLayerName.toLowerCase().includes("bottom") ||
+      dsnLayerName.includes("B.")
+    )
+      return "bottom"
+    return "top" // fallback
+  }
+
+  const layers = dsnPcb.structure.layers
+  const layer = layers.find((l) => l.name === dsnLayerName)
+  
+  if (!layer) {
+    if (dsnLayerName.toLowerCase().includes("top") || dsnLayerName.includes("F."))
+      return "top"
+    if (
+      dsnLayerName.toLowerCase().includes("bottom") ||
+      dsnLayerName.includes("B.")
+    )
+      return "bottom"
+    return "top" // fallback
+  }
+
+  const layerIndex = layer.property.index
+  const totalLayers = layers.length
+  
+  if (layerIndex === 0) return "top"
+  if (layerIndex === totalLayers - 1) return "bottom"
+  return `inner${layerIndex}`
+}


### PR DESCRIPTION
This PR adds support for multi-layer boards and power planes. It maps DSN layer names to standard names based on their index and converts DSN planes to circuit-json pcb_polygons.