### PR TITLE
fix: allow non-numeric pin numbers in dsn conversion

### DIFF
--- a/lib/dsn-pcb/dsn-json-to-circuit-json/dsn-component-converters/convert-dsn-pcb-components-to-source-components-and-ports.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/dsn-component-converters/convert-dsn-pcb-components-to-source-components-and-ports.ts
@@ -38,7 +38,12 @@ export const convertDsnPcbComponentsToSourceComponentsAndPorts = ({
             source_port_id: `source_port_${component.name}-Pad${pin.pin_number}_${place.refdes}`,
             source_component_id: sourceComponent.source_component_id,
             name: `${place.refdes}-${pin.pin_number}`,
-            pin_number: Number(pin.pin_number),
+            pin_number:
+              typeof pin.pin_number === "number"
+                ? pin.pin_number
+                : Number.isFinite(Number(pin.pin_number))
+                  ? Number(pin.pin_number)
+                  : undefined,
             port_hints: [],
           }
           // Handle case where place coordinates might be null/undefined


### PR DESCRIPTION
Smoothie Board conversions were outputting NaN for pin numbers because of a forced Number() cast on pins that use string labels (like GND). Fixed it to keep numeric pins as numbers and let string pins pass through as strings instead of coercing to NaN.
