### PR TITLE
fix: convert DSN structure planes to copper pours

### DIFF
--- a/lib/dsn-pcb/dsn-json-to-circuit-json/convert-dsn-pcb-to-circuit-json.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/convert-dsn-pcb-to-circuit-json.ts
@@ -1,13 +1,41 @@
 import { applyToPoint, fromTriangles, scale } from "transformation-matrix"
 
 import { su } from "@tscircuit/soup-util"
-import type { AnyCircuitElement, PcbBoard } from "circuit-json"
+import type {
+  AnyCircuitElement,
+  LayerRef,
+  PcbBoard,
+  PcbCopperPourPolygon,
+} from "circuit-json"
 import { pairs } from "lib/utils/pairs"
 import type { DsnPcb } from "../types"
 import { convertDsnPcbComponentsToSourceComponentsAndPorts } from "./dsn-component-converters/convert-dsn-pcb-components-to-source-components-and-ports"
 import { convertNetsToSourceNetsAndTraces } from "./dsn-component-converters/convert-nets-to-source-nets-and-traces"
 import { convertPadstacksToSmtPads } from "./dsn-component-converters/convert-padstacks-to-smtpads"
 import { convertWiresToPcbTraces } from "./dsn-component-converters/convert-wires-to-traces"
+
+function getCircuitJsonLayerName(
+  dsnPcb: DsnPcb,
+  dsnLayerName: string,
+): LayerRef {
+  const layer = dsnPcb.structure.layers.find(
+    ({ name }) => name === dsnLayerName,
+  )
+
+  if (layer) {
+    const layerIndex = layer.property.index
+    if (layerIndex === 0) return "top"
+    if (layerIndex === dsnPcb.structure.layers.length - 1) return "bottom"
+    return `inner${layerIndex}` as LayerRef
+  }
+
+  if (/^(top|f\.cu)$/i.test(dsnLayerName)) return "top"
+  if (/^(bottom|b\.cu)$/i.test(dsnLayerName)) return "bottom"
+  const innerMatch = dsnLayerName.match(/^In(\d+)\.Cu$/i)
+  if (innerMatch) return `inner${innerMatch[1]}` as LayerRef
+
+  return "top"
+}
 
 export function convertDsnPcbToCircuitJson(
   dsnPcb: DsnPcb,
@@ -28,7 +56,7 @@ export function convertDsnPcbToCircuitJson(
     height: 10,
     thickness: 1.4,
     material: "fr4",
-    num_layers: 4,
+    num_layers: dsnPcb.structure.layers.length || 2,
   }
   if (dsnPcb.structure.boundary.path) {
     const boundaryPath = pairs(dsnPcb.structure.boundary.path.coordinates)
@@ -49,6 +77,27 @@ export function convertDsnPcbToCircuitJson(
   }
 
   elements.push(board)
+
+  dsnPcb.structure.planes?.forEach((plane, planeIndex) => {
+    const copperPour: PcbCopperPourPolygon = {
+      type: "pcb_copper_pour",
+      pcb_copper_pour_id: `pcb_copper_pour_${plane.net_name}_${planeIndex}`,
+      covered_with_solder_mask: true,
+      layer: getCircuitJsonLayerName(dsnPcb, plane.polygon.layer),
+      source_net_id: `source_net_${plane.net_name}`,
+      shape: "polygon",
+      points: pairs(plane.polygon.coordinates).map(([x, y]) => {
+        const point = applyToPoint(transformDsnUnitToMm, { x, y }) as {
+          x: number
+          y: number
+        }
+
+        return { x: point.x, y: point.y }
+      }),
+    }
+
+    elements.push(copperPour)
+  })
 
   // Convert padstacks to SMT pads using the transformation matrix
   elements.push(...convertPadstacksToSmtPads(dsnPcb, transformDsnUnitToMm))

--- a/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
@@ -27,6 +27,7 @@ import type {
   Parser as ParserType,
   Path,
   PathShape,
+  Plane,
   Pin,
   Placement,
   Places,
@@ -211,6 +212,7 @@ export function processResolution(nodes: ASTNode[]): Resolution {
 export function processStructure(nodes: ASTNode[]): Structure {
   const structure: Partial<Structure> = {
     layers: [],
+    planes: [],
   }
 
   nodes.forEach((node) => {
@@ -224,6 +226,9 @@ export function processStructure(nodes: ASTNode[]): Structure {
             break
           case "boundary":
             structure.boundary = processBoundary(node.children!.slice(1))
+            break
+          case "plane":
+            structure.planes!.push(processPlane(node.children!))
             break
           case "via":
             if (
@@ -242,6 +247,30 @@ export function processStructure(nodes: ASTNode[]): Structure {
   })
 
   return structure as Structure
+}
+
+function processPlane(nodes: ASTNode[]): Plane {
+  if (
+    nodes[1]?.type !== "Atom" ||
+    typeof nodes[1].value !== "string" ||
+    nodes[2]?.type !== "List"
+  ) {
+    throw new Error("Invalid plane format")
+  }
+
+  const polygonNodes = nodes[2].children
+  if (
+    !polygonNodes ||
+    polygonNodes[0]?.type !== "Atom" ||
+    polygonNodes[0].value !== "polygon"
+  ) {
+    throw new Error("Invalid plane polygon format")
+  }
+
+  return {
+    net_name: nodes[1].value,
+    polygon: processPolygonShape(polygonNodes),
+  }
 }
 
 function processLayer(nodes: ASTNode[]): Layer {

--- a/lib/dsn-pcb/types.ts
+++ b/lib/dsn-pcb/types.ts
@@ -30,6 +30,7 @@ export interface DsnPcb {
         coordinates: number[]
       }
     }
+    planes?: Plane[]
     via: string
     rule: {
       clearances: Array<{
@@ -110,8 +111,14 @@ export interface Resolution {
 export interface Structure {
   layers: Layer[]
   boundary: Boundary
+  planes?: Plane[]
   via: string
   rule: Rule
+}
+
+export interface Plane {
+  net_name: string
+  polygon: PolygonShape
 }
 
 export interface Layer {

--- a/tests/repros/repro7-smoothie-board-structure.test.ts
+++ b/tests/repros/repro7-smoothie-board-structure.test.ts
@@ -1,0 +1,51 @@
+import { expect, test } from "bun:test"
+import { pcb_copper_pour, type PcbCopperPourPolygon } from "circuit-json"
+import { type DsnPcb, convertDsnPcbToCircuitJson, parseDsnToDsnJson } from "lib"
+
+// @ts-ignore
+import smoothieboardDsn from "../assets/repro/smoothieboard-repro.dsn" with {
+  type: "text",
+}
+
+test("smoothieboard structure plane converts to pcb copper pour", () => {
+  const dsnJson = parseDsnToDsnJson(smoothieboardDsn) as DsnPcb
+
+  expect(dsnJson.structure.planes).toHaveLength(1)
+  expect(dsnJson.structure.planes?.[0]).toEqual({
+    net_name: "AGND",
+    polygon: {
+      shapeType: "polygon",
+      layer: "Route2",
+      width: 0,
+      coordinates: [
+        214249, -158877, 82677, -159512, 82550, -50673, 214376, -50673, 214249,
+        -158877,
+      ],
+    },
+  })
+
+  const circuitJson = convertDsnPcbToCircuitJson(dsnJson)
+  const copperPours = circuitJson.filter(
+    (element): element is PcbCopperPourPolygon => {
+      return element.type === "pcb_copper_pour" && element.shape === "polygon"
+    },
+  )
+
+  expect(copperPours).toHaveLength(1)
+  expect(copperPours[0]).toMatchObject({
+    type: "pcb_copper_pour",
+    pcb_copper_pour_id: "pcb_copper_pour_AGND_0",
+    shape: "polygon",
+    layer: "inner1",
+    source_net_id: "source_net_AGND",
+    covered_with_solder_mask: true,
+  })
+  expect(copperPours[0].points).toEqual([
+    { x: 214.249, y: -158.877 },
+    { x: 82.677, y: -159.512 },
+    { x: 82.55, y: -50.673 },
+    { x: 214.376, y: -50.673 },
+    { x: 214.249, y: -158.877 },
+  ])
+  expect(pcb_copper_pour.parse(copperPours[0])).toEqual(copperPours[0])
+})


### PR DESCRIPTION
## Summary

Part of #54.

This PR preserves DSN structure-level copper planes when converting a DSN PCB to Circuit JSON. The Smoothie Board fixture includes a board-level AGND plane:

```dsn
(plane AGND (polygon Route2 0 ...))
```

On current main, `structure.plane` nodes are not parsed, so this AGND copper plane is silently dropped before conversion. That leaves the generated Circuit JSON missing a real board-level copper feature from the source DSN.

This intentionally does **not** duplicate the pin parsing, NaN, or component-rotation work in #123, #128, #131, #144, or #145. It targets the remaining DSN structure-plane path.

## What changed

- Parse `structure.plane` nodes into DSN JSON as `{ net_name, polygon }`.
- Convert DSN plane polygons to Circuit JSON `pcb_copper_pour` elements with `shape: "polygon"`.
- Map DSN layer names via `structure.layers[].property.index`, so Smoothie Board `Route2` becomes Circuit JSON `inner1`.
- Preserve the electrical association by setting `source_net_id` to `source_net_<net>` (`source_net_AGND` for this fixture).
- Set `pcb_board.num_layers` from the parsed DSN layer count instead of hardcoding 4.
- Add a focused Smoothie Board regression test for parser output, polygon conversion, layer mapping, coordinates, and `circuit-json` schema validity.

## Why

The Smoothie Board DSN already contains the AGND plane in the `structure` section. Without parsing and converting it, DSN -> Circuit JSON can render pads/vias while still omitting an important board-level copper feature. This is a separate data-loss path from the existing pin-number and rotation fixes.

## Verification

Local verification on `fix/smoothieboard-plane-copper-pour`:

- `bun test` -> 48 pass, 1 skip, 0 fail, 406 expect calls
- `bunx tsc --noEmit` -> pass
- `bun run format:check` -> pass
- `bun run build` -> pass

Smoothie-specific structural proof:

- parsed `structure.planes.length === 1`
- emitted exactly one `pcb_copper_pour` polygon
- emitted layer is `inner1`
- emitted source net is `source_net_AGND`
- `pcb_copper_pour.safeParse(...)` succeeds

## Scope / non-duplication

This PR does not change tokenizer behavior, pin-number parsing, component rotation, source-port coercion, via IDs, or pad IDs. Those areas are already covered by existing Smoothie Board PRs. This branch is deliberately scoped to the missing structure-level plane/polygon conversion.

## Bounty

/claim #54
