### PR TITLE
fix: match quoted DSN pin references

### DIFF
--- a/lib/dsn-pcb/dsn-json-to-circuit-json/dsn-component-converters/convert-nets-to-source-nets-and-traces.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/dsn-component-converters/convert-nets-to-source-nets-and-traces.ts
@@ -1,12 +1,18 @@
 import type { SourceNet, SourcePort, SourceTrace } from "circuit-json"
 import type { DsnPcb } from "lib/dsn-pcb/types"
 
+const normalizeDsnPinReference = (pinReference: string) =>
+  pinReference.replace(/"([^"]*)"/g, "$1")
+
 export const convertNetsToSourceNetsAndTraces = ({
   dsnPcb,
   source_ports,
 }: { dsnPcb: DsnPcb; source_ports: SourcePort[] }) => {
   const result: Array<SourceNet | SourceTrace> = []
   const { nets } = dsnPcb.network
+  const sourcePortByName = new Map(
+    source_ports.map((sourcePort) => [sourcePort.name, sourcePort]),
+  )
 
   let source_trace_id = dsnPcb.wiring.wires.length
   for (const net of nets) {
@@ -24,7 +30,7 @@ export const convertNetsToSourceNetsAndTraces = ({
     const connected_source_port_ids: string[] = []
     if (pins && pins.length > 0) {
       for (const pin of pins) {
-        const source_port = source_ports.find((sp) => sp.name === pin)
+        const source_port = sourcePortByName.get(normalizeDsnPinReference(pin))
         if (source_port) {
           connected_source_port_ids.push(source_port.source_port_id)
         }

--- a/tests/dsn-pcb/quoted-pin-reference-net-matching.test.ts
+++ b/tests/dsn-pcb/quoted-pin-reference-net-matching.test.ts
@@ -2,7 +2,7 @@ import { expect, test } from "bun:test"
 import type { SourcePort, SourceTrace } from "circuit-json"
 import { parseDsnToCircuitJson } from "lib"
 
-const dsnWithQuotedPinReference = `
+const dsnWithQuotedPinReferences = `
 (pcb quoted_pin_reference
   (resolution um 10)
   (unit um)
@@ -14,7 +14,10 @@ const dsnWithQuotedPinReference = `
   )
   (placement
     (component "USB-CONN"
-      (place J1 0 0 front 0)
+      (place X14 0 0 front 0)
+    )
+    (component "RJ45-CONN"
+      (place RJ1 3000 0 front 0)
     )
   )
   (library
@@ -22,22 +25,27 @@ const dsnWithQuotedPinReference = `
       (pin Rect[T]Pad_100x100_um "D-" 0 0)
       (pin Rect[T]Pad_100x100_um D+ 1000 0)
     )
+    (image "RJ45-CONN"
+      (pin Rect[T]Pad_100x100_um "RD-" 0 0)
+      (pin Rect[T]Pad_100x100_um RD+ 1000 0)
+    )
     (padstack Rect[T]Pad_100x100_um
       (shape (rect Top -50 -50 50 50))
       (attach off)
     )
   )
   (network
-    (net "/USB_D-" (pins J1-"D-"))
-    (net "/USB_D+" (pins J1-D+))
-    (class default "" "/USB_D-" "/USB_D+" (circuit (use_via "")) (rule (width 100) (clearance 100)))
+    (net "/USB_D-" (pins X14-"D-"))
+    (net "/ETH_RD-" (pins RJ1-"RD-"))
+    (net "/USB_D+" (pins X14-D+))
+    (class default "" "/USB_D-" "/ETH_RD-" "/USB_D+" (circuit (use_via "")) (rule (width 100) (clearance 100)))
   )
   (wiring)
 )
 `
 
 test("matches quoted DSN pin references to parsed source ports", () => {
-  const circuitJson = parseDsnToCircuitJson(dsnWithQuotedPinReference)
+  const circuitJson = parseDsnToCircuitJson(dsnWithQuotedPinReferences)
 
   const sourcePorts = circuitJson.filter(
     (element): element is SourcePort => element.type === "source_port",
@@ -46,14 +54,27 @@ test("matches quoted DSN pin references to parsed source ports", () => {
     (element): element is SourceTrace => element.type === "source_trace",
   )
 
-  const quotedPinPort = sourcePorts.find((port) => port.name === "J1-D-")
-  const quotedPinTrace = sourceTraces.find((trace) =>
-    trace.connected_source_net_ids.includes("source_net_/USB_D-"),
-  )
+  const getPortId = (name: string) => {
+    const sourcePort = sourcePorts.find((port) => port.name === name)
+    expect(sourcePort).toBeDefined()
+    return sourcePort!.source_port_id
+  }
 
-  expect(quotedPinPort).toBeDefined()
-  expect(quotedPinTrace).toBeDefined()
-  expect(quotedPinTrace?.connected_source_port_ids).toEqual([
-    quotedPinPort!.source_port_id,
+  const getTrace = (sourceNetId: string) => {
+    const sourceTrace = sourceTraces.find((trace) =>
+      trace.connected_source_net_ids.includes(sourceNetId),
+    )
+    expect(sourceTrace).toBeDefined()
+    return sourceTrace!
+  }
+
+  expect(getTrace("source_net_/USB_D-").connected_source_port_ids).toEqual([
+    getPortId("X14-D-"),
+  ])
+  expect(getTrace("source_net_/ETH_RD-").connected_source_port_ids).toEqual([
+    getPortId("RJ1-RD-"),
+  ])
+  expect(getTrace("source_net_/USB_D+").connected_source_port_ids).toEqual([
+    getPortId("X14-D+"),
   ])
 })

--- a/tests/dsn-pcb/quoted-pin-reference-net-matching.test.ts
+++ b/tests/dsn-pcb/quoted-pin-reference-net-matching.test.ts
@@ -1,0 +1,59 @@
+import { expect, test } from "bun:test"
+import type { SourcePort, SourceTrace } from "circuit-json"
+import { parseDsnToCircuitJson } from "lib"
+
+const dsnWithQuotedPinReference = `
+(pcb quoted_pin_reference
+  (resolution um 10)
+  (unit um)
+  (structure
+    (layer F.Cu (type signal) (property (index 0)))
+    (boundary (path pcb 0 0 0 1000 0 1000 1000 0 1000 0 0))
+    (via "")
+    (rule (width 100) (clearance 100))
+  )
+  (placement
+    (component "USB-CONN"
+      (place J1 0 0 front 0)
+    )
+  )
+  (library
+    (image "USB-CONN"
+      (pin Rect[T]Pad_100x100_um "D-" 0 0)
+      (pin Rect[T]Pad_100x100_um D+ 1000 0)
+    )
+    (padstack Rect[T]Pad_100x100_um
+      (shape (rect Top -50 -50 50 50))
+      (attach off)
+    )
+  )
+  (network
+    (net "/USB_D-" (pins J1-"D-"))
+    (net "/USB_D+" (pins J1-D+))
+    (class default "" "/USB_D-" "/USB_D+" (circuit (use_via "")) (rule (width 100) (clearance 100)))
+  )
+  (wiring)
+)
+`
+
+test("matches quoted DSN pin references to parsed source ports", () => {
+  const circuitJson = parseDsnToCircuitJson(dsnWithQuotedPinReference)
+
+  const sourcePorts = circuitJson.filter(
+    (element): element is SourcePort => element.type === "source_port",
+  )
+  const sourceTraces = circuitJson.filter(
+    (element): element is SourceTrace => element.type === "source_trace",
+  )
+
+  const quotedPinPort = sourcePorts.find((port) => port.name === "J1-D-")
+  const quotedPinTrace = sourceTraces.find((trace) =>
+    trace.connected_source_net_ids.includes("source_net_/USB_D-"),
+  )
+
+  expect(quotedPinPort).toBeDefined()
+  expect(quotedPinTrace).toBeDefined()
+  expect(quotedPinTrace?.connected_source_port_ids).toEqual([
+    quotedPinPort!.source_port_id,
+  ])
+})


### PR DESCRIPTION
## Summary

- normalize quoted DSN pin references before matching network pins to source ports
- preserve the parsed source port names unchanged while matching references like `X14-"D-"` to `X14-D-` and `RJ1-"RD-"` to `RJ1-RD-`
- add a focused regression test that covers multiple Smoothie-style quoted pin references plus an unquoted control net

This is scoped to a remaining Smoothie-style connection issue and does not duplicate the NaN pin-number, rotation, or copper-plane fixes in the other #54 PRs.

/claim #54

## Verification

- `bun test tests/dsn-pcb/quoted-pin-reference-net-matching.test.ts`
- `bun test tests/repros/repro7-smoothie-board.test.ts`
- `biome check lib/dsn-pcb/dsn-json-to-circuit-json/dsn-component-converters/convert-nets-to-source-nets-and-traces.ts tests/dsn-pcb/quoted-pin-reference-net-matching.test.ts`
- `tsc --noEmit`
- `bun run build`

Transparency note: this PR was prepared with AI-assisted coding and manually verified.
