### PR TITLE
fix: preserve numeric-prefix DSN labels

### DIFF
--- a/lib/common/parse-sexpr.ts
+++ b/lib/common/parse-sexpr.ts
@@ -44,26 +44,21 @@ export function tokenizeDsn(input: string): Token[] {
       }
       i++ // Skip the closing quote
       tokens.push({ type: "String", value })
-    } else if (char === "-" || /\d/.test(char)) {
-      // Parse number (integer or float)
-      let numStr = ""
-      if (char === "-") {
-        numStr += "-"
-        i++
-      }
-      while (i < length && /[\d.]/.test(input[i])) {
-        numStr += input[i]
-        i++
-      }
-      tokens.push({ type: "Number", value: parseFloat(numStr) })
     } else {
-      // Parse symbol
-      let sym = ""
+      // Parse an unquoted bare token, then classify it. DSN identifiers can
+      // start with digits, e.g. 3.3V nets or 1A pins, so tokenizing by the
+      // first character loses important label suffixes.
+      let value = ""
       while (i < length && !/\s|\(|\)/.test(input[i])) {
-        sym += input[i]
+        value += input[i]
         i++
       }
-      tokens.push({ type: "Symbol", value: sym })
+
+      if (/^-?(?:\d+\.?\d*|\.\d+)(?:[eE][+-]?\d+)?$/.test(value)) {
+        tokens.push({ type: "Number", value: Number(value) })
+      } else {
+        tokens.push({ type: "Symbol", value })
+      }
     }
   }
 

--- a/lib/dsn-pcb/dsn-json-to-circuit-json/dsn-component-converters/convert-dsn-pcb-components-to-source-components-and-ports.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/dsn-component-converters/convert-dsn-pcb-components-to-source-components-and-ports.ts
@@ -33,13 +33,18 @@ export const convertDsnPcbComponentsToSourceComponentsAndPorts = ({
       // Create ports for each pin in the image
       if (image.pins) {
         for (const pin of image.pins) {
+          const numericPinNumber = Number(pin.pin_number)
           const port: SourcePort = {
             type: "source_port",
             source_port_id: `source_port_${component.name}-Pad${pin.pin_number}_${place.refdes}`,
             source_component_id: sourceComponent.source_component_id,
             name: `${place.refdes}-${pin.pin_number}`,
-            pin_number: Number(pin.pin_number),
-            port_hints: [],
+            pin_number: Number.isFinite(numericPinNumber)
+              ? numericPinNumber
+              : undefined,
+            port_hints: Number.isFinite(numericPinNumber)
+              ? []
+              : [String(pin.pin_number)],
           }
           // Handle case where place coordinates might be null/undefined
           const placeX = place.x || 0

--- a/lib/dsn-pcb/dsn-json-to-circuit-json/dsn-component-converters/convert-padstacks-to-smtpads.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/dsn-component-converters/convert-padstacks-to-smtpads.ts
@@ -5,6 +5,16 @@ import { applyToPoint } from "transformation-matrix"
 
 const debug = Debug("dsn-converter:convertPadstacksToSmtpads")
 
+const getSmtPadIdPinPart = (pinNumber: number | string) => {
+  const numericPinNumber = Number(pinNumber)
+
+  if (Number.isFinite(numericPinNumber)) {
+    return String(numericPinNumber - 1)
+  }
+
+  return String(pinNumber).replace(/[^a-zA-Z0-9_-]/g, "_")
+}
+
 export function convertPadstacksToSmtPads(
   pcb: DsnPcb,
   transform: any,
@@ -116,6 +126,7 @@ export function convertPadstacksToSmtPads(
         })
 
         let pcbPad: PcbSmtPad
+        const smtPadIdPinPart = getSmtPadIdPinPart(pin.pin_number)
         if (rectShape || polygonShape || pathShape) {
           const layer = padstack.shapes[0].layer.includes("B.")
             ? "bottom"
@@ -126,7 +137,7 @@ export function convertPadstacksToSmtPads(
           })
           pcbPad = {
             type: "pcb_smtpad",
-            pcb_smtpad_id: `pcb_smtpad_${componentId}_${place.refdes}_${Number(pin.pin_number) - 1}`,
+            pcb_smtpad_id: `pcb_smtpad_${componentId}_${place.refdes}_${smtPadIdPinPart}`,
             pcb_component_id: `${componentId}_${place.refdes}`,
             pcb_port_id: `pcb_port_${componentId}-Pad${pin.pin_number}_${place.refdes}`,
             shape: "rect",
@@ -140,7 +151,7 @@ export function convertPadstacksToSmtPads(
         } else {
           pcbPad = {
             type: "pcb_smtpad",
-            pcb_smtpad_id: `pcb_smtpad_${componentId}_${place.refdes}_${Number(pin.pin_number) - 1}`,
+            pcb_smtpad_id: `pcb_smtpad_${componentId}_${place.refdes}_${smtPadIdPinPart}`,
             pcb_component_id: `${componentId}_${place.refdes}`,
             pcb_port_id: `pcb_port_${componentId}-Pad${pin.pin_number}_${place.refdes}`,
             shape: "circle",

--- a/lib/utils/get-pin-number.ts
+++ b/lib/utils/get-pin-number.ts
@@ -9,7 +9,7 @@ const debug = Debug("dsn-converter:getPinNum")
  */
 export function getPinNum(nodes: ASTNode[]): number | string | null {
   // Extract pin number from AST nodes
-  let pinNumber
+  let pinNumber: string | number | undefined
 
   if (nodes[2]?.type === "List" && nodes[2].children) {
     // Pin number is in a List structure
@@ -26,7 +26,11 @@ export function getPinNum(nodes: ASTNode[]): number | string | null {
   if (typeof pinNumber === "number") {
     return pinNumber
   }
-  // Try parsing as number first
-  const parsed = parseInt(String(pinNumber), 10)
-  return Number.isNaN(parsed) ? String(pinNumber) : parsed
+  const normalizedPinNumber = String(pinNumber)
+
+  // Only treat fully numeric labels as numbers. Labels such as "1A" are
+  // distinct DSN pin names and must not be truncated to 1.
+  return /^-?\d+$/.test(normalizedPinNumber)
+    ? Number(normalizedPinNumber)
+    : normalizedPinNumber
 }

--- a/tests/dsn-pcb/alphanumeric-pin-label-net-matching.test.ts
+++ b/tests/dsn-pcb/alphanumeric-pin-label-net-matching.test.ts
@@ -1,0 +1,73 @@
+import { expect, test } from "bun:test"
+import type { PcbSmtPad, SourcePort, SourceTrace } from "circuit-json"
+import { parseDsnToCircuitJson } from "lib"
+
+const dsnWithAlphanumericPinLabels = `
+(pcb alphanumeric_pin_label
+  (resolution um 10)
+  (unit um)
+  (structure
+    (layer Top (type signal))
+    (boundary (path pcb 0 0 0 3000 0 3000 3000 0 3000 0 0))
+  )
+  (placement
+    (component U_PART
+      (place U1 1000 1000 front 0 PN)
+    )
+    (component J_PART
+      (place J1 2000 1000 front 0 PN)
+    )
+  )
+  (library
+    (image U_PART
+      (pin Rect[T]Pad_100x100_um 1A 0 0)
+    )
+    (image J_PART
+      (pin Rect[T]Pad_100x100_um 2B 0 0)
+    )
+    (padstack Rect[T]Pad_100x100_um
+      (shape (rect Top -50 -50 50 50))
+    )
+  )
+  (network
+    (net 3.3V (pins U1-1A J1-2B))
+    (class default "" 3.3V (circuit (use_via "")) (rule (width 100) (clearance 100)))
+  )
+  (wiring)
+)
+`
+
+test("keeps alphanumeric DSN pin labels intact for ports, pads, and net matching", () => {
+  const circuitJson = parseDsnToCircuitJson(dsnWithAlphanumericPinLabels)
+
+  const sourcePorts = circuitJson.filter(
+    (element): element is SourcePort => element.type === "source_port",
+  )
+  const smtPads = circuitJson.filter(
+    (element): element is PcbSmtPad => element.type === "pcb_smtpad",
+  )
+  const sourceTrace = circuitJson.find(
+    (element): element is SourceTrace =>
+      element.type === "source_trace" &&
+      element.connected_source_net_ids.includes("source_net_3.3V"),
+  )
+
+  const u1Port = sourcePorts.find((port) => port.name === "U1-1A")
+  const j1Port = sourcePorts.find((port) => port.name === "J1-2B")
+
+  expect(u1Port).toBeDefined()
+  expect(j1Port).toBeDefined()
+  expect(u1Port?.pin_number).toBeUndefined()
+  expect(j1Port?.pin_number).toBeUndefined()
+  expect(u1Port?.port_hints).toEqual(["1A"])
+  expect(j1Port?.port_hints).toEqual(["2B"])
+  expect(sourceTrace?.connected_source_net_ids).toEqual(["source_net_3.3V"])
+  expect(sourceTrace?.connected_source_port_ids).toEqual([
+    u1Port!.source_port_id,
+    j1Port!.source_port_id,
+  ])
+  expect(smtPads.map((pad) => pad.pcb_smtpad_id).sort()).toEqual([
+    "pcb_smtpad_J_PART_J1_2B",
+    "pcb_smtpad_U_PART_U1_1A",
+  ])
+})


### PR DESCRIPTION
/claim #54

## Summary
- Classify unquoted DSN tokens as numbers only when the whole token is numeric, preserving labels like `3.3V`, `1A`, and `2B`.
- Avoid truncating alphanumeric pin labels in pin extraction/source port conversion.
- Generate stable SMT pad ids for nonnumeric pin labels instead of producing `NaN`/truncated ids.
- Add a regression test covering a `3.3V` net connected through `U1-1A` and `J1-2B` pins.

## Why this is distinct
This covers unquoted numeric-prefix DSN symbols. It is separate from quoted pin references, rotation handling, copper-pour parsing, and trace length support in the other open attempts.

## Verification
- `npx --yes bun@1.3.13 test tests/dsn-pcb/alphanumeric-pin-label-net-matching.test.ts`
- `npx --yes bun@1.3.13 test`
- `npx --yes bun@1.3.13 run build`
- `npx tsc --noEmit`
- `npx biome check lib/common/parse-sexpr.ts lib/utils/get-pin-number.ts lib/dsn-pcb/dsn-json-to-circuit-json/dsn-component-converters/convert-dsn-pcb-components-to-source-components-and-ports.ts lib/dsn-pcb/dsn-json-to-circuit-json/dsn-component-converters/convert-padstacks-to-smtpads.ts tests/dsn-pcb/alphanumeric-pin-label-net-matching.test.ts`
- `git diff --check`