### PR TITLE
fix: avoid duplicate DSN wire element ids

### DIFF
--- a/lib/dsn-pcb/dsn-json-to-circuit-json/dsn-component-converters/convert-polyline-path-to-pcb-traces.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/dsn-component-converters/convert-polyline-path-to-pcb-traces.ts
@@ -9,11 +9,13 @@ export const convertPolylinePathToPcbTraces = ({
   wire,
   transformUmToMm,
   netName,
+  pcbTraceId,
   fromSessionSpace = true,
 }: {
   wire: Wiring["wires"][number]
   transformUmToMm: Matrix
   netName: string
+  pcbTraceId?: string
   fromSessionSpace?: boolean
 }): PcbTrace[] => {
   const traces: PcbTrace[] = []
@@ -31,7 +33,7 @@ export const convertPolylinePathToPcbTraces = ({
 
   traces.push({
     type: "pcb_trace",
-    pcb_trace_id: `pcb_trace_${netName}`,
+    pcb_trace_id: pcbTraceId ?? `pcb_trace_${netName}`,
     source_trace_id: netName,
     route: pointsOnTraceMm.map((point) => ({
       route_type: "wire" as const,

--- a/lib/dsn-pcb/dsn-json-to-circuit-json/dsn-component-converters/convert-wires-to-traces.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/dsn-component-converters/convert-wires-to-traces.ts
@@ -20,6 +20,8 @@ export function convertWiresToPcbTraces(
 ): AnyCircuitElement[] {
   const tracesAndVias: AnyCircuitElement[] = []
   const processedNets = new Set<string>()
+  const netTraceCounts = new Map<string, number>()
+  const netViaCounts = new Map<string, number>()
 
   wiring.wires?.forEach((wire) => {
     debug("WIRE\n----\n", wire)
@@ -37,19 +39,33 @@ export function convertWiresToPcbTraces(
     processedNets.add(netName)
 
     if (wire.type === "via") {
+      const netViaIndex = netViaCounts.get(netName) ?? 0
+      netViaCounts.set(netName, netViaIndex + 1)
+      const viaIdSuffix = netViaIndex === 0 ? "" : `_${netViaIndex}`
+
       debug("wire is actually a via!")
       tracesAndVias.push(
-        ...convertWiringViaToPcbVias({ wire, transformUmToMm, netName }),
+        ...convertWiringViaToPcbVias({
+          wire,
+          transformUmToMm,
+          netName,
+          pcbViaId: `pcb_via_${netName}${viaIdSuffix}`,
+        }),
       )
       return
     }
 
     if ("polyline_path" in wire) {
+      const netTraceIndex = netTraceCounts.get(netName) ?? 0
+      netTraceCounts.set(netName, netTraceIndex + 1)
+      const traceIdSuffix = netTraceIndex === 0 ? "" : `_${netTraceIndex}`
+
       tracesAndVias.push(
         ...convertPolylinePathToPcbTraces({
           wire,
           transformUmToMm,
           netName,
+          pcbTraceId: `pcb_trace_${netName}${traceIdSuffix}`,
           fromSessionSpace,
         }),
       )
@@ -57,11 +73,16 @@ export function convertWiresToPcbTraces(
     }
 
     if ("path" in wire) {
+      const netTraceIndex = netTraceCounts.get(netName) ?? 0
+      netTraceCounts.set(netName, netTraceIndex + 1)
+      const traceIdSuffix = netTraceIndex === 0 ? "" : `_${netTraceIndex}`
+
       tracesAndVias.push(
         ...convertWiringPathToPcbTraces({
           wire,
           transformUmToMm,
           netName,
+          pcbTraceId: `pcb_trace_${netName}${traceIdSuffix}`,
           fromSessionSpace,
         }),
       )

--- a/lib/dsn-pcb/dsn-json-to-circuit-json/dsn-component-converters/convert-wiring-path-to-pcb-traces.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/dsn-component-converters/convert-wiring-path-to-pcb-traces.ts
@@ -15,11 +15,13 @@ export const convertWiringPathToPcbTraces = ({
   wire,
   transformUmToMm,
   netName,
+  pcbTraceId,
   fromSessionSpace = true,
 }: {
   wire: Wiring["wires"][number]
   transformUmToMm: Matrix
   netName: string
+  pcbTraceId?: string
   fromSessionSpace?: boolean
 }): Array<PcbTrace | SourceTrace> => {
   const coordinates = wire.path!.coordinates
@@ -50,7 +52,7 @@ export const convertWiringPathToPcbTraces = ({
 
     const pcbTrace: PcbTrace = {
       type: "pcb_trace",
-      pcb_trace_id: `pcb_trace_${netName}`,
+      pcb_trace_id: pcbTraceId ?? `pcb_trace_${netName}`,
       source_trace_id: netName.split("-")[0],
       route: routePoints as PcbTraceRoutePointWire[],
       trace_length: getTraceLength(routePoints),

--- a/lib/dsn-pcb/dsn-json-to-circuit-json/dsn-component-converters/convert-wiring-via-to-pcb-vias.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/dsn-component-converters/convert-wiring-via-to-pcb-vias.ts
@@ -9,10 +9,12 @@ export const convertWiringViaToPcbVias = ({
   wire,
   transformUmToMm,
   netName,
+  pcbViaId,
 }: {
   wire: Wiring["wires"][number]
   transformUmToMm: Matrix
   netName: string
+  pcbViaId?: string
 }): PcbVia[] => {
   if (!wire.path?.coordinates || wire.path.coordinates.length < 2) {
     debug("Couldn't create via")
@@ -25,7 +27,7 @@ export const convertWiringViaToPcbVias = ({
   const via: PcbVia = {
     type: "pcb_via",
     layers: ["top", "bottom"],
-    pcb_via_id: `pcb_via_${netName}`,
+    pcb_via_id: pcbViaId ?? `pcb_via_${netName}`,
     x: Number(circuitPoint.x.toFixed(4)),
     y: Number(circuitPoint.y.toFixed(4)),
     // TODO look up via size

--- a/tests/dsn-pcb/multiple-wire-via-ids.test.ts
+++ b/tests/dsn-pcb/multiple-wire-via-ids.test.ts
@@ -1,0 +1,104 @@
+import { expect, test } from "bun:test"
+import { su } from "@tscircuit/soup-util"
+import { type DsnPcb, convertDsnPcbToCircuitJson, parseDsnToDsnJson } from "lib"
+
+const dsnWithRepeatedPowerNetElements = `
+(pcb repeated-power-net
+  (parser
+    (string_quote ")
+    (space_in_quoted_tokens on)
+    (host_cad "dsn-converter-test")
+    (host_version "1")
+  )
+  (resolution um 10)
+  (unit um)
+  (structure
+    (layer F.Cu
+      (type signal)
+      (property (index 0))
+    )
+    (layer B.Cu
+      (type signal)
+      (property (index 1))
+    )
+    (boundary
+      (path pcb 0 0 0 10000 0 10000 10000 0 10000 0 0)
+    )
+    (via Via[0-1]_600:300_um)
+    (rule
+      (width 200)
+      (clearance 200)
+    )
+  )
+  (placement)
+  (library
+    (padstack Via[0-1]_600:300_um
+      (shape (circle F.Cu 600))
+      (attach off)
+    )
+  )
+  (network
+    (net POWER
+      (pins)
+    )
+    (class kicad_default "" POWER
+      (circuit
+        (use_via Via[0-1]_600:300_um)
+      )
+      (rule
+        (width 200)
+        (clearance 200)
+      )
+    )
+  )
+  (wiring
+    (wire
+      (path F.Cu 200 1000 1000 2000 1000)
+      (net POWER)
+      (type route)
+    )
+    (wire
+      (path F.Cu 200 3000 1000 4000 1000)
+      (net POWER)
+      (type route)
+    )
+    (via Via[0-1]_600:300_um 5000 1000
+      (net POWER)
+    )
+    (via Via[0-1]_600:300_um 6000 1000
+      (net POWER)
+    )
+  )
+)
+`
+
+test("multiple wires and vias on the same net use unique circuit-json ids", () => {
+  const dsnJson = parseDsnToDsnJson(dsnWithRepeatedPowerNetElements) as DsnPcb
+  const circuitJson = convertDsnPcbToCircuitJson(dsnJson)
+
+  const pcbTraces = su(circuitJson).pcb_trace.list()
+  const pcbVias = su(circuitJson).pcb_via.list()
+
+  expect(pcbTraces).toHaveLength(2)
+  expect(pcbVias).toHaveLength(2)
+
+  expect(new Set(pcbTraces.map((trace) => trace.pcb_trace_id)).size).toBe(
+    pcbTraces.length,
+  )
+  expect(new Set(pcbVias.map((via) => via.pcb_via_id)).size).toBe(
+    pcbVias.length,
+  )
+
+  expect(pcbTraces.map((trace) => trace.pcb_trace_id)).toEqual([
+    "pcb_trace_POWER",
+    "pcb_trace_POWER_1",
+  ])
+  expect(pcbVias.map((via) => via.pcb_via_id)).toEqual([
+    "pcb_via_POWER",
+    "pcb_via_POWER_1",
+  ])
+  expect(pcbTraces.map((trace) => trace.source_trace_id)).toEqual([
+    "POWER",
+    "POWER",
+  ])
+})


### PR DESCRIPTION
## Summary

- add deterministic per-net/per-element suffixes when converting multiple DSN `wire` / `via` entries on the same net
- preserve the original net name and `source_trace_id` linkage while making emitted `pcb_trace_id` and `pcb_via_id` values unique
- add a regression DSN with two route wires and two vias on the same `POWER` net

## Why

The DSN parser can produce multiple wiring records for the same net. The converter previously used only the net name for direct DSN `pcb_trace_id` and `pcb_via_id` values, so repeated same-net wires/vias emitted duplicate Circuit JSON IDs. Downstream consumers can collapse, overwrite, or mis-associate those route elements.

This is scoped to a remaining DSN-to-Circuit JSON ID-collision path and does not touch the existing Smoothie pin parsing, rotation, quoted-reference, or plane-conversion work in other #54 PRs.

## Verification

- `npx --yes bun@1.3.13 test tests/dsn-pcb/multiple-wire-via-ids.test.ts`
- `npx --yes bun@1.3.13 test`
- `npx tsc --noEmit`
- `npx --yes bun@1.3.13 run build`
- `npx biome check lib/dsn-pcb/dsn-json-to-circuit-json/dsn-component-converters/convert-wires-to-traces.ts lib/dsn-pcb/dsn-json-to-circuit-json/dsn-component-converters/convert-wiring-via-to-pcb-vias.ts lib/dsn-pcb/dsn-json-to-circuit-json/dsn-component-converters/convert-wiring-path-to-pcb-traces.ts lib/dsn-pcb/dsn-json-to-circuit-json/dsn-component-converters/convert-polyline-path-to-pcb-traces.ts tests/dsn-pcb/multiple-wire-via-ids.test.ts`
- `git diff --check`

Transparency note: this PR was prepared with AI-assisted coding and manually verified.

/claim #54
