### PR TITLE
Support session via padstack variants

### DIFF
--- a/lib/dsn-pcb/dsn-json-to-circuit-json/convert-dsn-session-to-circuit-json.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/convert-dsn-session-to-circuit-json.ts
@@ -108,7 +108,7 @@ export function convertDsnSessionToCircuitJson(
 
     // Get via padstack info if available
     const viaPadstackExists = dsnSession.routes.library_out?.padstacks?.find(
-      (p) => p.name === "Via[0-1]_600:300_um",
+      (p) => p.name.toLowerCase().includes("via"),
     )
     // Add associated vias if they exist at wire endpoints
     if (viaPadstackExists && net.vias && net.vias.length > 0) {

--- a/tests/repros/repro16-session-via-padstack-name.test.ts
+++ b/tests/repros/repro16-session-via-padstack-name.test.ts
@@ -1,0 +1,113 @@
+import { expect, test } from "bun:test"
+import { su } from "@tscircuit/soup-util"
+import {
+  type DsnPcb,
+  type DsnSession,
+  convertDsnSessionToCircuitJson,
+} from "lib"
+
+const baseDsnPcb: DsnPcb = {
+  is_dsn_pcb: true,
+  filename: "four-layer-session-via",
+  parser: {
+    string_quote: '"',
+    space_in_quoted_tokens: "on",
+    host_cad: "tscircuit",
+    host_version: "test",
+  },
+  resolution: { unit: "um", value: 10 },
+  unit: "um",
+  structure: {
+    layers: [
+      { name: "F.Cu", type: "signal", property: { index: 0 } },
+      { name: "In1.Cu", type: "signal", property: { index: 1 } },
+      { name: "In2.Cu", type: "signal", property: { index: 2 } },
+      { name: "B.Cu", type: "signal", property: { index: 3 } },
+    ],
+    boundary: {
+      path: {
+        layer: "F.Cu",
+        width: 0,
+        coordinates: [0, 0, 20000, 0, 20000, 20000, 0, 20000, 0, 0],
+      },
+    },
+    via: "Via[0-3]_600:300_um",
+    rule: { clearances: [], width: 1000 },
+  },
+  placement: { components: [] },
+  library: { images: [], padstacks: [] },
+  network: {
+    nets: [{ name: "VBUS", pins: [] }],
+    classes: [],
+  },
+  wiring: { wires: [] },
+}
+
+const sessionWithFourLayerVia: DsnSession = {
+  is_dsn_session: true,
+  filename: "four-layer-session-via",
+  placement: {
+    resolution: { unit: "um", value: 10 },
+    components: [],
+  },
+  routes: {
+    resolution: { unit: "um", value: 10 },
+    parser: {
+      string_quote: '"',
+      space_in_quoted_tokens: "on",
+      host_cad: "freerouting",
+      host_version: "test",
+    },
+    library_out: {
+      images: [],
+      padstacks: [
+        {
+          name: "Via[0-3]_600:300_um",
+          attach: "off",
+          shapes: [
+            { shapeType: "circle", layer: "F.Cu", diameter: 6000 },
+            { shapeType: "circle", layer: "In1.Cu", diameter: 6000 },
+            { shapeType: "circle", layer: "In2.Cu", diameter: 6000 },
+            { shapeType: "circle", layer: "B.Cu", diameter: 6000 },
+          ],
+        },
+      ],
+    },
+    network_out: {
+      nets: [
+        {
+          name: "VBUS",
+          wires: [
+            {
+              path: {
+                layer: "F.Cu",
+                width: 2000,
+                coordinates: [0, 0, 10000, 0],
+              },
+              net: "VBUS",
+              type: "route",
+            },
+          ],
+          vias: [{ x: 10000, y: 0 }],
+        },
+      ],
+    },
+  },
+}
+
+test("converts session vias when the via padstack is not the hard-coded two-layer name", () => {
+  const circuitJson = convertDsnSessionToCircuitJson(
+    baseDsnPcb,
+    sessionWithFourLayerVia,
+  )
+
+  const vias = su(circuitJson).pcb_via.list()
+  expect(vias).toHaveLength(1)
+  expect(vias[0]).toMatchObject({
+    pcb_via_id: "pcb_via_VBUS_1_0",
+    x: 1,
+    y: 0,
+    from_layer: "top",
+    to_layer: "bottom",
+  })
+})


### PR DESCRIPTION
## Summary
- convert DSN session vias when `library_out` contains any via-like padstack, not only the hard-coded `Via[0-1]_600:300_um` name
- preserve existing wire-endpoint via insertion behavior while allowing four-layer names such as `Via[0-3]_600:300_um`
- add a focused four-layer session regression test

## Root cause
`convertDsnSessionToCircuitJson` gated via conversion on one exact two-layer via padstack name. Valid sessions with a different via padstack name still parsed `net.vias`, but the converter skipped them entirely, dropping routed vias from Circuit JSON.

## Why this is distinct
This is separate from the recent Smoothie pin parsing, component rotation, quoted pin reference, copper plane, numeric-prefix label, and duplicate same-net route ID fixes. It only changes the session via padstack detection gate.

## Validation
- `npx --yes bun test tests/repros/repro16-session-via-padstack-name.test.ts`
- `npx --yes bun test`
- `npx --yes bun run build`
- `npx --yes biome check lib/dsn-pcb/dsn-json-to-circuit-json/convert-dsn-session-to-circuit-json.ts tests/repros/repro16-session-via-padstack-name.test.ts`
- `npx --yes tsc --noEmit`
- `git diff --check`

Note: full-repo `npx --yes biome check .` still reports two pre-existing issues unrelated to this patch (`lib/utils/get-pin-number.ts` implicit any and the existing `tests/repros/repro13-missing-traces-waterCounter.test.ts` filename).

/claim #54