### PR TITLE
Use session via padstack dimensions

### DIFF
--- a/lib/dsn-pcb/dsn-json-to-circuit-json/convert-dsn-session-to-circuit-json.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/convert-dsn-session-to-circuit-json.ts
@@ -106,13 +106,20 @@ export function convertDsnSessionToCircuitJson(
       }
     })
 
-    // Get via padstack info if available
-    const viaPadstackExists = dsnSession.routes.library_out?.padstacks?.find(
+    const viaPadstacks = dsnSession.routes.library_out?.padstacks ?? []
+    const defaultViaPadstack = viaPadstacks.find(
       (p) => p.name === "Via[0-1]_600:300_um",
     )
+
     // Add associated vias if they exist at wire endpoints
-    if (viaPadstackExists && net.vias && net.vias.length > 0) {
+    if (net.vias && net.vias.length > 0) {
       net.vias.forEach((via) => {
+        const viaPadstack =
+          viaPadstacks.find((p) => p.name === via.padstack_name) ??
+          defaultViaPadstack
+
+        if (!viaPadstack) return
+
         const viaPoint = applyToPoint(transformUmToMm, {
           x: via.x,
           y: via.y,
@@ -174,6 +181,7 @@ export function convertDsnSessionToCircuitJson(
             netName: net.name,
             fromLayer,
             toLayer,
+            padstack: viaPadstack,
           }),
         })
       })

--- a/lib/dsn-pcb/dsn-json-to-circuit-json/dsn-component-converters/convert-via-to-pcb-via.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/dsn-component-converters/convert-via-to-pcb-via.ts
@@ -1,5 +1,39 @@
 import type { LayerRef, PcbVia } from "circuit-json"
-import { type Matrix, applyToPoint } from "transformation-matrix"
+import type { Padstack } from "../../types"
+
+const DEFAULT_OUTER_DIAMETER_MM = 0.6
+const DEFAULT_HOLE_DIAMETER_MM = 0.3
+
+const getViaDiameterFromName = (padstackName?: string) => {
+  const match = padstackName?.match(
+    /Via\[\d+-\d+\]_(\d+(?:\.\d+)?):(\d+(?:\.\d+)?)_um/,
+  )
+  if (!match) return {}
+
+  return {
+    outerDiameter: Number(match[1]) / 1000,
+    holeDiameter: Number(match[2]) / 1000,
+  }
+}
+
+const getViaDimensions = (padstack?: Padstack) => {
+  const nameDimensions = getViaDiameterFromName(padstack?.name)
+  const circleShape = padstack?.shapes.find(
+    (shape) => shape.shapeType === "circle",
+  )
+
+  return {
+    outerDiameter:
+      circleShape?.diameter !== undefined
+        ? circleShape.diameter / 10000
+        : (nameDimensions.outerDiameter ?? DEFAULT_OUTER_DIAMETER_MM),
+    holeDiameter:
+      nameDimensions.holeDiameter ??
+      (padstack?.hole?.diameter !== undefined
+        ? padstack.hole.diameter / 10000
+        : DEFAULT_HOLE_DIAMETER_MM),
+  }
+}
 
 export const convertViaToPcbVia = ({
   x,
@@ -7,20 +41,24 @@ export const convertViaToPcbVia = ({
   netName,
   fromLayer,
   toLayer,
+  padstack,
 }: {
   x: number
   y: number
   netName: string
   fromLayer: LayerRef
   toLayer: LayerRef
+  padstack?: Padstack
 }): PcbVia => {
+  const { outerDiameter, holeDiameter } = getViaDimensions(padstack)
+
   return {
     type: "pcb_via",
     pcb_via_id: `pcb_via_${netName}_${x}_${y}`,
     x,
     y,
-    outer_diameter: 0.6, // From session file "Via[0-1]_600:300_um"
-    hole_diameter: 0.3, // From session file "Via[0-1]_600:300_um"
+    outer_diameter: outerDiameter,
+    hole_diameter: holeDiameter,
     layers: [fromLayer, toLayer],
     pcb_trace_id: `pcb_trace_${netName}`,
     from_layer: fromLayer,

--- a/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
@@ -1133,6 +1133,7 @@ function processSessionNode(ast: ASTNode): DsnSession {
             type: "route",
           })),
           vias: viaNodes.map((viaNode) => ({
+            padstack_name: viaNode.children![1].value as string,
             x: viaNode.children![2].value as number,
             y: viaNode.children![3].value as number,
           })),

--- a/lib/dsn-pcb/types.ts
+++ b/lib/dsn-pcb/types.ts
@@ -285,6 +285,7 @@ export interface Wire {
 }
 
 export interface Via {
+  padstack_name?: string
   x: number
   y: number
 }

--- a/tests/repros/repro17-session-via-padstack-dimensions.test.ts
+++ b/tests/repros/repro17-session-via-padstack-dimensions.test.ts
@@ -1,0 +1,158 @@
+import { expect, test } from "bun:test"
+import { su } from "@tscircuit/soup-util"
+import {
+  type DsnPcb,
+  type DsnSession,
+  convertDsnSessionToCircuitJson,
+  parseDsnToDsnJson,
+} from "lib"
+
+const baseDsnPcb: DsnPcb = {
+  is_dsn_pcb: true,
+  filename: "session-via-padstack-dimensions",
+  parser: {
+    string_quote: '"',
+    host_version: "",
+    space_in_quoted_tokens: "",
+    host_cad: "",
+  },
+  resolution: { unit: "um", value: 10 },
+  unit: "um",
+  structure: {
+    layers: [
+      { name: "F.Cu", type: "signal", property: { index: 0 } },
+      { name: "B.Cu", type: "signal", property: { index: 1 } },
+    ],
+    boundary: {
+      path: {
+        layer: "pcb",
+        width: 0,
+        coordinates: [-100000, -100000, 100000, -100000, 100000, 100000],
+      },
+    },
+    via: "Via[0-1]_600:300_um",
+    rule: { clearances: [], width: 2000 },
+  },
+  placement: { components: [] },
+  library: { images: [], padstacks: [] },
+  network: {
+    nets: [{ name: "GND", pins: [] }],
+    classes: [],
+  },
+  wiring: { wires: [] },
+}
+
+const sessionWithTwoViaPadstacks: DsnSession = {
+  is_dsn_session: true,
+  filename: "session-via-padstack-dimensions",
+  placement: {
+    resolution: { unit: "um", value: 10 },
+    components: [],
+  },
+  routes: {
+    resolution: { unit: "um", value: 10 },
+    parser: {
+      string_quote: '"',
+      host_version: "",
+      space_in_quoted_tokens: "",
+      host_cad: "",
+    },
+    library_out: {
+      images: [],
+      padstacks: [
+        {
+          name: "Via[0-1]_600:300_um",
+          shapes: [
+            { shapeType: "circle", layer: "F.Cu", diameter: 6000 },
+            { shapeType: "circle", layer: "B.Cu", diameter: 6000 },
+          ],
+          attach: "off",
+        },
+        {
+          name: "Via[0-1]_800:400_um",
+          shapes: [
+            { shapeType: "circle", layer: "F.Cu", diameter: 8000 },
+            { shapeType: "circle", layer: "B.Cu", diameter: 8000 },
+          ],
+          attach: "off",
+        },
+      ],
+    },
+    network_out: {
+      nets: [
+        {
+          name: "GND",
+          wires: [
+            {
+              path: {
+                layer: "F.Cu",
+                width: 2000,
+                coordinates: [0, 0, 10000, 0],
+              },
+              net: "GND",
+              type: "route",
+            },
+          ],
+          vias: [{ padstack_name: "Via[0-1]_800:400_um", x: 10000, y: 0 }],
+        },
+      ],
+    },
+  },
+}
+
+test("parses session via padstack names", () => {
+  const session = parseDsnToDsnJson(`
+    (session "session-via-padstack-dimensions"
+      (base_design "session-via-padstack-dimensions")
+      (placement
+        (resolution um 10)
+      )
+      (routes
+        (resolution um 10)
+        (parser
+          (host_cad "KiCad's Pcbnew")
+          (host_version)
+        )
+        (library_out
+          (padstack "Via[0-1]_600:300_um"
+            (shape (circle F.Cu 6000 0 0))
+            (shape (circle B.Cu 6000 0 0))
+            (attach off)
+          )
+          (padstack "Via[0-1]_800:400_um"
+            (shape (circle F.Cu 8000 0 0))
+            (shape (circle B.Cu 8000 0 0))
+            (attach off)
+          )
+        )
+        (network_out
+          (net GND
+            (wire
+              (path F.Cu 2000
+                0 0
+                10000 0
+              )
+            )
+            (via "Via[0-1]_800:400_um" 10000 0)
+          )
+        )
+      )
+    )
+  `) as DsnSession
+
+  expect(session.routes.network_out.nets[0].vias?.[0]?.padstack_name).toBe(
+    "Via[0-1]_800:400_um",
+  )
+})
+
+test("uses each session via padstack dimensions when converting to circuit json", () => {
+  const circuitJson = convertDsnSessionToCircuitJson(
+    baseDsnPcb,
+    sessionWithTwoViaPadstacks,
+  )
+  const vias = su(circuitJson).pcb_via.list()
+
+  expect(vias).toHaveLength(1)
+  expect(vias[0].outer_diameter).toBe(0.8)
+  expect(vias[0].hole_diameter).toBe(0.4)
+})


### PR DESCRIPTION
## Summary
- preserve the padstack name on parsed session via records
- match each session via to its selected `library_out` padstack during conversion
- derive emitted `pcb_via` outer/hole diameters from the matched via padstack instead of always using 0.6/0.3 mm
- add regression coverage for sessions containing both 600/300 and 800/400 via padstacks

## Root cause
Session `(via padstack x y)` records included the padstack name, but the parser dropped it and only kept coordinates. `convertDsnSessionToCircuitJson` therefore could not tell which padstack each via used and emitted every converted session via with the hard-coded `Via[0-1]_600:300_um` dimensions.

## Why this is distinct
This is separate from the recent Smoothie pin parsing, component rotation, quoted-reference, copper-plane, numeric-prefix label, duplicate-ID, and via-padstack-name fixes. It focuses on per-via padstack selection and dimensions when multiple session via padstacks are available.

## Validation
- `npx --yes bun test tests/repros/repro17-session-via-padstack-dimensions.test.ts`
- `npx --yes bun test`
- `npx --yes bun run build`
- `npx --yes biome check lib/dsn-pcb/types.ts lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts lib/dsn-pcb/dsn-json-to-circuit-json/dsn-component-converters/convert-via-to-pcb-via.ts lib/dsn-pcb/dsn-json-to-circuit-json/convert-dsn-session-to-circuit-json.ts tests/repros/repro17-session-via-padstack-dimensions.test.ts`
- `npx --yes tsc --noEmit`
- `git diff --check`

/claim #54