### PR TITLE
fix: support boundary rect and polygon shapes

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
@@ -26,6 +26,21 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
     return `${padding}(path ${path.layer} ${path.width}  ${stringifyCoordinates(path.coordinates)})`
   }
 
+  const stringifyBoundaryShape = (
+    boundary: DsnPcb["structure"]["boundary"],
+  ) => {
+    if (boundary.path) return stringifyPath(boundary.path, 0)
+    if (boundary.rect) {
+      const layer = boundary.rect.layer ? `${boundary.rect.layer} ` : ""
+      return `(rect ${layer}${stringifyCoordinates(boundary.rect.coordinates)})`
+    }
+    if (boundary.polygon) {
+      const layer = boundary.polygon.layer ? `${boundary.polygon.layer} ` : ""
+      return `(polygon ${layer}${boundary.polygon.width} ${stringifyCoordinates(boundary.polygon.coordinates)})`
+    }
+    return ""
+  }
+
   // Start with pcb
   result += `(pcb ${dsnJson.filename ? dsnJson.filename : "./converted_dsn.dsn"}\n`
 
@@ -53,7 +68,7 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
   })
   if (dsnJson.structure.boundary) {
     result += `${indent}${indent}(boundary\n`
-    result += `${indent}${indent}${indent}${stringifyPath(dsnJson.structure.boundary.path, 0)}\n`
+    result += `${indent}${indent}${indent}${stringifyBoundaryShape(dsnJson.structure.boundary)}\n`
     result += `${indent}${indent})\n`
   }
   result += `${indent}${indent}(via ${stringifyValue(dsnJson.structure.via)})\n`

--- a/lib/dsn-pcb/dsn-json-to-circuit-json/convert-dsn-pcb-to-circuit-json.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/convert-dsn-pcb-to-circuit-json.ts
@@ -9,6 +9,25 @@ import { convertNetsToSourceNetsAndTraces } from "./dsn-component-converters/con
 import { convertPadstacksToSmtPads } from "./dsn-component-converters/convert-padstacks-to-smtpads"
 import { convertWiresToPcbTraces } from "./dsn-component-converters/convert-wires-to-traces"
 
+function getBoundaryCoordinatePairs(
+  boundary: DsnPcb["structure"]["boundary"],
+): Array<[number, number]> {
+  if (boundary.path?.coordinates.length) {
+    return pairs(boundary.path.coordinates)
+  }
+  if (boundary.rect?.coordinates.length) {
+    const [x1, y1, x2, y2] = boundary.rect.coordinates
+    return [
+      [x1, y1],
+      [x2, y2],
+    ]
+  }
+  if (boundary.polygon?.coordinates.length) {
+    return pairs(boundary.polygon.coordinates)
+  }
+  return []
+}
+
 export function convertDsnPcbToCircuitJson(
   dsnPcb: DsnPcb,
   fromSessionSpace = false,
@@ -30,8 +49,8 @@ export function convertDsnPcbToCircuitJson(
     material: "fr4",
     num_layers: 4,
   }
-  if (dsnPcb.structure.boundary.path) {
-    const boundaryPath = pairs(dsnPcb.structure.boundary.path.coordinates)
+  const boundaryPath = getBoundaryCoordinatePairs(dsnPcb.structure.boundary)
+  if (boundaryPath.length > 0) {
     const maxX = Math.max(...boundaryPath.map(([x]) => x))
     const minX = Math.min(...boundaryPath.map(([x]) => x))
     const maxY = Math.max(...boundaryPath.map(([, y]) => y))

--- a/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
@@ -296,14 +296,75 @@ function processBoundary(nodes: ASTNode[]): Boundary {
   const boundary: Partial<Boundary> = {}
   nodes.forEach((node) => {
     if (node.type === "List" && node.children![0].type === "Atom") {
-      boundary.path = processPath(node.children!)
+      const boundaryType = node.children![0].value
+      switch (boundaryType) {
+        case "path":
+          boundary.path = processPath(node.children!)
+          break
+        case "rect":
+          boundary.rect = processBoundaryRect(node.children!)
+          break
+        case "polygon":
+          boundary.polygon = processBoundaryPolygon(node.children!)
+          break
+      }
     }
   })
   // Ensure boundary.path is defined
-  if (!boundary.path) {
+  if (!boundary.path && !boundary.rect && !boundary.polygon) {
     boundary.path = { layer: "", width: 0, coordinates: [] }
   }
   return boundary as Boundary
+}
+
+function processBoundaryRect(nodes: ASTNode[]): NonNullable<Boundary["rect"]> {
+  let coordinateStartIndex = 1
+  const rect: NonNullable<Boundary["rect"]> = {
+    type: "rect",
+    coordinates: [],
+  }
+
+  if (nodes[1]?.type === "Atom" && typeof nodes[1].value === "string") {
+    rect.layer = nodes[1].value
+    coordinateStartIndex = 2
+  }
+
+  rect.coordinates = nodes
+    .slice(coordinateStartIndex)
+    .filter((node) => node.type === "Atom" && typeof node.value === "number")
+    .map((node) => node.value as number)
+
+  return rect
+}
+
+function processBoundaryPolygon(
+  nodes: ASTNode[],
+): NonNullable<Boundary["polygon"]> {
+  let currentIndex = 1
+  let currentNode = nodes[currentIndex]
+  const polygon: NonNullable<Boundary["polygon"]> = {
+    type: "polygon",
+    width: 0,
+    coordinates: [],
+  }
+
+  if (currentNode?.type === "Atom" && typeof currentNode.value === "string") {
+    polygon.layer = currentNode.value
+    currentIndex++
+    currentNode = nodes[currentIndex]
+  }
+
+  if (currentNode?.type === "Atom" && typeof currentNode.value === "number") {
+    polygon.width = currentNode.value
+    currentIndex++
+  }
+
+  polygon.coordinates = nodes
+    .slice(currentIndex)
+    .filter((node) => node.type === "Atom" && typeof node.value === "number")
+    .map((node) => node.value as number)
+
+  return polygon
 }
 
 function processPath(nodes: ASTNode[]): Path {

--- a/lib/dsn-pcb/types.ts
+++ b/lib/dsn-pcb/types.ts
@@ -23,13 +23,7 @@ export interface DsnPcb {
         index: number
       }
     }>
-    boundary: {
-      path: {
-        layer: string
-        width: number
-        coordinates: number[]
-      }
-    }
+    boundary: Boundary
     via: string
     rule: {
       clearances: Array<{
@@ -125,10 +119,12 @@ export interface Layer {
 export interface Boundary {
   rect?: {
     type: string
+    layer?: string
     coordinates: number[] // [x1, y1, x2, y2]
   }
   polygon?: {
     type: string
+    layer?: string
     width: number
     coordinates: number[]
   }

--- a/tests/dsn-pcb/boundary-shapes.test.ts
+++ b/tests/dsn-pcb/boundary-shapes.test.ts
@@ -1,0 +1,80 @@
+import { expect, test } from "bun:test"
+import { type DsnPcb, convertDsnPcbToCircuitJson, parseDsnToDsnJson } from "lib"
+
+const makeDsn = (boundary: string) => `(pcb "boundary-shapes"
+  (parser
+    (string_quote ")
+    (space_in_quoted_tokens on)
+    (host_cad "test")
+    (host_version "test")
+  )
+  (resolution um 10)
+  (unit um)
+  (structure
+    (layer Top
+      (type signal)
+      (property
+        (index 0)
+      )
+    )
+    (layer Bottom
+      (type signal)
+      (property
+        (index 1)
+      )
+    )
+    (boundary
+      ${boundary}
+    )
+    (via "Via[0-1]_600:300_um")
+    (rule
+      (width 100)
+      (clearance 100)
+    )
+  )
+  (placement)
+  (library)
+  (network)
+  (wiring)
+)`
+
+test("parses rectangular board boundaries", () => {
+  const dsnJson = parseDsnToDsnJson(
+    makeDsn("(rect Top -1000 -500 3000 1500)"),
+  ) as DsnPcb
+  const circuitJson = convertDsnPcbToCircuitJson(dsnJson)
+  const board = circuitJson.find((elm) => elm.type === "pcb_board")
+
+  expect(dsnJson.structure.boundary.rect).toEqual({
+    type: "rect",
+    layer: "Top",
+    coordinates: [-1000, -500, 3000, 1500],
+  })
+  expect(board).toMatchObject({
+    type: "pcb_board",
+    center: { x: 1, y: 0.5 },
+    width: 4,
+    height: 2,
+  })
+})
+
+test("parses polygon board boundaries", () => {
+  const dsnJson = parseDsnToDsnJson(
+    makeDsn("(polygon Top 0 0 0 4000 0 4000 2000 0 2000)"),
+  ) as DsnPcb
+  const circuitJson = convertDsnPcbToCircuitJson(dsnJson)
+  const board = circuitJson.find((elm) => elm.type === "pcb_board")
+
+  expect(dsnJson.structure.boundary.polygon).toEqual({
+    type: "polygon",
+    layer: "Top",
+    width: 0,
+    coordinates: [0, 0, 4000, 0, 4000, 2000, 0, 2000],
+  })
+  expect(board).toMatchObject({
+    type: "pcb_board",
+    center: { x: 2, y: 1 },
+    width: 4,
+    height: 2,
+  })
+})


### PR DESCRIPTION
### Context

/claim #54

DSN PCB files can encode board boundaries as `rect` or `polygon` shapes, not only `path`. The current parser sends every boundary child through `processPath`, so `(boundary (rect ...))` or `(boundary (polygon ...))` become malformed path data and `convertDsnPcbToCircuitJson` cannot derive board dimensions from those boundaries.

This is scoped away from the active #54 work on pin parsing, rotations, quoted references, numeric-prefix labels, duplicate IDs, copper planes, and via padstacks.

### Decisions

- Add boundary-specific parsing for `rect`, `polygon`, and the existing `path` shape.
- Reuse parsed boundary shape coordinates when calculating `pcb_board` center, width, and height.
- Preserve `rect` and `polygon` boundary shapes in `stringifyDsnJson`.
- Leave DSN unit scaling unchanged; boundary coordinates still use the existing `1 / 1000` conversion.

### Risk Areas

- `DsnPcb.structure.boundary` now represents multiple DSN shape variants instead of only `path`.
- Board dimensions are derived from rect/polygon coordinate bounds as well as path coordinate bounds.

### Checks Run

- `bun test tests/dsn-pcb/boundary-shapes.test.ts tests/dsn-pcb/stringify-dsn-json.test.ts tests/dsn-pcb/parse-dsn-json-to-circuit-json.test.ts tests/dsn-pcb/convert-dsn-file-to-circuit-json.test.ts`
- `bun run format:check`
- `bun run build`
