### PR TITLE
fix: offset SMT pads by padstack shape center

### DIFF
--- a/lib/dsn-pcb/dsn-json-to-circuit-json/dsn-component-converters/convert-padstacks-to-smtpads.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/dsn-component-converters/convert-padstacks-to-smtpads.ts
@@ -1,9 +1,68 @@
 import type { AnyCircuitElement, PcbSmtPad } from "circuit-json"
 import Debug from "debug"
-import type { DsnPcb } from "lib/dsn-pcb/types"
+import type { DsnPcb, Shape } from "lib/dsn-pcb/types"
 import { applyToPoint } from "transformation-matrix"
 
 const debug = Debug("dsn-converter:convertPadstacksToSmtpads")
+
+function getShapeBounds(shape: Shape): {
+  width: number
+  height: number
+  centerX: number
+  centerY: number
+} {
+  if (shape.shapeType === "rect") {
+    const [x1, y1, x2, y2] = shape.coordinates
+    return {
+      width: Math.abs(x2 - x1) / 1000,
+      height: Math.abs(y2 - y1) / 1000,
+      centerX: (x1 + x2) / 2,
+      centerY: (y1 + y2) / 2,
+    }
+  }
+
+  if (shape.shapeType === "polygon") {
+    let minX = Infinity
+    let maxX = -Infinity
+    let minY = Infinity
+    let maxY = -Infinity
+
+    for (let i = 0; i < shape.coordinates.length; i += 2) {
+      const x = shape.coordinates[i]
+      const y = shape.coordinates[i + 1]
+
+      minX = Math.min(minX, x)
+      maxX = Math.max(maxX, x)
+      minY = Math.min(minY, y)
+      maxY = Math.max(maxY, y)
+    }
+
+    return {
+      width: Math.abs(maxX - minX) / 1000,
+      height: Math.abs(maxY - minY) / 1000,
+      centerX: (minX + maxX) / 2,
+      centerY: (minY + maxY) / 2,
+    }
+  }
+
+  if (shape.shapeType === "path") {
+    const [x1, y1, x2, y2] = shape.coordinates
+    return {
+      width: shape.width / 1000,
+      height: Math.sqrt((x2 - x1) ** 2 + (y2 - y1) ** 2) / 1000,
+      centerX: (x1 + x2) / 2,
+      centerY: (y1 + y2) / 2,
+    }
+  }
+
+  const radius = shape.diameter / 2 / 1000
+  return {
+    width: radius,
+    height: radius,
+    centerX: shape.x ?? 0,
+    centerY: shape.y ?? 0,
+  }
+}
 
 export function convertPadstacksToSmtPads(
   pcb: DsnPcb,
@@ -63,56 +122,21 @@ export function convertPadstacksToSmtPads(
           pathShape,
         })
 
-        let width: number
-        let height: number
-
-        if (rectShape) {
-          // Handle rectangle shape
-          const [x1, y1, x2, y2] = rectShape.coordinates
-          width = Math.abs(x2 - x1) / 1000 // Convert μm to mm
-          height = Math.abs(y2 - y1) / 1000 // Convert μm to mm
-        } else if (polygonShape) {
-          // Handle polygon shape
-          const coordinates = polygonShape.coordinates
-          let minX = Infinity
-          let maxX = -Infinity
-          let minY = Infinity
-          let maxY = -Infinity
-
-          // Coordinates are in pairs (x,y), so iterate by 2
-          for (let i = 0; i < coordinates.length; i += 2) {
-            const x = coordinates[i]
-            const y = coordinates[i + 1]
-
-            minX = Math.min(minX, x)
-            maxX = Math.max(maxX, x)
-            minY = Math.min(minY, y)
-            maxY = Math.max(maxY, y)
-          }
-
-          width = Math.abs(maxX - minX) / 1000
-          height = Math.abs(maxY - minY) / 1000
-        } else if (pathShape) {
-          // For path shapes (oval/pill pads), width is the path width
-          // and height is the distance between path endpoints
-          const [x1, y1, x2, y2] = pathShape.coordinates
-          width = pathShape.width / 1000 // Convert μm to mm
-          height = Math.sqrt((x2 - x1) ** 2 + (y2 - y1) ** 2) / 1000
-        } else if (circleShape) {
-          // Handle circle shape
-          const radius = circleShape.diameter / 2 / 1000
-          width = radius
-          height = radius
-        } else {
+        const selectedShape =
+          rectShape ?? polygonShape ?? pathShape ?? circleShape
+        if (!selectedShape) {
           console.warn(`No valid shape found for padstack: ${padstack.name}`)
           return
         }
 
+        const { width, height, centerX, centerY } =
+          getShapeBounds(selectedShape)
+
         // Calculate position in circuit space using the transformation matrix
         // Convert component position and pin offset to circuit coordinates
         const { x: circuitX, y: circuitY } = applyToPoint(transform, {
-          x: (compX || 0) + pin.x,
-          y: (compY || 0) + pin.y,
+          x: (compX || 0) + pin.x + centerX,
+          y: (compY || 0) + pin.y + centerY,
         })
 
         let pcbPad: PcbSmtPad

--- a/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
@@ -775,6 +775,18 @@ function processCircleShape(nodes: ASTNode[]): CircleShape {
   ) {
     circle.layer = shapeNodes[1].value
     circle.diameter = shapeNodes[2].value
+    if (
+      shapeNodes[3]?.type === "Atom" &&
+      typeof shapeNodes[3].value === "number"
+    ) {
+      circle.x = shapeNodes[3].value
+    }
+    if (
+      shapeNodes[4]?.type === "Atom" &&
+      typeof shapeNodes[4].value === "number"
+    ) {
+      circle.y = shapeNodes[4].value
+    }
     return circle as CircleShape
   } else {
     // Try to extract coordinates if they exist

--- a/lib/dsn-pcb/types.ts
+++ b/lib/dsn-pcb/types.ts
@@ -229,6 +229,8 @@ export interface PolygonShape extends BaseShape {
 export interface CircleShape extends BaseShape {
   shapeType: "circle"
   diameter: number
+  x?: number
+  y?: number
 }
 
 export interface RectShape extends BaseShape {

--- a/tests/dsn-pcb/padstack-shape-center-offset.test.ts
+++ b/tests/dsn-pcb/padstack-shape-center-offset.test.ts
@@ -1,0 +1,60 @@
+import { expect, test } from "bun:test"
+import type { PcbSmtPad } from "circuit-json"
+import { type DsnPcb, parseDsnToDsnJson } from "lib"
+import { convertDsnJsonToCircuitJson } from "../../lib/dsn-pcb/dsn-json-to-circuit-json/convert-dsn-json-to-circuit-json.ts"
+
+const dsnWithOffCenterPadstackShape = `
+(pcb off_center_padstack_shape
+  (parser
+    (string_quote ")
+    (space_in_quoted_tokens on)
+    (host_cad "test")
+    (host_version "1")
+  )
+  (resolution um 1)
+  (unit um)
+  (structure
+    (layer F.Cu (type signal) (property (index 0)))
+    (layer B.Cu (type signal) (property (index 1)))
+    (boundary (path pcb 0 -5000 -5000 5000 -5000 5000 5000 -5000 5000 -5000 -5000))
+    (via "Via[0-1]_600:300_um")
+    (rule (width 100) (clearance 100))
+  )
+  (placement
+    (component U
+      (place U1 1000 2000 front 0)
+    )
+  )
+  (library
+    (image U
+      (pin OffsetRect 1 0 0)
+    )
+    (padstack OffsetRect
+      (shape (rect F.Cu 0 0 1000 500))
+      (attach off)
+    )
+  )
+  (network
+    (net N1 (pins U1-1))
+    (class default N1 (circuit (use_via "Via[0-1]_600:300_um")) (rule (width 100) (clearance 100)))
+  )
+  (wiring)
+)
+`
+
+test("offsets SMT pad centers by the padstack shape center", () => {
+  const dsnJson = parseDsnToDsnJson(dsnWithOffCenterPadstackShape) as DsnPcb
+  const circuitJson = convertDsnJsonToCircuitJson(dsnJson)
+  const pcbSmtpad = circuitJson.find(
+    (element): element is PcbSmtPad => element.type === "pcb_smtpad",
+  )
+
+  expect(pcbSmtpad).toBeDefined()
+  if (!pcbSmtpad || pcbSmtpad.shape !== "rect") {
+    throw new Error("Expected a rectangular pcb_smtpad")
+  }
+  expect(pcbSmtpad.x).toBe(1.5)
+  expect(pcbSmtpad.y).toBe(2.25)
+  expect(pcbSmtpad.width).toBe(1)
+  expect(pcbSmtpad.height).toBe(0.5)
+})


### PR DESCRIPTION
## Summary
/claim #54

- compute the local center of DSN padstack shapes while converting SMT pads
- add that shape-local center to the pin position before converting to Circuit JSON coordinates
- preserve optional circle shape x/y offsets from DSN syntax like `(circle F.Cu 1000 200 300)`
- add a regression test for an off-center rectangular padstack shape

## Root cause
DSN padstack shape coordinates are relative to the pin origin. The converter already used those coordinates to determine pad dimensions, but it always emitted the `pcb_smtpad` at the pin coordinate itself. For an off-center shape such as `(rect F.Cu 0 0 1000 500)`, the rendered pad center should be shifted by `(500, 250)` DSN units.

## Why this is distinct
This is scoped to padstack shape-local center offsets. It does not change the active work around component rotation, pin parsing, quoted labels, via dimensions, copper planes, boundary shapes, or stroked path extents.

## Validation
- `bun test tests/dsn-pcb/padstack-shape-center-offset.test.ts`
- `bun x biome check lib/dsn-pcb/types.ts lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts lib/dsn-pcb/dsn-json-to-circuit-json/dsn-component-converters/convert-padstacks-to-smtpads.ts tests/dsn-pcb/padstack-shape-center-offset.test.ts`
- `bun x tsc --noEmit`
- `bun test`