### PR TITLE
fix: keep DSN pcb port component ids scoped

### DIFF
--- a/lib/dsn-pcb/dsn-json-to-circuit-json/dsn-component-converters/convert-dsn-pcb-components-to-source-components-and-ports.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/dsn-component-converters/convert-dsn-pcb-components-to-source-components-and-ports.ts
@@ -52,7 +52,7 @@ export const convertDsnPcbComponentsToSourceComponentsAndPorts = ({
             pcb_port_id: `pcb_port_${component.name}-Pad${pin.pin_number}_${place.refdes}`,
             type: "pcb_port",
             source_port_id: port.source_port_id,
-            pcb_component_id: component.name,
+            pcb_component_id: `${component.name}_${place.refdes}`,
             x: pcb_port_center.x,
             y: pcb_port_center.y,
             layers: [place.side === "back" ? "bottom" : "top"],

--- a/tests/dsn-pcb/dsn-pcb-port-component-ids.test.ts
+++ b/tests/dsn-pcb/dsn-pcb-port-component-ids.test.ts
@@ -1,0 +1,54 @@
+import { expect, test } from "bun:test"
+import { parseDsnToCircuitJson } from "lib"
+
+const twoPlacementDsn = `(pcb "component-id-test"
+  (parser (string_quote ") (space_in_quoted_tokens on) (host_cad "test") (host_version "1"))
+  (resolution um 10)
+  (unit um)
+  (structure
+    (layer Top (type signal) (property (index 0)))
+    (boundary (path Top 0 0 0 10000 0 10000 10000 0 10000 0 0))
+    (via Via[0-0]_600:300_um)
+    (rule (width 100) (clearance 100))
+  )
+  (placement
+    (component U_LIB
+      (place U1 1000 2000 front 0)
+      (place U2 3000 2000 front 0)
+    )
+  )
+  (library
+    (image U_LIB
+      (pin RectPad 1 0 0)
+    )
+    (padstack RectPad
+      (shape (rect Top -500 -250 500 250))
+    )
+  )
+  (network
+    (net N1 (pins U1-1 U2-1))
+  )
+  (wiring)
+)`
+
+test("dsn pcb ports use placement-specific component ids", () => {
+  const circuitJson = parseDsnToCircuitJson(twoPlacementDsn)
+  const smtPads = circuitJson.filter((element) => element.type === "pcb_smtpad")
+  const pcbPorts = circuitJson.filter((element) => element.type === "pcb_port")
+
+  expect(smtPads.map((pad) => pad.pcb_component_id).sort()).toEqual([
+    "U_LIB_U1",
+    "U_LIB_U2",
+  ])
+  expect(pcbPorts.map((port) => port.pcb_component_id).sort()).toEqual([
+    "U_LIB_U1",
+    "U_LIB_U2",
+  ])
+
+  for (const smtPad of smtPads) {
+    const pcbPort = pcbPorts.find(
+      (port) => port.pcb_port_id === smtPad.pcb_port_id,
+    )
+    expect(pcbPort?.pcb_component_id).toBe(smtPad.pcb_component_id)
+  }
+})


### PR DESCRIPTION
Part of #54.

/claim #54

## Summary
- Scope DSN-derived `pcb_port.pcb_component_id` to the concrete placement refdes, matching the existing `pcb_smtpad.pcb_component_id` format.
- Prevent multiple placements of the same DSN image from collapsing all PCB ports under the shared library/image name.
- Add a focused two-placement regression test proving each `pcb_port` keeps the same component id as its matching `pcb_smtpad`.

## Root Cause
`convertPadstacksToSmtPads` already emits placement-specific component ids such as `U_LIB_U1` and `U_LIB_U2`, but `convertDsnPcbComponentsToSourceComponentsAndPorts` was emitting `pcb_port.pcb_component_id` as only `U_LIB`. Downstream consumers that group pads and ports by `pcb_component_id` could therefore lose the concrete component instance association.

## Verification
- `bun test tests/dsn-pcb/dsn-pcb-port-component-ids.test.ts`
- `bun test tests/repros/repro3-fix-hover-trace.test.ts tests/dsn-pcb/convert-dsn-file-to-circuit-json.test.ts`
- `./node_modules/.bin/biome check lib/dsn-pcb/dsn-json-to-circuit-json/dsn-component-converters/convert-dsn-pcb-components-to-source-components-and-ports.ts tests/dsn-pcb/dsn-pcb-port-component-ids.test.ts`
- `./node_modules/.bin/tsc --noEmit`
- `bun run build`
- `git diff --check`
