### PR TITLE
Emit pcb_component placements when converting DSN images

### DIFF
--- a/lib/dsn-pcb/dsn-json-to-circuit-json/dsn-component-converters/convert-dsn-pcb-components-to-source-components-and-ports.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/dsn-component-converters/convert-dsn-pcb-components-to-source-components-and-ports.ts
@@ -1,4 +1,9 @@
-import type { AnySourceComponent, PcbPort, SourcePort } from "circuit-json"
+import type {
+  AnyCircuitElement,
+  AnySourceComponent,
+  PcbPort,
+  SourcePort,
+} from "circuit-json"
 import type { DsnPcb, Image, Pin } from "lib/dsn-pcb/types"
 import { type Matrix, applyToPoint } from "transformation-matrix"
 
@@ -8,8 +13,8 @@ export const convertDsnPcbComponentsToSourceComponentsAndPorts = ({
 }: {
   dsnPcb: DsnPcb
   transformDsnUnitToMm: Matrix
-}): Array<AnySourceComponent | SourcePort | PcbPort> => {
-  const result: Array<AnySourceComponent | SourcePort | PcbPort> = []
+}): AnyCircuitElement[] => {
+  const result: AnyCircuitElement[] = []
 
   // Map to store image definitions for component lookup
   const imageMap = new Map(dsnPcb.library.images.map((img) => [img.name, img]))
@@ -20,6 +25,7 @@ export const convertDsnPcbComponentsToSourceComponentsAndPorts = ({
 
     // Create source component for each place
     component.places.forEach((place) => {
+      const pcbComponentId = `${component.name}_${place.refdes}`
       const sourceComponent: AnySourceComponent = {
         type: "source_component",
         source_component_id: `sc_${component.name}_${place.refdes}`,
@@ -29,6 +35,24 @@ export const convertDsnPcbComponentsToSourceComponentsAndPorts = ({
         ftype: "simple_chip",
       }
       result.push(sourceComponent)
+
+      const bounds = getImageBounds(image)
+      const placeX = place.x || 0
+      const placeY = place.y || 0
+      const pcbComponentCenter = applyToPoint(transformDsnUnitToMm, {
+        x: placeX + bounds.centerX,
+        y: placeY + bounds.centerY,
+      })
+      result.push({
+        type: "pcb_component",
+        pcb_component_id: pcbComponentId,
+        source_component_id: sourceComponent.source_component_id,
+        center: pcbComponentCenter,
+        width: bounds.width * transformDsnUnitToMm.a,
+        height: bounds.height * transformDsnUnitToMm.a,
+        layer: place.side === "back" ? "bottom" : "top",
+        rotation: place.rotation ?? 0,
+      } as AnyCircuitElement)
 
       // Create ports for each pin in the image
       if (image.pins) {
@@ -42,8 +66,6 @@ export const convertDsnPcbComponentsToSourceComponentsAndPorts = ({
             port_hints: [],
           }
           // Handle case where place coordinates might be null/undefined
-          const placeX = place.x || 0
-          const placeY = place.y || 0
           const pcb_port_center = applyToPoint(transformDsnUnitToMm, {
             x: placeX + pin.x,
             y: placeY + pin.y,
@@ -52,7 +74,7 @@ export const convertDsnPcbComponentsToSourceComponentsAndPorts = ({
             pcb_port_id: `pcb_port_${component.name}-Pad${pin.pin_number}_${place.refdes}`,
             type: "pcb_port",
             source_port_id: port.source_port_id,
-            pcb_component_id: component.name,
+            pcb_component_id: pcbComponentId,
             x: pcb_port_center.x,
             y: pcb_port_center.y,
             layers: [place.side === "back" ? "bottom" : "top"],
@@ -64,4 +86,49 @@ export const convertDsnPcbComponentsToSourceComponentsAndPorts = ({
   }
 
   return result
+}
+
+function getImageBounds(image: Image): {
+  centerX: number
+  centerY: number
+  width: number
+  height: number
+} {
+  const xs: number[] = []
+  const ys: number[] = []
+
+  for (const outline of image.outlines ?? []) {
+    const coordinates = outline.path?.coordinates ?? []
+    for (let i = 0; i < coordinates.length; i += 2) {
+      const x = coordinates[i]
+      const y = coordinates[i + 1]
+      if (Number.isFinite(x) && Number.isFinite(y)) {
+        xs.push(x!)
+        ys.push(y!)
+      }
+    }
+  }
+
+  for (const pin of image.pins ?? []) {
+    if (Number.isFinite(pin.x) && Number.isFinite(pin.y)) {
+      xs.push(pin.x)
+      ys.push(pin.y)
+    }
+  }
+
+  if (xs.length === 0 || ys.length === 0) {
+    return { centerX: 0, centerY: 0, width: 1000, height: 1000 }
+  }
+
+  const minX = Math.min(...xs)
+  const maxX = Math.max(...xs)
+  const minY = Math.min(...ys)
+  const maxY = Math.max(...ys)
+
+  return {
+    centerX: (minX + maxX) / 2,
+    centerY: (minY + maxY) / 2,
+    width: Math.max(maxX - minX, 1000),
+    height: Math.max(maxY - minY, 1000),
+  }
 }

--- a/tests/dsn-pcb/dsn-component-placement-ids.test.ts
+++ b/tests/dsn-pcb/dsn-component-placement-ids.test.ts
@@ -1,0 +1,72 @@
+import { expect, test } from "bun:test"
+import { scale } from "transformation-matrix"
+
+import { convertDsnPcbComponentsToSourceComponentsAndPorts } from "../../lib/dsn-pcb/dsn-json-to-circuit-json/dsn-component-converters/convert-dsn-pcb-components-to-source-components-and-ports"
+import type { DsnPcb } from "../../lib/dsn-pcb/types"
+
+test("creates pcb_component entries with ids shared by ports and pads", () => {
+  const dsnPcb = {
+    library: {
+      images: [
+        {
+          name: "Resistor_SMD",
+          outlines: [
+            {
+              path: {
+                layer: "signal",
+                width: 0,
+                coordinates: [-1500, -500, 1500, -500, 1500, 500, -1500, 500],
+              },
+            },
+          ],
+          pins: [
+            { padstack_name: "pad", pin_number: 1, x: -1000, y: 0 },
+            { padstack_name: "pad", pin_number: 2, x: 1000, y: 0 },
+          ],
+        },
+      ],
+      padstacks: [],
+    },
+    placement: {
+      components: [
+        {
+          name: "Resistor_SMD",
+          places: [
+            {
+              refdes: "R1",
+              PN: "10k",
+              x: 5000,
+              y: 7000,
+              side: "front",
+              rotation: 90,
+            },
+          ],
+        },
+      ],
+    },
+  } as DsnPcb
+
+  const elements = convertDsnPcbComponentsToSourceComponentsAndPorts({
+    dsnPcb,
+    transformDsnUnitToMm: scale(1 / 1000),
+  }) as any[]
+
+  const pcbComponent = elements.find(
+    (element) => element.type === "pcb_component",
+  )
+  expect(pcbComponent).toMatchObject({
+    pcb_component_id: "Resistor_SMD_R1",
+    source_component_id: "sc_Resistor_SMD_R1",
+    center: { x: 5, y: 7 },
+    width: 3,
+    height: 1,
+    layer: "top",
+    rotation: 90,
+  })
+
+  const pcbPorts = elements.filter((element) => element.type === "pcb_port")
+  expect(pcbPorts).toHaveLength(2)
+  expect(
+    pcbPorts.every((port) => port.pcb_component_id === "Resistor_SMD_R1"),
+  ).toBe(true)
+})


### PR DESCRIPTION
Fixes #54.

/claim #54

Summary:
- creates pcb_component entries for each DSN component placement using image bounds
- makes generated pcb_port ids reference the same pcb_component_id as the placement and pads
- adds focused coverage for component placement dimensions and shared port ids

Verification:
- git diff --check
- not run: bun test (bun is not installed in this environment)