### PR TITLE
Use DSN layer count for imported board metadata

### DIFF
--- a/lib/dsn-pcb/dsn-json-to-circuit-json/convert-dsn-pcb-to-circuit-json.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/convert-dsn-pcb-to-circuit-json.ts
@@ -28,7 +28,8 @@ export function convertDsnPcbToCircuitJson(
     height: 10,
     thickness: 1.4,
     material: "fr4",
-    num_layers: 4,
+    num_layers:
+      dsnPcb.structure.layers?.length > 0 ? dsnPcb.structure.layers.length : 4,
   }
   if (dsnPcb.structure.boundary.path) {
     const boundaryPath = pairs(dsnPcb.structure.boundary.path.coordinates)

--- a/tests/dsn-pcb/multi-layer-support.test.ts
+++ b/tests/dsn-pcb/multi-layer-support.test.ts
@@ -1,6 +1,55 @@
 import { expect, test } from "bun:test"
 import type { AnyCircuitElement } from "circuit-json"
 import { convertCircuitJsonToDsnJson } from "../../lib/dsn-pcb/circuit-json-to-dsn-json/convert-circuit-json-to-dsn-json"
+import { convertDsnPcbToCircuitJson } from "../../lib/dsn-pcb/dsn-json-to-circuit-json/convert-dsn-pcb-to-circuit-json"
+import type { DsnPcb } from "../../lib/dsn-pcb/types"
+
+function createDsnPcbWithLayerCount(numLayers: number): DsnPcb {
+  const layerNames =
+    numLayers === 2
+      ? ["F.Cu", "B.Cu"]
+      : [
+          "F.Cu",
+          ...Array.from({ length: numLayers - 2 }, (_, i) => `In${i + 1}.Cu`),
+          "B.Cu",
+        ]
+
+  return {
+    is_dsn_pcb: true,
+    filename: "layer-count-test.dsn",
+    parser: {
+      string_quote: '"',
+      host_version: "test",
+      space_in_quoted_tokens: "on",
+      host_cad: "test",
+    },
+    resolution: { unit: "um", value: 10 },
+    unit: "um",
+    structure: {
+      layers: layerNames.map((name, index) => ({
+        name,
+        type: "signal",
+        property: { index },
+      })),
+      boundary: {
+        path: {
+          layer: "F.Cu",
+          width: 0,
+          coordinates: [0, 0, 10000, 0, 10000, 10000, 0, 10000],
+        },
+      },
+      via: `Via[0-${numLayers - 1}]_600:300_um`,
+      rule: {
+        clearances: [],
+        width: 200,
+      },
+    },
+    placement: { components: [] },
+    library: { images: [], padstacks: [] },
+    network: { nets: [], classes: [] },
+    wiring: { wires: [] },
+  }
+}
 
 test("multi-layer support - 2 layers (default)", () => {
   const circuitElements: AnyCircuitElement[] = [
@@ -159,4 +208,22 @@ test("multi-layer support - no num_layers specified (default to 2)", () => {
   expect(dsnJson.structure.layers[0].property.index).toBe(0)
   expect(dsnJson.structure.layers[1].name).toBe("B.Cu")
   expect(dsnJson.structure.layers[1].property.index).toBe(1)
+})
+
+test("dsn import sets board num_layers from structure layers", () => {
+  const twoLayerCircuitJson = convertDsnPcbToCircuitJson(
+    createDsnPcbWithLayerCount(2),
+  )
+  const twoLayerBoard = twoLayerCircuitJson.find(
+    (element) => element.type === "pcb_board",
+  )
+  expect(twoLayerBoard?.num_layers).toBe(2)
+
+  const sixLayerCircuitJson = convertDsnPcbToCircuitJson(
+    createDsnPcbWithLayerCount(6),
+  )
+  const sixLayerBoard = sixLayerCircuitJson.find(
+    (element) => element.type === "pcb_board",
+  )
+  expect(sixLayerBoard?.num_layers).toBe(6)
 })


### PR DESCRIPTION
## Summary

- Set imported `pcb_board.num_layers` from `dsnPcb.structure.layers.length` instead of hard-coding `4`.
- Preserve the existing fallback for malformed DSNs with no structure layers.
- Add DSN-to-Circuit JSON regression coverage for 2-layer and 6-layer boards.

## Verification

- `bun test tests/dsn-pcb/multi-layer-support.test.ts --timeout 30000`
- `bunx biome check lib/dsn-pcb/dsn-json-to-circuit-json/convert-dsn-pcb-to-circuit-json.ts tests/dsn-pcb/multi-layer-support.test.ts`
- `bunx tsc --noEmit`
- `bun test --timeout 60000`
- `bun run build`
- `git diff --check`

/claim #54