### PR TITLE
Parse DSN image keepouts

### DIFF
--- a/lib/dsn-pcb/dsn-json-to-circuit-json/convert-dsn-pcb-to-circuit-json.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/convert-dsn-pcb-to-circuit-json.ts
@@ -5,6 +5,7 @@ import type { AnyCircuitElement, PcbBoard } from "circuit-json"
 import { pairs } from "lib/utils/pairs"
 import type { DsnPcb } from "../types"
 import { convertDsnPcbComponentsToSourceComponentsAndPorts } from "./dsn-component-converters/convert-dsn-pcb-components-to-source-components-and-ports"
+import { convertKeepoutsToPcbKeepouts } from "./dsn-component-converters/convert-keepouts-to-pcb-keepouts"
 import { convertNetsToSourceNetsAndTraces } from "./dsn-component-converters/convert-nets-to-source-nets-and-traces"
 import { convertPadstacksToSmtPads } from "./dsn-component-converters/convert-padstacks-to-smtpads"
 import { convertWiresToPcbTraces } from "./dsn-component-converters/convert-wires-to-traces"
@@ -52,6 +53,8 @@ export function convertDsnPcbToCircuitJson(
 
   // Convert padstacks to SMT pads using the transformation matrix
   elements.push(...convertPadstacksToSmtPads(dsnPcb, transformDsnUnitToMm))
+
+  elements.push(...convertKeepoutsToPcbKeepouts(dsnPcb, transformDsnUnitToMm))
 
   // Convert wires to PCB traces using the transformation matrix
   if (dsnPcb.wiring && dsnPcb.network) {

--- a/lib/dsn-pcb/dsn-json-to-circuit-json/dsn-component-converters/convert-keepouts-to-pcb-keepouts.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/dsn-component-converters/convert-keepouts-to-pcb-keepouts.ts
@@ -1,0 +1,63 @@
+import type { AnyCircuitElement } from "circuit-json"
+import type { Matrix } from "transformation-matrix"
+import { applyToPoint } from "transformation-matrix"
+import type { DsnPcb } from "../../types"
+
+const sanitizeIdPart = (value: string) =>
+  value.replace(/[^a-zA-Z0-9_-]/g, "_") || "unnamed"
+
+const getCircuitJsonLayer = (dsnPcb: DsnPcb, layer: string) => {
+  const normalizedLayer = layer.toLowerCase()
+  if (normalizedLayer === "top" || normalizedLayer === "f.cu") return "top"
+  if (normalizedLayer === "bottom" || normalizedLayer === "b.cu")
+    return "bottom"
+
+  const layerDefinition = dsnPcb.structure.layers.find((l) => l.name === layer)
+  const layerIndex = layerDefinition?.property?.index
+  if (layerIndex === undefined) return layer
+
+  const maxLayerIndex = Math.max(
+    ...dsnPcb.structure.layers.map((l) => l.property.index),
+  )
+  if (layerIndex === 0) return "top"
+  if (layerIndex === maxLayerIndex) return "bottom"
+  return `inner${layerIndex}`
+}
+
+export function convertKeepoutsToPcbKeepouts(
+  dsnPcb: DsnPcb,
+  transformDsnUnitToMm: Matrix,
+): AnyCircuitElement[] {
+  const elements: AnyCircuitElement[] = []
+
+  for (const image of dsnPcb.library.images) {
+    if (!image.keepouts?.length) continue
+
+    const placementComponent = dsnPcb.placement.components.find(
+      (comp) => comp.name === image.name,
+    )
+    if (!placementComponent) continue
+
+    for (const place of placementComponent.places) {
+      image.keepouts.forEach((keepout, keepoutIndex) => {
+        const { shape } = keepout
+        const center = applyToPoint(transformDsnUnitToMm, {
+          x: (place.x || 0) + shape.x,
+          y: (place.y || 0) + shape.y,
+        })
+
+        elements.push({
+          type: "pcb_keepout",
+          pcb_keepout_id: `pcb_keepout_${sanitizeIdPart(image.name)}_${sanitizeIdPart(place.refdes)}_${keepoutIndex}`,
+          shape: "circle",
+          center,
+          radius: shape.diameter / 2 / 1000,
+          layers: [getCircuitJsonLayer(dsnPcb, shape.layer)],
+          description: keepout.name || undefined,
+        } as AnyCircuitElement)
+      })
+    }
+  }
+
+  return elements
+}

--- a/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
@@ -18,6 +18,8 @@ import type {
   DsnPcb,
   DsnSession,
   Image,
+  Keepout,
+  KeepoutCircleShape,
   Layer,
   Library,
   Net,
@@ -534,6 +536,7 @@ function processImage(nodes: ASTNode[]): Image {
   }
   image.outlines = []
   image.pins = []
+  image.keepouts = []
 
   nodes.slice(2).forEach((node) => {
     if (node.type === "List") {
@@ -545,6 +548,9 @@ function processImage(nodes: ASTNode[]): Image {
         } else if (key === "pin") {
           const pin = processPin(node.children!)
           if (pin) image.pins!.push(pin)
+        } else if (key === "keepout") {
+          const keepout = processKeepout(node.children!)
+          if (keepout) image.keepouts!.push(keepout)
         }
       }
     }
@@ -565,6 +571,55 @@ function processOutline(nodes: ASTNode[]): Outline {
     }
   })
   return outline as Outline
+}
+
+function processKeepout(nodes: ASTNode[]): Keepout | null {
+  const nameNode = nodes[1]
+  const shapeNode = nodes.find((node) => node.type === "List")
+
+  if (!shapeNode?.children || shapeNode.children[0]?.type !== "Atom") {
+    debug("Unsupported keepout format:", nodes)
+    return null
+  }
+
+  const shapeType = shapeNode.children[0].value
+  if (shapeType !== "circle") {
+    debug("Unsupported keepout shape:", shapeType)
+    return null
+  }
+
+  return {
+    name:
+      nameNode?.type === "Atom" && nameNode.value !== undefined
+        ? String(nameNode.value)
+        : "",
+    shape: processKeepoutCircleShape(shapeNode.children!),
+  }
+}
+
+function processKeepoutCircleShape(nodes: ASTNode[]): KeepoutCircleShape {
+  if (
+    nodes[1]?.type === "Atom" &&
+    typeof nodes[1].value === "string" &&
+    nodes[2]?.type === "Atom" &&
+    typeof nodes[2].value === "number"
+  ) {
+    return {
+      shapeType: "circle",
+      layer: nodes[1].value,
+      diameter: nodes[2].value,
+      x:
+        nodes[3]?.type === "Atom" && typeof nodes[3].value === "number"
+          ? nodes[3].value
+          : 0,
+      y:
+        nodes[4]?.type === "Atom" && typeof nodes[4].value === "number"
+          ? nodes[4].value
+          : 0,
+    }
+  }
+
+  throw new Error("Invalid keepout circle shape format")
 }
 
 function processPin(nodes: ASTNode[]): Pin | null {

--- a/lib/dsn-pcb/types.ts
+++ b/lib/dsn-pcb/types.ts
@@ -182,6 +182,7 @@ export interface Image {
   name: string
   outlines: Outline[]
   pins: Pin[]
+  keepouts?: Keepout[]
 }
 
 export interface Outline {
@@ -191,6 +192,20 @@ export interface Outline {
 export interface Pin {
   padstack_name: string
   pin_number: number | string
+  x: number
+  y: number
+}
+
+export interface Keepout {
+  name: string
+  shape: KeepoutShape
+}
+
+export type KeepoutShape = KeepoutCircleShape
+
+export interface KeepoutCircleShape extends BaseShape {
+  shapeType: "circle"
+  diameter: number
   x: number
   y: number
 }

--- a/tests/dsn-pcb/dsn-image-keepouts.test.ts
+++ b/tests/dsn-pcb/dsn-image-keepouts.test.ts
@@ -1,0 +1,87 @@
+import { expect, test } from "bun:test"
+import type { DsnPcb } from "lib"
+import {
+  convertDsnPcbToCircuitJson,
+  parseDsnToCircuitJson,
+  parseDsnToDsnJson,
+} from "lib"
+
+// @ts-ignore
+import smoothieBoardDsn from "../assets/repro/smoothieboard-repro.dsn" with {
+  type: "text",
+}
+
+const dsnWithImageKeepouts = `
+(pcb keepout_fixture
+  (resolution um 10)
+  (unit um)
+  (structure
+    (layer Top (type signal) (property (index 0)))
+    (layer Route2 (type signal) (property (index 1)))
+    (layer Bottom (type signal) (property (index 2)))
+    (boundary (path pcb 0 0 0 3000 0 3000 3000 0 3000 0 0))
+  )
+  (placement
+    (component KEEPOUT_IMAGE
+      (place K1 1000 2000 front 0)
+    )
+  )
+  (library
+    (image KEEPOUT_IMAGE
+      (keepout "mounting hole" (circle Top 1000 200 -300))
+      (keepout "inner keepout" (circle Route2 600))
+    )
+  )
+  (network)
+  (wiring)
+)
+`
+
+test("converts DSN image circle keepouts into placed pcb_keepout elements", () => {
+  const dsnJson = parseDsnToDsnJson(dsnWithImageKeepouts) as DsnPcb
+  expect(dsnJson.library.images[0].keepouts).toHaveLength(2)
+
+  const circuitJson = parseDsnToCircuitJson(dsnWithImageKeepouts)
+  const keepouts = circuitJson.filter(
+    (element) => element.type === "pcb_keepout",
+  ) as any[]
+
+  expect(keepouts).toHaveLength(2)
+  expect(keepouts[0]).toMatchObject({
+    type: "pcb_keepout",
+    pcb_keepout_id: "pcb_keepout_KEEPOUT_IMAGE_K1_0",
+    shape: "circle",
+    center: { x: 1.2, y: 1.7 },
+    radius: 0.5,
+    layers: ["top"],
+    description: "mounting hole",
+  })
+  expect(keepouts[1]).toMatchObject({
+    center: { x: 1, y: 2 },
+    radius: 0.3,
+    layers: ["inner1"],
+    description: "inner keepout",
+  })
+})
+
+test("preserves Smoothie Board library keepouts", () => {
+  const dsnJson = parseDsnToDsnJson(smoothieBoardDsn) as DsnPcb
+  const circuitJson = convertDsnPcbToCircuitJson(dsnJson)
+  const keepouts = circuitJson.filter(
+    (element) => element.type === "pcb_keepout",
+  ) as any[]
+
+  const hole0Keepouts = keepouts.filter(
+    (keepout) => keepout.center.x === 185.458 && keepout.center.y === -55.7911,
+  )
+
+  expect(keepouts.length).toBeGreaterThan(16)
+  expect(hole0Keepouts).toHaveLength(4)
+  expect(hole0Keepouts.map((keepout) => keepout.layers[0]).sort()).toEqual([
+    "bottom",
+    "inner1",
+    "inner2",
+    "top",
+  ])
+  expect(hole0Keepouts.every((keepout) => keepout.radius === 1.8)).toBe(true)
+})


### PR DESCRIPTION
/claim #54

## Summary
- Parse circular DSN `keepout` records inside library images.
- Convert placed image keepouts into Circuit JSON `pcb_keepout` elements.
- Map DSN layer names like `Top`, `Route2`, `Route15`, and `Bottom` to Circuit JSON layer names.
- Add focused coverage for a small fixture and the Smoothie Board fixture.

## Why this helps #54
The Smoothie Board DSN contains image-level circular keepouts, including board mounting holes and connector exclusion zones. Current `main` keeps image outlines and pins but silently drops `keepout` records, so valid routing exclusion geometry never reaches Circuit JSON.

## Verification
- `pnpm dlx --package bun@1.3.13 bun --config=.\bunfig.no-preload.toml test tests\dsn-pcb\dsn-image-keepouts.test.ts` (2 pass, 8 assertions; no-preload config used locally to avoid the repo's Windows `sharp` visual-test preload failure)
- `pnpm exec biome check lib\dsn-pcb\types.ts lib\dsn-pcb\dsn-json-to-circuit-json\parse-dsn-to-dsn-json.ts lib\dsn-pcb\dsn-json-to-circuit-json\convert-dsn-pcb-to-circuit-json.ts lib\dsn-pcb\dsn-json-to-circuit-json\dsn-component-converters\convert-keepouts-to-pcb-keepouts.ts tests\dsn-pcb\dsn-image-keepouts.test.ts`
- `pnpm exec tsup-node .\lib\index.ts --format esm --dts --sourcemap`
- `git diff --check`

Note: `pnpm exec tsc --noEmit` still reports existing missing `looks-same` declarations in `tests/dsn-pcb/basic-via-pcb-layer-change.test.tsx` and `tests/dsn-pcb/merge-dsn-session-with-conversion.test.tsx`, unrelated to this patch.