### PR TITLE
Map DSN Top and Bottom wire layers

### DIFF
--- a/lib/dsn-pcb/dsn-json-to-circuit-json/dsn-component-converters/convert-polyline-path-to-pcb-traces.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/dsn-component-converters/convert-polyline-path-to-pcb-traces.ts
@@ -2,6 +2,7 @@ import type { PcbTrace } from "circuit-json"
 import { chunks } from "lib/utils/chunks"
 import { computeSegIntersection } from "lib/utils/compute-seg-intersection"
 import { getTraceLength } from "lib/utils/get-trace-length"
+import { mapDsnLayerToCircuitLayer } from "lib/utils/map-dsn-layer-to-circuit-layer"
 import { type Matrix, applyToPoint } from "transformation-matrix"
 import type { Wiring } from "../../types"
 
@@ -40,7 +41,7 @@ export const convertPolylinePathToPcbTraces = ({
       width: fromSessionSpace
         ? wire.polyline_path!.width / 10000 // session space to circuit space
         : wire.polyline_path!.width / 1000, // dsn space to circuit space
-      layer: wire.polyline_path?.layer.includes("B.") ? "bottom" : "top",
+      layer: mapDsnLayerToCircuitLayer(wire.polyline_path?.layer),
     })),
     trace_length: getTraceLength(pointsOnTraceMm),
   })

--- a/lib/dsn-pcb/dsn-json-to-circuit-json/dsn-component-converters/convert-wiring-path-to-pcb-traces.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/dsn-component-converters/convert-wiring-path-to-pcb-traces.ts
@@ -7,6 +7,7 @@ import type {
 import Debug from "debug"
 import { type Matrix, applyToPoint } from "transformation-matrix"
 import { getTraceLength } from "../../../utils/get-trace-length"
+import { mapDsnLayerToCircuitLayer } from "../../../utils/map-dsn-layer-to-circuit-layer"
 import type { Wiring } from "../../types"
 
 const debug = Debug("dsn-converter:convertWiringPathToPcbTraces")
@@ -45,7 +46,7 @@ export const convertWiringPathToPcbTraces = ({
       width: fromSessionSpace
         ? wire.path!.width / 10000 // session space to circuit space
         : wire.path!.width / 1000, // dsn space to circuit space
-      layer: wire.path!.layer.includes("F.") ? "top" : "bottom",
+      layer: mapDsnLayerToCircuitLayer(wire.path!.layer),
     }))
 
     const pcbTrace: PcbTrace = {

--- a/lib/utils/map-dsn-layer-to-circuit-layer.ts
+++ b/lib/utils/map-dsn-layer-to-circuit-layer.ts
@@ -1,0 +1,24 @@
+import type { LayerRef } from "circuit-json"
+
+export function mapDsnLayerToCircuitLayer(layerName?: string): LayerRef {
+  const normalized = layerName?.trim().toLowerCase()
+
+  if (normalized === "top" || normalized === "front" || normalized === "f.cu") {
+    return "top"
+  }
+
+  if (
+    normalized === "bottom" ||
+    normalized === "back" ||
+    normalized === "b.cu"
+  ) {
+    return "bottom"
+  }
+
+  const innerLayerMatch = normalized?.match(/^in([1-6])\.cu$/)
+  if (innerLayerMatch) {
+    return `inner${innerLayerMatch[1]}` as LayerRef
+  }
+
+  return "top"
+}

--- a/lib/utils/map-dsn-layer-to-circuit-layer.ts
+++ b/lib/utils/map-dsn-layer-to-circuit-layer.ts
@@ -15,7 +15,7 @@ export function mapDsnLayerToCircuitLayer(layerName?: string): LayerRef {
     return "bottom"
   }
 
-  const innerLayerMatch = normalized?.match(/^in([1-6])\.cu$/)
+  const innerLayerMatch = normalized?.match(/^in([1-9]\d*)\.cu$/)
   if (innerLayerMatch) {
     return `inner${innerLayerMatch[1]}` as LayerRef
   }

--- a/tests/dsn-pcb/dsn-wire-layer-name-mapping.test.ts
+++ b/tests/dsn-pcb/dsn-wire-layer-name-mapping.test.ts
@@ -1,0 +1,67 @@
+import { expect, test } from "bun:test"
+import { type DsnPcb, parseDsnToDsnJson } from "lib"
+import { convertDsnJsonToCircuitJson } from "../../lib/dsn-pcb/dsn-json-to-circuit-json/convert-dsn-json-to-circuit-json.ts"
+
+test("maps DSN Top and Bottom wire layer names to circuit layers", () => {
+  const dsn = `(pcb layer-name-test
+    (parser
+      (string_quote "")
+      (space_in_quoted_tokens on)
+      (host_cad "dsn-converter-test")
+      (host_version "1")
+    )
+    (resolution um 10)
+    (unit um)
+    (structure
+      (layer Top (type signal) (property (index 0)))
+      (layer Bottom (type signal) (property (index 1)))
+      (boundary (path pcb 0 0 0 10000 0 10000 10000 0 10000 0 0))
+      (via Via[0-1]_600:300_um)
+      (rule (width 200))
+    )
+    (placement)
+    (library)
+    (network
+      (net TOP_NET (pins))
+      (net BOTTOM_NET (pins))
+      (class kicad_default TOP_NET BOTTOM_NET
+        (circuit (use_via Via[0-1]_600:300_um))
+        (rule (width 200))
+      )
+    )
+    (wiring
+      (wire
+        (path Top 200 0 0 10000 0)
+        (net TOP_NET)
+      )
+      (wire
+        (polyline_path Bottom 200
+          0 0 10000 0
+          5000 -5000 5000 5000
+        )
+        (net BOTTOM_NET)
+      )
+    )
+  )`
+
+  const dsnJson = parseDsnToDsnJson(dsn) as DsnPcb
+  const circuitJson = convertDsnJsonToCircuitJson(dsnJson)
+  const traces = circuitJson.filter((element) => element.type === "pcb_trace")
+  const topTrace = traces.find(
+    (trace) => trace.pcb_trace_id === "pcb_trace_TOP_NET",
+  )
+  const bottomTrace = traces.find(
+    (trace) => trace.pcb_trace_id === "pcb_trace_BOTTOM_NET",
+  )
+
+  expect(
+    topTrace?.route.every(
+      (point) => point.route_type === "wire" && point.layer === "top",
+    ),
+  ).toBe(true)
+  expect(
+    bottomTrace?.route.every(
+      (point) => point.route_type === "wire" && point.layer === "bottom",
+    ),
+  ).toBe(true)
+})

--- a/tests/dsn-pcb/dsn-wire-layer-name-mapping.test.ts
+++ b/tests/dsn-pcb/dsn-wire-layer-name-mapping.test.ts
@@ -2,7 +2,7 @@ import { expect, test } from "bun:test"
 import { type DsnPcb, parseDsnToDsnJson } from "lib"
 import { convertDsnJsonToCircuitJson } from "../../lib/dsn-pcb/dsn-json-to-circuit-json/convert-dsn-json-to-circuit-json.ts"
 
-test("maps DSN Top and Bottom wire layer names to circuit layers", () => {
+test("maps DSN Top, Bottom, and inner wire layer names to circuit layers", () => {
   const dsn = `(pcb layer-name-test
     (parser
       (string_quote "")
@@ -14,6 +14,7 @@ test("maps DSN Top and Bottom wire layer names to circuit layers", () => {
     (unit um)
     (structure
       (layer Top (type signal) (property (index 0)))
+      (layer In7.Cu (type signal) (property (index 7)))
       (layer Bottom (type signal) (property (index 1)))
       (boundary (path pcb 0 0 0 10000 0 10000 10000 0 10000 0 0))
       (via Via[0-1]_600:300_um)
@@ -23,8 +24,9 @@ test("maps DSN Top and Bottom wire layer names to circuit layers", () => {
     (library)
     (network
       (net TOP_NET (pins))
+      (net INNER7_NET (pins))
       (net BOTTOM_NET (pins))
-      (class kicad_default TOP_NET BOTTOM_NET
+      (class kicad_default TOP_NET INNER7_NET BOTTOM_NET
         (circuit (use_via Via[0-1]_600:300_um))
         (rule (width 200))
       )
@@ -33,6 +35,10 @@ test("maps DSN Top and Bottom wire layer names to circuit layers", () => {
       (wire
         (path Top 200 0 0 10000 0)
         (net TOP_NET)
+      )
+      (wire
+        (path In7.Cu 200 0 2000 10000 2000)
+        (net INNER7_NET)
       )
       (wire
         (polyline_path Bottom 200
@@ -53,6 +59,9 @@ test("maps DSN Top and Bottom wire layer names to circuit layers", () => {
   const bottomTrace = traces.find(
     (trace) => trace.pcb_trace_id === "pcb_trace_BOTTOM_NET",
   )
+  const inner7Trace = traces.find(
+    (trace) => trace.pcb_trace_id === "pcb_trace_INNER7_NET",
+  )
 
   expect(
     topTrace?.route.every(
@@ -62,6 +71,12 @@ test("maps DSN Top and Bottom wire layer names to circuit layers", () => {
   expect(
     bottomTrace?.route.every(
       (point) => point.route_type === "wire" && point.layer === "bottom",
+    ),
+  ).toBe(true)
+  expect(
+    inner7Trace?.route.every(
+      (point) =>
+        point.route_type === "wire" && (point.layer as string) === "inner7",
     ),
   ).toBe(true)
 })


### PR DESCRIPTION
Summary
- Add a shared helper for mapping DSN wire layer names into Circuit JSON layer refs.
- Map `Top` / `F.Cu` to `top` and `Bottom` / `B.Cu` to `bottom` for both path and polyline wire conversion.
- Add focused regression coverage for a `Top` path wire and a `Bottom` polyline wire.

Why this helps #54
DSN files can use layer names such as `Top` and `Bottom`. The direct path converter previously treated `Top` as bottom, while the polyline converter treated `Bottom` as top, so routed copper could land on the wrong Circuit JSON layer.

Verification
- bun test tests/dsn-pcb/dsn-wire-layer-name-mapping.test.ts
- bun test
- bunx biome check lib/utils/map-dsn-layer-to-circuit-layer.ts lib/dsn-pcb/dsn-json-to-circuit-json/dsn-component-converters/convert-wiring-path-to-pcb-traces.ts lib/dsn-pcb/dsn-json-to-circuit-json/dsn-component-converters/convert-polyline-path-to-pcb-traces.ts tests/dsn-pcb/dsn-wire-layer-name-mapping.test.ts
- bunx tsc --noEmit
- bun run build
- git diff --check

/claim #54

Transparency note: AI-assisted with Codex; I reviewed the diff and verified it locally before submission.