### PR TITLE
Parse DSN placements without explicit rotation

### DIFF
--- a/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
@@ -457,23 +457,26 @@ function processPlace(nodes: ASTNode[]): Places {
     throw new Error("Invalid place format: invalid refdes")
   }
 
-  // Process coordinates and rotation
+  // Process coordinates, side, and optional rotation
   const coordIndex = 2
-  if (coordIndex + 3 < nodes.length) {
+  if (coordIndex + 2 < nodes.length) {
     if (
       nodes[coordIndex].type === "Atom" &&
       typeof nodes[coordIndex].value === "number" &&
       nodes[coordIndex + 1].type === "Atom" &&
       typeof nodes[coordIndex + 1].value === "number" &&
       nodes[coordIndex + 2].type === "Atom" &&
-      typeof nodes[coordIndex + 2].value === "string" &&
-      nodes[coordIndex + 3].type === "Atom" &&
-      typeof nodes[coordIndex + 3].value === "number"
+      typeof nodes[coordIndex + 2].value === "string"
     ) {
       places.x = nodes[coordIndex].value as number
       places.y = nodes[coordIndex + 1].value as number
       places.side = nodes[coordIndex + 2].value as string
-      places.rotation = nodes[coordIndex + 3].value as number
+      if (
+        nodes[coordIndex + 3]?.type === "Atom" &&
+        typeof nodes[coordIndex + 3].value === "number"
+      ) {
+        places.rotation = nodes[coordIndex + 3].value as number
+      }
     }
   }
 

--- a/tests/repros/repro16-place-without-rotation.test.ts
+++ b/tests/repros/repro16-place-without-rotation.test.ts
@@ -1,0 +1,47 @@
+import { expect, test } from "bun:test"
+import { type DsnPcb, parseDsnToDsnJson } from "lib"
+
+test("parses DSN component placement coordinates when rotation is omitted", () => {
+  const dsn = `
+    (pcb rotationless-placement
+      (parser
+        (string_quote ")
+        (space_in_quoted_tokens on)
+        (host_cad "fixture")
+        (host_version "1")
+      )
+      (resolution um 10)
+      (structure
+        (layer F.Cu (type signal))
+        (layer B.Cu (type signal))
+        (boundary (path pcb 0 0 0 10000 0 10000 10000 0 10000 0 0))
+      )
+      (placement
+        (component R_0603
+          (place R1 1234 -5678 front)
+        )
+      )
+      (library
+        (image R_0603
+          (pin Round[T]Pad_1000_1000_um 1 0 0)
+        )
+        (padstack Round[T]Pad_1000_1000_um
+          (shape (circle F.Cu 1000))
+          (attach off)
+        )
+      )
+      (network
+        (net N1 (pins R1-1))
+      )
+      (wiring)
+    )
+  `
+
+  const parsed = parseDsnToDsnJson(dsn) as DsnPcb
+  const place = parsed.placement.components[0].places[0]
+
+  expect(place.x).toBe(1234)
+  expect(place.y).toBe(-5678)
+  expect(place.side).toBe("front")
+  expect(place.rotation).toBe(0)
+})


### PR DESCRIPTION
## Summary

- Parse DSN `(place ref x y side)` coordinates even when the optional rotation token is omitted.
- Keep the existing `rotation: 0` default for rotationless placements.
- Add a focused regression test for this parser case.

## Verification

- `./node_modules/.bin/biome format --write lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts tests/repros/repro16-place-without-rotation.test.ts`
- `./node_modules/.bin/biome format lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts tests/repros/repro16-place-without-rotation.test.ts`
- `./node_modules/.bin/tsc --noEmit`
- `./node_modules/.bin/tsup-node ./lib/index.ts --format esm --dts --sourcemap`
- `git diff --check`

Not run: `bun test tests/repros/repro16-place-without-rotation.test.ts` because `bun` is not installed in this environment.

/claim #54