### PR TITLE
Preserve DSN session route metadata

### DIFF
--- a/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
@@ -1073,6 +1073,31 @@ function processSessionNode(ast: ASTNode): DsnSession {
       child.children[0].value === "routes",
   )
   if (routesNode) {
+    const routesResolutionNode = routesNode.children!.find(
+      (child) =>
+        child.type === "List" &&
+        child.children?.[0].type === "Atom" &&
+        child.children[0].value === "resolution",
+    )
+    if (routesResolutionNode) {
+      session.routes.resolution = processResolution(
+        routesResolutionNode.children!,
+      )
+    }
+
+    const routesParserNode = routesNode.children!.find(
+      (child) =>
+        child.type === "List" &&
+        child.children?.[0].type === "Atom" &&
+        child.children[0].value === "parser",
+    )
+    if (routesParserNode) {
+      session.routes.parser = {
+        ...session.routes.parser,
+        ...processParser(routesParserNode.children!.slice(1)),
+      }
+    }
+
     // Extract library_out section
     const libraryNode = routesNode.children!.find(
       (child) =>

--- a/tests/dsn-pcb/parse-session-file.test.ts
+++ b/tests/dsn-pcb/parse-session-file.test.ts
@@ -60,3 +60,24 @@ test("parse session file", () => {
   expect(firstPadstack?.shapes[0].layer).toBe("F.Cu")
   expect((firstPadstack?.shapes[0] as any).diameter).toBe(6000)
 })
+
+test("parse session routes resolution and parser metadata", () => {
+  const sessionJson = parseDsnToDsnJson(`(session custom
+  (base_design custom)
+  (placement
+    (resolution um 10)
+  )
+  (routes
+    (resolution mm 1000)
+    (parser
+      (host_cad "Freerouting")
+      (host_version "1.9.0")
+    )
+    (network_out)
+  )
+)`) as DsnSession
+
+  expect(sessionJson.routes.resolution).toEqual({ unit: "mm", value: 1000 })
+  expect(sessionJson.routes.parser.host_cad).toBe("Freerouting")
+  expect(sessionJson.routes.parser.host_version).toBe("1.9.0")
+})


### PR DESCRIPTION
/claim #54

## Summary
- Parse the `routes` section resolution from DSN session files instead of leaving it at the default.
- Parse the `routes` parser metadata (`host_cad`, `host_version`, etc.) while retaining defaults for omitted fields.
- Add focused regression coverage for non-default route resolution/parser metadata.

## Tests
- `npx --yes bun test tests/dsn-pcb/parse-session-file.test.ts`
- `npx --yes bun run build`
- `git diff --check`