### PR TITLE
Resume session routes after explicit vias

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/process-pcb-traces/index.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/process-pcb-traces/index.ts
@@ -85,6 +85,8 @@ export function processPcbTraces(
 
       let currentLayer = ""
       let currentWire: Wire | null = null
+      let pendingWireStart: { x: number; y: number; layer: LayerRef } | null =
+        null
 
       // Process each point in the route
       for (let i = 0; i < pcbTrace.route.length; i++) {
@@ -106,6 +108,16 @@ export function processPcbTraces(
 
             dsnWrapper.addWire(currentWire)
             currentLayer = point.layer
+
+            if (pendingWireStart) {
+              if (pendingWireStart.layer === point.layer) {
+                currentWire.path.coordinates.push(
+                  pendingWireStart.x * CJ_TO_DSN_SCALE,
+                  pendingWireStart.y * CJ_TO_DSN_SCALE,
+                )
+              }
+              pendingWireStart = null
+            }
           }
 
           if (currentWire && !hasLayerChanged) {
@@ -186,6 +198,11 @@ export function processPcbTraces(
           })
 
           currentLayer = point.to_layer
+          pendingWireStart = {
+            x: point.x,
+            y: point.y,
+            layer: point.to_layer,
+          }
           currentWire = null // Start fresh wire after via
         }
       }

--- a/tests/dsn-pcb/convert-circuit-json-to-dsn-session.unit.test.ts
+++ b/tests/dsn-pcb/convert-circuit-json-to-dsn-session.unit.test.ts
@@ -132,7 +132,7 @@ test("converts component placement", () => {
   )
 })
 
-test("4-layer session via padstack spans all layers", () => {
+test("4-layer session via padstack spans all layers and resumes route after via", () => {
   const dsnPcb: DsnPcb = {
     is_dsn_pcb: true,
     filename: "test.dsn",
@@ -199,6 +199,14 @@ test("4-layer session via padstack spans all layers", () => {
     "In2.Cu",
     "B.Cu",
   ])
+
+  const net = session.routes.network_out.nets[0]
+  expect(net.wires).toHaveLength(3)
+  expect(net.wires[2].path).toEqual({
+    layer: "B.Cu",
+    width: 2000,
+    coordinates: [10000, 10000, 20000, 20000],
+  })
 })
 
 // Test net and wire conversion


### PR DESCRIPTION
Summary
- Resume the destination-layer DSN session route from the explicit via coordinate instead of starting at the next wire point.
- Add regression coverage proving the bottom-layer route keeps the via-to-next-point segment.
- Keep this distinct from implicit layer-change export and session-via import/linkage fixes.

Root cause
When processPcbTraces hit an explicit route_type=via, it closed the current wire at the via and set currentWire to null. The next destination-layer wire then started at the following wire point, so the segment from the via coordinate to that point was dropped from the DSN session export.

Verification
- bun test tests/dsn-pcb/convert-circuit-json-to-dsn-session.unit.test.ts
- bunx biome check lib/dsn-pcb/circuit-json-to-dsn-json/process-pcb-traces/index.ts tests/dsn-pcb/convert-circuit-json-to-dsn-session.unit.test.ts
- bunx tsc --noEmit
- bun test
- bun run build
- git diff --check

/claim #54