### PR TITLE
Fix parsing DSN classes without descriptions

### DIFF
--- a/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
@@ -798,6 +798,8 @@ export function processNetwork(nodes: ASTNode[]): Network {
     nets: [],
     classes: [],
   }
+  const netNodes: ASTNode[] = []
+  const classNodes: ASTNode[] = []
 
   nodes.forEach((node) => {
     if (node.type === "List") {
@@ -805,18 +807,23 @@ export function processNetwork(nodes: ASTNode[]): Network {
       if (keyNode.type === "Atom" && typeof keyNode.value === "string") {
         const key = keyNode.value
         if (key === "net") {
-          network.nets!.push(processNet(node.children!))
+          netNodes.push(node)
         } else if (key === "class") {
-          network.classes!.push(
-            processClass(
-              node.children!,
-              network.nets!.map((net) => net.name),
-            ),
-          )
+          classNodes.push(node)
         }
       }
     }
   })
+
+  netNodes.forEach((node) => {
+    network.nets!.push(processNet(node.children!))
+  })
+
+  const knownNetNames = network.nets!.map((net) => net.name)
+  classNodes.forEach((node) => {
+    network.classes!.push(processClass(node.children!, knownNetNames))
+  })
+
   return network as Network
 }
 

--- a/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
@@ -807,7 +807,12 @@ export function processNetwork(nodes: ASTNode[]): Network {
         if (key === "net") {
           network.nets!.push(processNet(node.children!))
         } else if (key === "class") {
-          network.classes!.push(processClass(node.children!))
+          network.classes!.push(
+            processClass(
+              node.children!,
+              network.nets!.map((net) => net.name),
+            ),
+          )
         }
       }
     }
@@ -842,20 +847,27 @@ function processNet(nodes: ASTNode[]): Net {
   return net as Net
 }
 
-function processClass(nodes: ASTNode[]): Class {
+function processClass(nodes: ASTNode[], knownNetNames: string[] = []): Class {
   const classObj: Partial<Class> = {}
-  if (
-    nodes[1].type === "Atom" &&
-    typeof nodes[1].value === "string" &&
-    nodes[2].type === "Atom" &&
-    typeof nodes[2].value === "string"
-  ) {
+  if (nodes[1].type === "Atom" && typeof nodes[1].value === "string") {
     classObj.name = nodes[1].value
-    classObj.description = nodes[2].value
+  }
+
+  const knownNetNameSet = new Set(knownNetNames)
+  let i = 2
+  const maybeDescriptionNode = nodes[i]
+  if (
+    maybeDescriptionNode?.type === "Atom" &&
+    typeof maybeDescriptionNode.value === "string" &&
+    !knownNetNameSet.has(maybeDescriptionNode.value)
+  ) {
+    classObj.description = maybeDescriptionNode.value
+    i++
+  } else {
+    classObj.description = ""
   }
 
   // The next nodes until 'circuit' are net names
-  let i = 3
   classObj.net_names = []
   while (
     i < nodes.length &&

--- a/tests/dsn-pcb/parse-dsn-json-to-circuit-json.test.ts
+++ b/tests/dsn-pcb/parse-dsn-json-to-circuit-json.test.ts
@@ -38,3 +38,16 @@ test("parse network classes without descriptions", async () => {
   expect(pcb.network.classes[1].description).toBe("")
   expect(pcb.network.classes[1].net_names[0]).toBe("Net-(R1-Pad1)")
 })
+
+test("parse descriptionless network classes before net declarations", async () => {
+  const pcb = parseDsnToDsnJson(`(pcb test
+    (network
+      (class kicad_default N1 (rule (width 1)))
+      (net N1 (pins U1-1))
+    )
+  )`) as DsnPcb
+
+  expect(pcb.network.classes[0].name).toBe("kicad_default")
+  expect(pcb.network.classes[0].description).toBe("")
+  expect(pcb.network.classes[0].net_names).toEqual(["N1"])
+})

--- a/tests/dsn-pcb/parse-dsn-json-to-circuit-json.test.ts
+++ b/tests/dsn-pcb/parse-dsn-json-to-circuit-json.test.ts
@@ -4,6 +4,10 @@ import { convertCircuitJsonToPcbSvg } from "circuit-to-svg"
 import { type DsnPcb, parseDsnToDsnJson } from "lib"
 import { convertDsnJsonToCircuitJson } from "../../lib/dsn-pcb/dsn-json-to-circuit-json/convert-dsn-json-to-circuit-json.ts"
 // @ts-ignore
+import freeroutingDsnFile from "../assets/testkicadproject/freeroutingTraceAdded-2.dsn" with {
+  type: "text",
+}
+// @ts-ignore
 import testDsnFile from "../assets/testkicadproject/testkicadproject.dsn" with {
   type: "text",
 }
@@ -22,4 +26,15 @@ test("parse json to circuit json", async () => {
   expect(convertCircuitJsonToPcbSvg(circuitJson)).toMatchSvgSnapshot(
     import.meta.path,
   )
+})
+
+test("parse network classes without descriptions", async () => {
+  const pcb = parseDsnToDsnJson(freeroutingDsnFile) as DsnPcb
+
+  expect(pcb.network.classes[0].name).toBe("default")
+  expect(pcb.network.classes[0].description).toBe("")
+
+  expect(pcb.network.classes[1].name).toBe("kicad_default")
+  expect(pcb.network.classes[1].description).toBe("")
+  expect(pcb.network.classes[1].net_names[0]).toBe("Net-(R1-Pad1)")
 })


### PR DESCRIPTION
/claim #54

## Summary
- Parse DSN class names even when the class omits the optional description field.
- Use the already parsed net names to tell the difference between an omitted description and the first net name.
- Add a regression check using a Freerouting DSN fixture that has descriptionless `default` and `kicad_default` classes.

## Verification
- `bun test tests/dsn-pcb/parse-dsn-json-to-circuit-json.test.ts`
- `bun x biome check lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts tests/dsn-pcb/parse-dsn-json-to-circuit-json.test.ts`
- `bun x tsc --noEmit`
- `bun run build`
- `bun test` still has 3 pre-existing failures on `origin/main` too: two Windows `debug-files` path mkdir errors and `stringify-dsn-json.test.ts` parser round-trip mismatch.