### PR TITLE
Preserve vias when stringifying DSN sessions

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-session.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-session.ts
@@ -3,6 +3,8 @@ import type { DsnSession } from "../types"
 export const stringifyDsnSession = (session: DsnSession): string => {
   const indent = "  "
   let result = ""
+  const defaultViaPadstackName =
+    session.routes.library_out?.padstacks[0]?.name ?? "Via[0-1]_600:300_um"
 
   // Start with session
   result += `(session ${session.filename}\n`
@@ -58,6 +60,12 @@ export const stringifyDsnSession = (session: DsnSession): string => {
   session.routes.network_out.nets.forEach((net) => {
     result += `${indent}${indent}${indent}(net ${JSON.stringify(net.name)}\n`
     net.wires.forEach((wire) => {
+      if (wire.type === "via" && wire.path) {
+        const [x, y] = wire.path.coordinates
+        result += `${indent}${indent}${indent}${indent}(via ${JSON.stringify(defaultViaPadstackName)} ${x} ${y})\n`
+        return
+      }
+
       if (wire.path) {
         result += `${indent}${indent}${indent}${indent}(wire\n`
         result += `${indent}${indent}${indent}${indent}${indent}(path ${wire.path.layer} ${wire.path.width}\n`
@@ -65,6 +73,9 @@ export const stringifyDsnSession = (session: DsnSession): string => {
         result += `${indent}${indent}${indent}${indent}${indent})\n`
         result += `${indent}${indent}${indent}${indent})\n`
       }
+    })
+    net.vias?.forEach((via) => {
+      result += `${indent}${indent}${indent}${indent}(via ${JSON.stringify(defaultViaPadstackName)} ${via.x} ${via.y})\n`
     })
     result += `${indent}${indent}${indent})\n`
   })

--- a/tests/dsn-pcb/stringify-dsn-session.test.ts
+++ b/tests/dsn-pcb/stringify-dsn-session.test.ts
@@ -25,3 +25,73 @@ test("stringify session file", () => {
   expect(reparsedNet.name).toBe(originalNet.name)
   expect(reparsedNet.wires).toHaveLength(originalNet.wires.length)
 })
+
+test("stringifies session vias as via records", () => {
+  const sessionJson: DsnSession = {
+    is_dsn_session: true,
+    filename: "via-session",
+    placement: {
+      resolution: { unit: "um", value: 10 },
+      components: [],
+    },
+    routes: {
+      resolution: { unit: "um", value: 10 },
+      parser: {
+        string_quote: '"',
+        space_in_quoted_tokens: "on",
+        host_cad: "test",
+        host_version: "1",
+      },
+      library_out: {
+        images: [],
+        padstacks: [
+          {
+            name: "Via[0-1]_600:300_um",
+            shapes: [],
+            attach: "off",
+          },
+        ],
+      },
+      network_out: {
+        nets: [
+          {
+            name: "Net-(R1-Pad1)",
+            wires: [
+              {
+                path: {
+                  layer: "F.Cu",
+                  width: 2000,
+                  coordinates: [0, 0, 10000, 0],
+                },
+                net: "Net-(R1-Pad1)",
+                type: "route",
+              },
+              {
+                path: {
+                  layer: "F.Cu",
+                  width: 600,
+                  coordinates: [10000, 0],
+                },
+                net: "Net-(R1-Pad1)",
+                type: "via",
+              },
+            ],
+            vias: [{ x: 20000, y: 0 }],
+          },
+        ],
+      },
+    },
+  }
+
+  const stringified = stringifyDsnSession(sessionJson)
+  expect(stringified).toContain('(via "Via[0-1]_600:300_um" 10000 0)')
+  expect(stringified).toContain('(via "Via[0-1]_600:300_um" 20000 0)')
+
+  const reparsed = parseDsnToDsnJson(stringified) as DsnSession
+  const reparsedNet = reparsed.routes.network_out.nets[0]
+  expect(reparsedNet.wires).toHaveLength(1)
+  expect(reparsedNet.vias).toEqual([
+    { x: 10000, y: 0 },
+    { x: 20000, y: 0 },
+  ])
+})


### PR DESCRIPTION
Summary
- Emit DSN session via records when stringifying parsed `net.vias`.
- Emit session wire entries marked `type: "via"` as `(via "Padstack" x y)` instead of a one-point wire path.
- Add roundtrip regression coverage proving vias survive stringify + parse.

Root cause
`stringifyDsnSession` only wrote `net.wires`, so parsed session vias were dropped on stringify. It also treated session wire entries with `type: "via"` as normal wires, which produced a single-point wire instead of a DSN via record.

Why this is distinct
This is separate from session-via import dimensions/linkage and explicit-via route continuation. It only fixes the session text serialization path.

Verification
- bun test tests/dsn-pcb/stringify-dsn-session.test.ts
- bunx biome check lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-session.ts tests/dsn-pcb/stringify-dsn-session.test.ts
- bunx tsc --noEmit
- bun test
- bun run build
- git diff --check

/claim #54