### PR TITLE
Preserve rect padstack shapes when stringifying DSN JSON

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
@@ -97,6 +97,8 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
         result += `${indent}${indent}${indent}(shape (polygon ${shape.layer} ${shape.width} ${stringifyCoordinates(shape.coordinates)}))\n`
       } else if (shape.shapeType === "circle") {
         result += `${indent}${indent}${indent}(shape (circle ${shape.layer} ${shape.diameter}))\n`
+      } else if (shape.shapeType === "rect") {
+        result += `${indent}${indent}${indent}(shape (rect ${shape.layer} ${stringifyCoordinates(shape.coordinates)}))\n`
       } else if (shape.shapeType === "path") {
         result += `${indent}${indent}${indent}(shape (path ${shape.layer} ${shape.width} ${stringifyCoordinates(shape.coordinates)}))\n`
       }

--- a/tests/dsn-pcb/stringify-dsn-json.test.ts
+++ b/tests/dsn-pcb/stringify-dsn-json.test.ts
@@ -17,3 +17,66 @@ test("stringify dsn json", () => {
   // Test that we can parse the generated string back to the same structure
   // expect(reparsedJson).toEqual(dsnJson)
 })
+
+test("stringify dsn json preserves rectangular padstack shapes", () => {
+  const dsnWithRectPadstack = `(pcb rect-padstack-test
+  (parser
+    (string_quote ")
+    (space_in_quoted_tokens on)
+    (host_cad "KiCad's Pcbnew")
+    (host_version "test")
+  )
+  (resolution um 10)
+  (unit um)
+  (structure
+    (layer F.Cu
+      (type signal)
+      (property
+        (index 0)
+      )
+    )
+    (layer B.Cu
+      (type signal)
+      (property
+        (index 1)
+      )
+    )
+    (boundary
+      (path pcb 0 0 0 1000 0 1000 1000 0 1000 0 0)
+    )
+    (via "Via[0-1]_600:300_um")
+    (rule
+      (width 200)
+      (clearance 150)
+    )
+  )
+  (placement)
+  (library
+    (padstack RectPad
+      (shape (rect F.Cu -500 -250 500 250))
+      (attach off)
+    )
+  )
+  (network
+    (class kicad_default ""
+      (circuit
+        (use_via "Via[0-1]_600:300_um")
+      )
+      (rule
+        (width 150)
+        (clearance 150)
+      )
+    )
+  )
+  (wiring)
+)`
+
+  const dsnJson = parseDsnToDsnJson(dsnWithRectPadstack) as DsnPcb
+  const dsnString = stringifyDsnJson(dsnJson)
+  const reparsedJson = parseDsnToDsnJson(dsnString) as DsnPcb
+
+  expect(dsnString).toContain("(shape (rect F.Cu -500 -250 500 250))")
+  expect(reparsedJson.library.padstacks[0].shapes[0]).toEqual(
+    dsnJson.library.padstacks[0].shapes[0],
+  )
+})


### PR DESCRIPTION
## Summary

/claim #54

This fixes a narrow DSN JSON round-trip gap: `parseDsnToDsnJson` already parses padstack `(shape (rect ...))` entries into `RectShape`, but `stringifyDsnJson` only wrote `polygon`, `circle`, and `path` padstack shapes. A parsed DSN containing rectangular padstack geometry could therefore stringify back with the rectangular shape silently omitted.

Changes:
- Add `rect` padstack shape serialization to `stringifyDsnJson`
- Add a regression test that parses a DSN with a rectangular padstack, stringifies it, reparses it, and verifies the shape survives

## Verification

- `bun test tests/dsn-pcb/stringify-dsn-json.test.ts`
- `bun test`
- `bunx --bun biome format lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts tests/dsn-pcb/stringify-dsn-json.test.ts`
- `git diff --check`
- `bun run build`

Note: repo-wide `bun run format:check` currently fails on pre-existing `debug-files/...` JSON artifacts outside this diff. The two touched files pass Biome formatting directly.
