### PR TITLE
Use board via for trace width classes

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/process-nets.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/process-nets.ts
@@ -2,7 +2,11 @@ import { su } from "@tscircuit/soup-util"
 import type { AnyCircuitElement, SourceTrace } from "circuit-json"
 import type { DsnPcb } from "../types"
 
-export function processNets(circuitElements: AnyCircuitElement[], pcb: DsnPcb) {
+export function processNets(
+  circuitElements: AnyCircuitElement[],
+  pcb: DsnPcb,
+  defaultViaName = pcb.structure.via || "Via[0-1]_600:300_um",
+) {
   const componentNameMap = new Map<string, string>()
 
   for (const element of circuitElements) {
@@ -208,7 +212,7 @@ export function processNets(circuitElements: AnyCircuitElement[], pcb: DsnPcb) {
         description: `Trace width ${traceWidth}μm`,
         net_names: [],
         circuit: {
-          use_via: "Via[0-1]_600:300_um",
+          use_via: defaultViaName,
         },
         rule: {
           clearances: [

--- a/tests/dsn-pcb/multi-layer-support.test.ts
+++ b/tests/dsn-pcb/multi-layer-support.test.ts
@@ -1,6 +1,8 @@
 import { expect, test } from "bun:test"
 import type { AnyCircuitElement } from "circuit-json"
 import { convertCircuitJsonToDsnJson } from "../../lib/dsn-pcb/circuit-json-to-dsn-json/convert-circuit-json-to-dsn-json"
+import { processNets } from "../../lib/dsn-pcb/circuit-json-to-dsn-json/process-nets"
+import type { DsnPcb } from "../../lib/dsn-pcb/types"
 
 test("multi-layer support - 2 layers (default)", () => {
   const circuitElements: AnyCircuitElement[] = [
@@ -113,6 +115,107 @@ test("multi-layer support - 4 layer via padstack spans all layers", () => {
 
   // Net class should reference the same via
   expect(dsnJson.network.classes[0].circuit.use_via).toBe("Via[0-3]_600:300_um")
+})
+
+test("multi-layer support - custom trace width classes use board via padstack", () => {
+  const pcb: DsnPcb = {
+    is_dsn_pcb: true,
+    filename: "test.dsn",
+    parser: {
+      string_quote: "",
+      host_version: "",
+      space_in_quoted_tokens: "",
+      host_cad: "",
+    },
+    resolution: { unit: "um", value: 10 },
+    unit: "um",
+    structure: {
+      layers: [
+        { name: "F.Cu", type: "signal", property: { index: 0 } },
+        { name: "In1.Cu", type: "signal", property: { index: 1 } },
+        { name: "In2.Cu", type: "signal", property: { index: 2 } },
+        { name: "B.Cu", type: "signal", property: { index: 3 } },
+      ],
+      boundary: { path: { layer: "pcb", width: 0, coordinates: [] } },
+      via: "Via[0-3]_600:300_um",
+      rule: { width: 0, clearances: [] },
+    },
+    placement: { components: [] },
+    library: { images: [], padstacks: [] },
+    network: {
+      nets: [],
+      classes: [
+        {
+          name: "kicad_default",
+          description: "",
+          net_names: [],
+          circuit: { use_via: "Via[0-3]_600:300_um" },
+          rule: { width: 150, clearances: [{ value: 150 }] },
+        },
+      ],
+    },
+    wiring: { wires: [] },
+  }
+
+  const circuitElements: AnyCircuitElement[] = [
+    {
+      type: "source_component",
+      source_component_id: "source_component_1",
+      name: "R1",
+    } as any,
+    {
+      type: "source_component",
+      source_component_id: "source_component_2",
+      name: "C1",
+    } as any,
+    {
+      type: "source_port",
+      source_port_id: "source_port_1",
+      source_component_id: "source_component_1",
+      port_hints: ["1"],
+    } as any,
+    {
+      type: "source_port",
+      source_port_id: "source_port_2",
+      source_component_id: "source_component_2",
+      port_hints: ["1"],
+    } as any,
+    {
+      type: "pcb_port",
+      pcb_port_id: "pcb_port_1",
+      source_port_id: "source_port_1",
+    } as any,
+    {
+      type: "pcb_port",
+      pcb_port_id: "pcb_port_2",
+      source_port_id: "source_port_2",
+    } as any,
+    {
+      type: "pcb_smtpad",
+      pcb_smtpad_id: "pad1",
+      pcb_port_id: "pcb_port_1",
+    } as any,
+    {
+      type: "pcb_smtpad",
+      pcb_smtpad_id: "pad2",
+      pcb_port_id: "pcb_port_2",
+    } as any,
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_1",
+      connected_source_net_ids: [],
+      connected_source_port_ids: ["source_port_1", "source_port_2"],
+      min_trace_thickness: 0.3,
+    } as any,
+  ]
+
+  processNets(circuitElements, pcb)
+
+  const customTraceClass = pcb.network.classes.find(
+    (cls) => cls.name === "trace_width_300um",
+  )
+  expect(customTraceClass).toBeDefined()
+  expect(customTraceClass!.circuit.use_via).toBe("Via[0-3]_600:300_um")
 })
 
 test("multi-layer support - 2 layer via padstack has F.Cu and B.Cu", () => {


### PR DESCRIPTION
Summary
- Pass the board default via padstack through `processNets`.
- Use that via padstack for generated custom trace-width classes instead of hard-coding the 2-layer via name.
- Add regression coverage for a 4-layer board with a custom trace-width source trace.

Root cause
The default net class already uses the board-specific via name, but custom trace-width classes created inside `processNets` still hard-coded `Via[0-1]_600:300_um`. On 4-layer or higher boards that makes those classes reference a via padstack that does not match the exported board layer count.

Verification
- bun test tests/dsn-pcb/multi-layer-support.test.ts
- bunx biome check lib/dsn-pcb/circuit-json-to-dsn-json/process-nets.ts tests/dsn-pcb/multi-layer-support.test.ts
- bunx tsc --noEmit
- bun test
- bun run build
- git diff --check

/claim #54