### PR TITLE
Preserve DSN class use_layer constraints

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
@@ -118,7 +118,12 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
   dsnJson.network.classes.forEach((cls) => {
     result += `${indent}${indent}(class ${stringifyValue(cls.name)} ${stringifyValue(cls.description)}${cls.net_names.map((n) => ` ${stringifyValue(n)}`).join("")}\n`
     result += `${indent}${indent}${indent}(circuit\n`
-    result += `${indent}${indent}${indent}${indent}(use_via ${stringifyValue(cls.circuit.use_via)})\n`
+    if (cls.circuit.use_via) {
+      result += `${indent}${indent}${indent}${indent}(use_via ${stringifyValue(cls.circuit.use_via)})\n`
+    }
+    if (cls.circuit.use_layer?.length) {
+      result += `${indent}${indent}${indent}${indent}(use_layer ${cls.circuit.use_layer.join(" ")})\n`
+    }
     result += `${indent}${indent}${indent})\n`
     if (cls.rule) {
       result += `${indent}${indent}${indent}(rule\n`

--- a/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
@@ -901,6 +901,18 @@ function processCircuit(nodes: ASTNode[]): Circuit {
       ) {
         circuit.use_via = node.children![1].value
       }
+    } else if (
+      node.type === "List" &&
+      node.children![0].type === "Atom" &&
+      node.children![0].value === "use_layer"
+    ) {
+      circuit.use_layer = node
+        .children!.slice(1)
+        .filter(
+          (child): child is ASTNode & { value: string } =>
+            child.type === "Atom" && typeof child.value === "string",
+        )
+        .map((child) => child.value)
     }
   })
   return circuit as Circuit

--- a/lib/dsn-pcb/types.ts
+++ b/lib/dsn-pcb/types.ts
@@ -57,6 +57,7 @@ export interface DsnPcb {
       net_names: string[]
       circuit: {
         use_via: string
+        use_layer?: string[]
       }
       rule: {
         clearances: Array<{
@@ -261,7 +262,8 @@ export interface Class {
 }
 
 export interface Circuit {
-  use_via: string
+  use_via?: string
+  use_layer?: string[]
 }
 
 export interface Wiring {

--- a/tests/dsn-pcb/stringify-dsn-json.test.ts
+++ b/tests/dsn-pcb/stringify-dsn-json.test.ts
@@ -17,3 +17,23 @@ test("stringify dsn json", () => {
   // Test that we can parse the generated string back to the same structure
   // expect(reparsedJson).toEqual(dsnJson)
 })
+
+test("preserves network class use_layer constraints", () => {
+  const dsnWithUseLayer = testDsnFile.replace(
+    "(use_via Via[0-1]_600:300_um)",
+    "(use_layer F.Cu B.Cu)\n        (use_via Via[0-1]_600:300_um)",
+  )
+  const dsnJson = parseDsnToDsnJson(dsnWithUseLayer) as DsnPcb
+
+  expect(dsnJson.network.classes.map((cls) => cls.circuit.use_layer)).toEqual([
+    ["F.Cu", "B.Cu"],
+  ])
+
+  const dsnString = stringifyDsnJson(dsnJson)
+  expect(dsnString).toContain("(use_layer F.Cu B.Cu)")
+
+  const reparsedJson = parseDsnToDsnJson(dsnString) as DsnPcb
+  expect(
+    reparsedJson.network.classes.map((cls) => cls.circuit.use_layer),
+  ).toEqual([["F.Cu", "B.Cu"]])
+})


### PR DESCRIPTION
## Summary
- parse `(use_layer ...)` entries inside network class `circuit` blocks
- add `use_layer` to the DSN circuit type and preserve it when stringifying DSN JSON
- cover parse/stringify/reparse behavior with a regression test

## Tests
- `npx --yes bun test tests/dsn-pcb/stringify-dsn-json.test.ts`
- `npx --yes bun run build`
- `git diff --check`

/claim #54