### PR TITLE
Scale session placements when merging

### DIFF
--- a/lib/dsn-pcb/dsn-json-to-circuit-json/merge-dsn-session-into-dsn-pcb.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/merge-dsn-session-into-dsn-pcb.ts
@@ -1,7 +1,61 @@
 import Debug from "debug"
-import type { DsnPcb, DsnSession } from "../types"
+import type { ComponentPlacement, DsnPcb, DsnSession } from "../types"
 
 const debug = Debug("dsn-converter:mergeDsnSessionIntoDsnPcb")
+
+const coordinatesMatch = (a: number, b: number) => Math.abs(a - b) < 1e-6
+
+const shouldScaleSessionPlacement = (
+  dsnPcb: DsnPcb,
+  dsnSession: DsnSession,
+) => {
+  const existingPlaces = new Map<string, { x: number; y: number }>()
+
+  dsnPcb.placement.components.forEach((component) => {
+    component.places.forEach((place) => {
+      existingPlaces.set(`${component.name}:${place.refdes}`, {
+        x: place.x,
+        y: place.y,
+      })
+    })
+  })
+
+  let scaledMatches = 0
+  let unscaledMatches = 0
+
+  dsnSession.placement.components.forEach((component) => {
+    component.places.forEach((place) => {
+      const existingPlace = existingPlaces.get(
+        `${component.name}:${place.refdes}`,
+      )
+      if (!existingPlace) return
+
+      for (const axis of ["x", "y"] as const) {
+        if (coordinatesMatch(place[axis], existingPlace[axis])) {
+          unscaledMatches++
+        }
+        if (coordinatesMatch(place[axis] / 10, existingPlace[axis])) {
+          scaledMatches++
+        }
+      }
+    })
+  })
+
+  return scaledMatches > unscaledMatches
+}
+
+const scalePlacementComponents = (
+  components: ComponentPlacement[],
+  coordinateDivisor: number,
+): ComponentPlacement[] =>
+  components.map((component) => ({
+    ...component,
+    places: component.places.map((place) => ({
+      ...place,
+      x: place.x / coordinateDivisor,
+      y: place.y / coordinateDivisor,
+    })),
+  }))
 
 export function mergeDsnSessionIntoDsnPcb(
   dsnPcb: DsnPcb,
@@ -12,7 +66,14 @@ export function mergeDsnSessionIntoDsnPcb(
 
   // Update placement if session has different component positions
   if (dsnSession.placement?.components) {
-    mergedPcb.placement.components = dsnSession.placement.components
+    const coordinateDivisor = shouldScaleSessionPlacement(dsnPcb, dsnSession)
+      ? 10
+      : 1
+
+    mergedPcb.placement.components = scalePlacementComponents(
+      dsnSession.placement.components,
+      coordinateDivisor,
+    )
   }
 
   // Add wires from session's network_out to PCB's wiring

--- a/tests/dsn-pcb/merge-dsn-session-placement-scaling.test.ts
+++ b/tests/dsn-pcb/merge-dsn-session-placement-scaling.test.ts
@@ -1,0 +1,123 @@
+import { expect, test } from "bun:test"
+import type { DsnPcb, DsnSession } from "lib"
+import { mergeDsnSessionIntoDsnPcb } from "lib"
+
+test("scales session placements when merging into a DSN PCB", () => {
+  const dsnPcb: DsnPcb = {
+    is_dsn_pcb: true,
+    filename: "board.dsn",
+    parser: {
+      string_quote: '"',
+      host_version: "test",
+      space_in_quoted_tokens: "on",
+      host_cad: "test",
+    },
+    resolution: { unit: "um", value: 10 },
+    unit: "um",
+    structure: {
+      layers: [],
+      boundary: {
+        path: { layer: "pcb", width: 0, coordinates: [] },
+      },
+      via: "Via[0-1]_600:300_um",
+      rule: {
+        clearances: [],
+        width: 200,
+      },
+    },
+    placement: {
+      components: [
+        {
+          name: "R_0402",
+          places: [
+            {
+              refdes: "R1",
+              x: 3000,
+              y: -1000,
+              side: "front",
+              rotation: 0,
+              PN: "1k",
+            },
+          ],
+        },
+      ],
+    },
+    library: {
+      images: [],
+      padstacks: [],
+    },
+    network: {
+      nets: [],
+      classes: [],
+    },
+    wiring: {
+      wires: [
+        {
+          path: { layer: "F.Cu", width: 200, coordinates: [0, 0, 1000, 0] },
+          net: "OLD",
+          type: "route",
+        },
+      ],
+    },
+  }
+
+  const session: DsnSession = {
+    is_dsn_session: true,
+    filename: "board.ses",
+    placement: {
+      resolution: { unit: "um", value: 10 },
+      components: [
+        {
+          name: "R_0402",
+          places: [
+            {
+              refdes: "R1",
+              x: 30000,
+              y: -10000,
+              side: "front",
+              rotation: 90,
+              PN: "1k",
+            },
+          ],
+        },
+      ],
+    },
+    routes: {
+      resolution: { unit: "um", value: 10 },
+      parser: {
+        string_quote: '"',
+        host_version: "test",
+        space_in_quoted_tokens: "on",
+        host_cad: "test",
+      },
+      network_out: {
+        nets: [
+          {
+            name: "N1",
+            wires: [
+              {
+                path: {
+                  layer: "F.Cu",
+                  width: 2000,
+                  coordinates: [0, 0, 30000, 0],
+                },
+                net: "N1",
+                type: "route",
+              },
+            ],
+          },
+        ],
+      },
+    },
+  }
+
+  const mergedPcb = mergeDsnSessionIntoDsnPcb(dsnPcb, session)
+
+  expect(mergedPcb.placement.components[0].places[0]).toMatchObject({
+    refdes: "R1",
+    x: 3000,
+    y: -1000,
+    rotation: 90,
+  })
+  expect(mergedPcb.wiring.wires[0].path.coordinates).toEqual([0, 0, 3000, 0])
+})


### PR DESCRIPTION
## Summary
- Detect Freerouting-style session placement coordinates that are 10x the original DSN placement coordinates.
- Scale only those session placements when merging into a DSN PCB, while preserving internally generated sessions that are already in DSN coordinate space.
- Add regression coverage proving placement coordinates and routed wire coordinates are restored to matching DSN units.

/claim #54

## Verification
- bun test tests/dsn-pcb/merge-dsn-session-placement-scaling.test.ts tests/dsn-pcb/merge-dsn-session-with-conversion.test.tsx
- bunx biome check lib/dsn-pcb/dsn-json-to-circuit-json/merge-dsn-session-into-dsn-pcb.ts tests/dsn-pcb/merge-dsn-session-placement-scaling.test.ts
- bunx tsc --noEmit
- bun test
- bun run build
- git diff --check

Transparency note: AI-assisted with Codex; I reviewed the diff and verified it locally before submission.