### PR TITLE
Fix DSN parser string quote round trip

### DIFF
--- a/lib/common/parse-sexpr.ts
+++ b/lib/common/parse-sexpr.ts
@@ -13,6 +13,23 @@ export function tokenizeDsn(input: string): Token[] {
   let i = 0
   const length = input.length
 
+  const isStringQuoteValue = () => {
+    const previousToken = tokens[tokens.length - 1]
+    if (
+      previousToken?.type !== "Symbol" ||
+      previousToken.value !== "string_quote"
+    ) {
+      return false
+    }
+
+    let nextIndex = i + 1
+    while (nextIndex < length && /\s/.test(input[nextIndex])) {
+      nextIndex++
+    }
+
+    return input[nextIndex] === ")"
+  }
+
   while (i < length) {
     const char = input[i]
 
@@ -24,6 +41,9 @@ export function tokenizeDsn(input: string): Token[] {
       i++
     } else if (/\s/.test(char)) {
       // Ignore whitespace
+      i++
+    } else if (char === '"' && isStringQuoteValue()) {
+      tokens.push({ type: "String", value: '"' })
       i++
     } else if (char === '"') {
       // Parse quoted string

--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
@@ -10,7 +10,7 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
       return '""'
     }
     if (typeof value === "string") {
-      return `"${value}"`
+      return `"${value.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`
     }
     return value.toString()
   }
@@ -31,10 +31,10 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
 
   // Parser section
   result += `${indent}(parser\n`
-  result += `${indent}${indent}(string_quote ")\n`
-  result += `${indent}${indent}(space_in_quoted_tokens on)\n`
-  result += `${indent}${indent}(host_cad "KiCad's Pcbnew")\n`
-  result += `${indent}${indent}(host_version "${dsnJson.parser.host_version}")\n`
+  result += `${indent}${indent}(string_quote ${stringifyValue(dsnJson.parser.string_quote)})\n`
+  result += `${indent}${indent}(space_in_quoted_tokens ${dsnJson.parser.space_in_quoted_tokens})\n`
+  result += `${indent}${indent}(host_cad ${stringifyValue(dsnJson.parser.host_cad)})\n`
+  result += `${indent}${indent}(host_version ${stringifyValue(dsnJson.parser.host_version)})\n`
   result += `${indent})\n`
 
   // Resolution and unit

--- a/tests/dsn-pcb/stringify-dsn-json.test.ts
+++ b/tests/dsn-pcb/stringify-dsn-json.test.ts
@@ -10,6 +10,9 @@ test("stringify dsn json", () => {
   const dsnString = stringifyDsnJson(dsnJson)
   const reparsedJson = parseDsnToDsnJson(dsnString) as DsnPcb
 
+  expect(dsnString).toContain('(string_quote "\\"")')
+  expect(reparsedJson.parser).toEqual(dsnJson.parser)
+
   for (const key of Object.keys(reparsedJson) as Array<keyof DsnPcb>) {
     expect(reparsedJson[key]).toEqual(dsnJson[key] as any)
   }


### PR DESCRIPTION
/claim #54

## Summary
- parse `(string_quote ")` as the literal quote character instead of absorbing the following parser fields
- escape string values when writing DSN JSON back to DSN text
- use parser metadata from the parsed DSN instead of hard-coded `host_cad` / `space_in_quoted_tokens` values

## Tests
- `bun test tests/dsn-pcb/stringify-dsn-json.test.ts`
- `bun x biome check lib/common/parse-sexpr.ts lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts tests/dsn-pcb/stringify-dsn-json.test.ts`
- `bun x tsc --noEmit`
- `bun run build`
- `bun test` (fails only on the two existing Windows debug path mkdir failures: `basic-via-pcb-layer-change`, `merge-dsn-session-with-conversion`)
