### PR TITLE
Stringify DSN wiring vias as via records

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
@@ -136,7 +136,9 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
   result += `${indent}(wiring\n`
   ;(dsnJson.wiring?.wires ?? []).forEach((wire) => {
     if (wire.type === "via") {
-      result += `${indent}${indent}(via ${stringifyPath(wire.path, 3)}(net ${stringifyValue(wire.net)}))\n`
+      const [x, y] = wire.path.coordinates
+      const padstackName = (wire as any).padstack_name ?? dsnJson.structure.via
+      result += `${indent}${indent}(via ${stringifyValue(padstackName)} ${x} ${y} (net ${stringifyValue(wire.net)}))\n`
     } else {
       result += `${indent}${indent}(wire ${stringifyPath(wire.path, 3)}(net ${stringifyValue(wire.net)})(type ${wire.type}))\n`
     }

--- a/tests/dsn-pcb/stringify-dsn-json.test.ts
+++ b/tests/dsn-pcb/stringify-dsn-json.test.ts
@@ -17,3 +17,28 @@ test("stringify dsn json", () => {
   // Test that we can parse the generated string back to the same structure
   // expect(reparsedJson).toEqual(dsnJson)
 })
+
+test("stringify dsn json emits standard wiring via records", () => {
+  const dsnJson = parseDsnToDsnJson(testDsnFile) as DsnPcb
+  dsnJson.wiring.wires.push({
+    type: "via",
+    net: "N1",
+    path: {
+      layer: "all",
+      width: 0,
+      coordinates: [123, 456],
+    },
+  })
+
+  const dsnString = stringifyDsnJson(dsnJson)
+
+  expect(dsnString).toContain('(via "Via[0-1]_600:300_um" 123 456 (net "N1"))')
+  expect(dsnString).not.toContain("(via       (path")
+
+  const reparsedJson = parseDsnToDsnJson(dsnString) as DsnPcb
+  const via = reparsedJson.wiring.wires.find(
+    (wire) => wire.type === "via" && wire.net === "N1",
+  )
+
+  expect(via?.path.coordinates).toEqual([123, 456])
+})


### PR DESCRIPTION
Summary
- Emit DSN PCB `wiring` vias as standard `(via "Padstack" x y (net ...))` records instead of nesting a `path` record inside `via`.
- Use the board default via padstack when the via wire has no explicit padstack name.
- Add round-trip regression coverage proving the generated via syntax reparses to the expected net and coordinates.

Bounty
/claim #54

Verification
- `bun test tests/dsn-pcb/stringify-dsn-json.test.ts`
- `bunx biome check lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts tests/dsn-pcb/stringify-dsn-json.test.ts`
- `bunx tsc --noEmit`
- `bun test`
- `bun run build`
- `git diff --check`

Transparency note: AI-assisted with Codex; I reviewed the diff and verified it locally before submission.