### PR TITLE
Preserve polyline paths when stringifying DSN

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
@@ -26,6 +26,11 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
     return `${padding}(path ${path.layer} ${path.width}  ${stringifyCoordinates(path.coordinates)})`
   }
 
+  const stringifyPolylinePath = (path: any, level: number): string => {
+    const padding = indent.repeat(level)
+    return `${padding}(polyline_path ${path.layer} ${path.width}  ${stringifyCoordinates(path.coordinates)})`
+  }
+
   // Start with pcb
   result += `(pcb ${dsnJson.filename ? dsnJson.filename : "./converted_dsn.dsn"}\n`
 
@@ -137,6 +142,8 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
   ;(dsnJson.wiring?.wires ?? []).forEach((wire) => {
     if (wire.type === "via") {
       result += `${indent}${indent}(via ${stringifyPath(wire.path, 3)}(net ${stringifyValue(wire.net)}))\n`
+    } else if (wire.polyline_path) {
+      result += `${indent}${indent}(wire ${stringifyPolylinePath(wire.polyline_path, 3)}(net ${stringifyValue(wire.net)})(type ${wire.type}))\n`
     } else {
       result += `${indent}${indent}(wire ${stringifyPath(wire.path, 3)}(net ${stringifyValue(wire.net)})(type ${wire.type}))\n`
     }

--- a/lib/dsn-pcb/types.ts
+++ b/lib/dsn-pcb/types.ts
@@ -69,6 +69,11 @@ export interface DsnPcb {
   }
   wiring: {
     wires: Array<{
+      polyline_path?: {
+        layer: string
+        width: number
+        coordinates: number[]
+      }
       path: {
         layer: string
         width: number

--- a/tests/dsn-pcb/stringify-dsn-json.test.ts
+++ b/tests/dsn-pcb/stringify-dsn-json.test.ts
@@ -17,3 +17,36 @@ test("stringify dsn json", () => {
   // Test that we can parse the generated string back to the same structure
   // expect(reparsedJson).toEqual(dsnJson)
 })
+
+test("stringify dsn json preserves polyline_path wires", () => {
+  const dsnJson = parseDsnToDsnJson(testDsnFile) as DsnPcb
+  dsnJson.wiring.wires.push({
+    type: "route",
+    net: "N2",
+    polyline_path: {
+      layer: "F.Cu",
+      width: 200,
+      coordinates: [0, 0, 100, 0, 100, 0, 100, 100],
+    },
+    path: {
+      layer: "F.Cu",
+      width: 200,
+      coordinates: [],
+    },
+  })
+
+  const dsnString = stringifyDsnJson(dsnJson)
+
+  expect(dsnString).toContain(
+    "(polyline_path F.Cu 200  0 0 100 0 100 0 100 100)",
+  )
+
+  const reparsedJson = parseDsnToDsnJson(dsnString) as DsnPcb
+  const polylineWire = reparsedJson.wiring.wires.find(
+    (wire) => wire.net === "N2" && wire.polyline_path,
+  )
+
+  expect(polylineWire?.polyline_path?.coordinates).toEqual([
+    0, 0, 100, 0, 100, 0, 100, 100,
+  ])
+})


### PR DESCRIPTION
Summary
- Add DSN PCB stringifier support for wiring records that contain `polyline_path`.
- Keep the `DsnPcb` wiring type aligned with the parser by declaring `polyline_path` on direct wiring records.
- Add a round-trip regression proving a `polyline_path` wire stringifies and parses back with its coordinates intact.

Bounty
/claim #54

Verification
- `bun test tests/dsn-pcb/stringify-dsn-json.test.ts`
- `bunx biome check lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts lib/dsn-pcb/types.ts tests/dsn-pcb/stringify-dsn-json.test.ts`
- `bunx tsc --noEmit`
- `bun test`
- `bun run build`
- `git diff --check`

Transparency note: AI-assisted with Codex; I reviewed the diff and verified it locally before submission.