### PR TITLE
Preserve DSN class circuit metadata

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
@@ -118,7 +118,13 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
   dsnJson.network.classes.forEach((cls) => {
     result += `${indent}${indent}(class ${stringifyValue(cls.name)} ${stringifyValue(cls.description)}${cls.net_names.map((n) => ` ${stringifyValue(n)}`).join("")}\n`
     result += `${indent}${indent}${indent}(circuit\n`
+    if (cls.circuit.clearance_class) {
+      result += `${indent}${indent}${indent}${indent}(clearance_class ${stringifyValue(cls.circuit.clearance_class)})\n`
+    }
     result += `${indent}${indent}${indent}${indent}(use_via ${stringifyValue(cls.circuit.use_via)})\n`
+    if (cls.circuit.via_rule) {
+      result += `${indent}${indent}${indent}${indent}(via_rule ${stringifyValue(cls.circuit.via_rule)})\n`
+    }
     result += `${indent}${indent}${indent})\n`
     if (cls.rule) {
       result += `${indent}${indent}${indent}(rule\n`
@@ -135,10 +141,13 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
   // Wiring section
   result += `${indent}(wiring\n`
   ;(dsnJson.wiring?.wires ?? []).forEach((wire) => {
+    const clearanceClass = wire.clearance_class
+      ? `(clearance_class ${stringifyValue(wire.clearance_class)})`
+      : ""
     if (wire.type === "via") {
-      result += `${indent}${indent}(via ${stringifyPath(wire.path, 3)}(net ${stringifyValue(wire.net)}))\n`
+      result += `${indent}${indent}(via ${stringifyPath(wire.path, 3)}(net ${stringifyValue(wire.net)})${clearanceClass})\n`
     } else {
-      result += `${indent}${indent}(wire ${stringifyPath(wire.path, 3)}(net ${stringifyValue(wire.net)})(type ${wire.type}))\n`
+      result += `${indent}${indent}(wire ${stringifyPath(wire.path, 3)}(net ${stringifyValue(wire.net)})${clearanceClass}(type ${wire.type}))\n`
     }
   })
   result += `${indent})\n`

--- a/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
@@ -890,17 +890,26 @@ function processClass(nodes: ASTNode[]): Class {
 function processCircuit(nodes: ASTNode[]): Circuit {
   const circuit: Partial<Circuit> = {}
   nodes.forEach((node) => {
-    if (
-      node.type === "List" &&
-      node.children![0].type === "Atom" &&
-      node.children![0].value === "use_via"
-    ) {
-      if (
-        node.children![1].type === "Atom" &&
-        typeof node.children![1].value === "string"
-      ) {
-        circuit.use_via = node.children![1].value
-      }
+    if (node.type !== "List" || node.children![0].type !== "Atom") {
+      return
+    }
+
+    const key = node.children![0].value
+    const valueNode = node.children![1]
+    if (valueNode?.type !== "Atom" || typeof valueNode.value !== "string") {
+      return
+    }
+
+    switch (key) {
+      case "clearance_class":
+        circuit.clearance_class = valueNode.value
+        break
+      case "use_via":
+        circuit.use_via = valueNode.value
+        break
+      case "via_rule":
+        circuit.via_rule = valueNode.value
+        break
     }
   })
   return circuit as Circuit

--- a/lib/dsn-pcb/types.ts
+++ b/lib/dsn-pcb/types.ts
@@ -56,7 +56,9 @@ export interface DsnPcb {
       description: string
       net_names: string[]
       circuit: {
+        clearance_class?: string
         use_via: string
+        via_rule?: string
       }
       rule: {
         clearances: Array<{
@@ -77,6 +79,7 @@ export interface DsnPcb {
          */
         coordinates: number[]
       }
+      clearance_class?: string
       net: string
       type: string
     }>
@@ -261,7 +264,9 @@ export interface Class {
 }
 
 export interface Circuit {
+  clearance_class?: string
   use_via: string
+  via_rule?: string
 }
 
 export interface Wiring {

--- a/tests/dsn-pcb/dsn-class-circuit-metadata.test.ts
+++ b/tests/dsn-pcb/dsn-class-circuit-metadata.test.ts
@@ -1,0 +1,139 @@
+import { expect, test } from "bun:test"
+import { stringifyDsnJson } from "../../lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json"
+import { parseDsnToDsnJson } from "../../lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json"
+import type { DsnPcb } from "../../lib/dsn-pcb/types"
+
+const dsnWithClassCircuitMetadata = `(pcb "./class-circuit-metadata.dsn"
+  (parser
+    (string_quote ")
+    (space_in_quoted_tokens on)
+    (host_cad "KiCad")
+    (host_version "1")
+  )
+  (resolution um 10)
+  (unit um)
+  (structure
+    (layer F.Cu
+      (type signal)
+      (property
+        (index 0)
+      )
+    )
+    (layer B.Cu
+      (type signal)
+      (property
+        (index 1)
+      )
+    )
+    (boundary
+      (path pcb 0 0 0 1000 0 1000 1000 0 1000 0 0)
+    )
+    (via "Via[0-1]_600:300_um")
+    (rule
+      (width 150)
+      (clearance 200)
+    )
+  )
+  (placement)
+  (library)
+  (network
+    (net "N1"
+      (pins U1-1 U2-1)
+    )
+    (class "default" "desc" "N1"
+      (circuit
+        (clearance_class default)
+        (use_via "Via[0-1]_600:300_um")
+        (via_rule default)
+      )
+      (rule
+        (width 150)
+        (clearance 200)
+      )
+    )
+  )
+  (wiring)
+)`
+
+test("preserves class circuit clearance_class and via_rule metadata", () => {
+  const dsnJson = parseDsnToDsnJson(dsnWithClassCircuitMetadata) as DsnPcb
+  const circuit = dsnJson.network.classes[0].circuit
+
+  expect(circuit.clearance_class).toBe("default")
+  expect(circuit.use_via).toBe("Via[0-1]_600:300_um")
+  expect(circuit.via_rule).toBe("default")
+
+  const dsnString = stringifyDsnJson(dsnJson)
+  const reparsed = parseDsnToDsnJson(dsnString) as DsnPcb
+  const reparsedCircuit = reparsed.network.classes[0].circuit
+
+  expect(dsnString).toContain('(clearance_class "default")')
+  expect(dsnString).toContain('(via_rule "default")')
+  expect(reparsedCircuit.clearance_class).toBe("default")
+  expect(reparsedCircuit.use_via).toBe("Via[0-1]_600:300_um")
+  expect(reparsedCircuit.via_rule).toBe("default")
+})
+
+const dsnWithWireClearanceClass = `(pcb "./wire-clearance-class.dsn"
+  (parser
+    (string_quote ")
+    (space_in_quoted_tokens on)
+    (host_cad "KiCad")
+    (host_version "1")
+  )
+  (resolution um 10)
+  (unit um)
+  (structure
+    (layer F.Cu
+      (type signal)
+      (property
+        (index 0)
+      )
+    )
+    (boundary
+      (path pcb 0 0 0 1000 0 1000 1000 0 1000 0 0)
+    )
+    (via "Via[0-1]_600:300_um")
+    (rule
+      (width 150)
+      (clearance 200)
+    )
+  )
+  (placement)
+  (library)
+  (network
+    (net "N1"
+      (pins U1-1 U2-1)
+    )
+    (class "default" "desc" "N1"
+      (circuit
+        (use_via "Via[0-1]_600:300_um")
+      )
+      (rule
+        (width 150)
+        (clearance 200)
+      )
+    )
+  )
+  (wiring
+    (wire
+      (path F.Cu 100 0 0 1000 0)
+      (net "N1")
+      (clearance_class tight)
+      (type route)
+    )
+  )
+)`
+
+test("preserves wire clearance_class metadata", () => {
+  const dsnJson = parseDsnToDsnJson(dsnWithWireClearanceClass) as DsnPcb
+  const wire = dsnJson.wiring.wires[0]
+
+  expect(wire.clearance_class).toBe("tight")
+
+  const dsnString = stringifyDsnJson(dsnJson)
+  const reparsed = parseDsnToDsnJson(dsnString) as DsnPcb
+
+  expect(dsnString).toContain('(clearance_class "tight")')
+  expect(reparsed.wiring.wires[0].clearance_class).toBe("tight")
+})


### PR DESCRIPTION
## Summary
- parse `clearance_class` and `via_rule` entries inside DSN network class `circuit` blocks
- preserve class-level circuit metadata and wire-level `clearance_class` metadata when stringifying DSN JSON back to DSN text
- add focused parse -> stringify -> parse regressions for class circuit metadata and wire clearance classes

## Why
Freerouting DSN class circuit blocks can include routing metadata such as `(clearance_class default)` and `(via_rule default)`, and routed wires can carry their own `(clearance_class ...)`. The converter previously parsed or encountered those fields but dropped them during DSN JSON round trips. This is separate from the open `use_layer` preservation work and does not touch Smoothie geometry, via dimensions, layer counts, placement rotation, or string escaping.

/claim #54

## Verification
- `bun test dsn-class-circuit-metadata.test.ts` from `tests/dsn-pcb`
- `bun x biome check lib/dsn-pcb/types.ts lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts tests/dsn-pcb/dsn-class-circuit-metadata.test.ts`
- `bun x tsc --noEmit`
- `bun run build`
- `git diff --check`

Not run: full `bun test` locally, because this Windows environment could not build/load the repo preload dependency `sharp` after install; the parser-focused tests were run from `tests/dsn-pcb` to avoid that unrelated preload.

Transparency: AI-assisted with Codex; I reviewed the diff and verification before submission.