### PR TITLE
Preserve session padstack shapes when stringifying

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-session.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-session.ts
@@ -1,4 +1,20 @@
-import type { DsnSession } from "../types"
+import type { DsnSession, Shape } from "../types"
+
+const stringifyCoordinates = (coordinates: number[]): string =>
+  coordinates.join(" ")
+
+const stringifyPadstackShape = (shape: Shape): string => {
+  switch (shape.shapeType) {
+    case "circle":
+      return `(shape (circle ${shape.layer} ${shape.diameter}))`
+    case "rect":
+      return `(shape (rect ${shape.layer} ${stringifyCoordinates(shape.coordinates)}))`
+    case "polygon":
+      return `(shape (polygon ${shape.layer} ${shape.width} ${stringifyCoordinates(shape.coordinates)}))`
+    case "path":
+      return `(shape (path ${shape.layer} ${shape.width} ${stringifyCoordinates(shape.coordinates)}))`
+  }
+}
 
 export const stringifyDsnSession = (session: DsnSession): string => {
   const indent = "  "
@@ -41,11 +57,7 @@ export const stringifyDsnSession = (session: DsnSession): string => {
     session.routes.library_out.padstacks.forEach((padstack) => {
       result += `${indent}${indent}${indent}(padstack ${JSON.stringify(padstack.name)}\n`
       padstack.shapes.forEach((shape) => {
-        if (shape.shapeType === "circle") {
-          result += `${indent}${indent}${indent}${indent}(shape\n`
-          result += `${indent}${indent}${indent}${indent}${indent}(circle ${shape.layer} ${shape.diameter} 0 0)\n`
-          result += `${indent}${indent}${indent}${indent})\n`
-        }
+        result += `${indent}${indent}${indent}${indent}${stringifyPadstackShape(shape)}\n`
       })
       result += `${indent}${indent}${indent}${indent}(attach ${padstack.attach})\n`
       result += `${indent}${indent}${indent})\n`

--- a/tests/dsn-pcb/stringify-dsn-session.test.ts
+++ b/tests/dsn-pcb/stringify-dsn-session.test.ts
@@ -25,3 +25,37 @@ test("stringify session file", () => {
   expect(reparsedNet.name).toBe(originalNet.name)
   expect(reparsedNet.wires).toHaveLength(originalNet.wires.length)
 })
+
+test("stringify session preserves library_out padstack shapes", () => {
+  const sessionJson = parseDsnToDsnJson(`(session board.ses
+    (base_design board.dsn)
+    (placement
+      (resolution um 10)
+    )
+    (was_is)
+    (routes
+      (resolution um 10)
+      (parser
+        (host_cad "freerouting")
+        (host_version "1.0")
+      )
+      (library_out
+        (padstack "MixedPadstack"
+          (shape (circle F.Cu 200))
+          (shape (rect F.Cu -100 -50 100 50))
+          (shape (polygon B.Cu 0 -100 -100 100 -100 100 100 -100 100))
+          (shape (path F.Cu 50 0 0 100 0))
+          (attach off)
+        )
+      )
+      (network_out)
+    )
+  )`) as DsnSession
+
+  const stringified = stringifyDsnSession(sessionJson)
+  const reparsed = parseDsnToDsnJson(stringified) as DsnSession
+
+  expect(reparsed.routes.library_out?.padstacks[0].shapes).toEqual(
+    sessionJson.routes.library_out?.padstacks[0].shapes,
+  )
+})


### PR DESCRIPTION
Summary
- Add DSN session stringifier support for all parsed `library_out` padstack shape types: circle, rect, polygon, and path.
- Prevent non-circle session padstack shapes from being dropped during parse -> stringify -> parse round trips.
- Add regression coverage proving mixed session padstack shapes survive stringification.

Bounty
/claim #54

Verification
- `bun test tests/dsn-pcb/stringify-dsn-session.test.ts`
- `bunx biome check lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-session.ts tests/dsn-pcb/stringify-dsn-session.test.ts`
- `bunx tsc --noEmit`
- `bun test`
- `bun run build`
- `git diff --check`

Transparency note: AI-assisted with Codex; I reviewed the diff and verified it locally before submission.