### PR TITLE
Preserve session placement PN metadata

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-session.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-session.ts
@@ -16,7 +16,7 @@ export const stringifyDsnSession = (session: DsnSession): string => {
   session.placement.components.forEach((component) => {
     result += `${indent}${indent}(component ${component.name}\n`
     component.places.forEach((place) => {
-      result += `${indent}${indent}${indent}(place ${place.refdes} ${place.x} ${place.y} ${place.side} ${place.rotation})\n`
+      result += `${indent}${indent}${indent}(place ${place.refdes} ${place.x} ${place.y} ${place.side} ${place.rotation}${place.PN ? ` (PN ${JSON.stringify(place.PN)})` : ""})\n`
     })
     result += `${indent}${indent})\n`
   })

--- a/tests/dsn-pcb/stringify-dsn-session.test.ts
+++ b/tests/dsn-pcb/stringify-dsn-session.test.ts
@@ -25,3 +25,29 @@ test("stringify session file", () => {
   expect(reparsedNet.name).toBe(originalNet.name)
   expect(reparsedNet.wires).toHaveLength(originalNet.wires.length)
 })
+
+test("stringify session preserves placement PN metadata", () => {
+  const sessionJson = parseDsnToDsnJson(`(session board.ses
+    (base_design board.dsn)
+    (placement
+      (resolution um 10)
+      (component "Resistor_0603"
+        (place R1 100 200 front 90 (PN "10k"))
+      )
+    )
+    (was_is)
+    (routes
+      (resolution um 10)
+      (parser
+        (host_cad "freerouting")
+        (host_version "1.0")
+      )
+      (network_out)
+    )
+  )`) as DsnSession
+
+  const stringified = stringifyDsnSession(sessionJson)
+  const reparsed = parseDsnToDsnJson(stringified) as DsnSession
+
+  expect(reparsed.placement.components[0].places[0].PN).toBe("10k")
+})


### PR DESCRIPTION
Summary
- Emit optional `(PN ...)` placement metadata from `stringifyDsnSession` when it is present.
- Add a DSN session parse -> stringify -> parse regression proving placement part-number metadata survives round trips.
- Keep this scoped to session placement metadata, separate from placement scaling, rotation, parser metadata, and padstack-shape PRs.

Bounty
/claim #54

Verification
- `bun test tests/dsn-pcb/stringify-dsn-session.test.ts`
- `bunx biome check lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-session.ts tests/dsn-pcb/stringify-dsn-session.test.ts`
- `bunx tsc --noEmit`
- `bun test`
- `bun run build`
- `git diff --check`

Transparency note: AI-assisted with Codex; I reviewed the diff and verified it locally before submission.