### PR TITLE
Preserve DSN layers without property blocks

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
@@ -46,9 +46,11 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
   dsnJson.structure.layers.forEach((layer) => {
     result += `${indent}${indent}(layer ${layer.name}\n`
     result += `${indent}${indent}${indent}(type ${layer.type})\n`
-    result += `${indent}${indent}${indent}(property\n`
-    result += `${indent}${indent}${indent}${indent}(index ${layer.property.index})\n`
-    result += `${indent}${indent}${indent})\n`
+    if (layer.property) {
+      result += `${indent}${indent}${indent}(property\n`
+      result += `${indent}${indent}${indent}${indent}(index ${layer.property.index})\n`
+      result += `${indent}${indent}${indent})\n`
+    }
     result += `${indent}${indent})\n`
   })
   if (dsnJson.structure.boundary) {

--- a/tests/dsn-pcb/stringify-dsn-json.test.ts
+++ b/tests/dsn-pcb/stringify-dsn-json.test.ts
@@ -17,3 +17,45 @@ test("stringify dsn json", () => {
   // Test that we can parse the generated string back to the same structure
   // expect(reparsedJson).toEqual(dsnJson)
 })
+
+test("stringify dsn json preserves layers without property blocks", () => {
+  const dsnJson = parseDsnToDsnJson(`(pcb "freerouting-output.dsn"
+  (parser
+    (string_quote ")
+    (space_in_quoted_tokens on)
+    (host_cad "freerouting")
+    (host_version "1.9")
+  )
+  (resolution um 10)
+  (unit um)
+  (structure
+    (layer F.Cu
+      (type signal)
+    )
+    (layer B.Cu
+      (type signal)
+    )
+    (boundary
+      (path pcb 0 0 0 1000 0 1000 1000 0 1000)
+    )
+    (via "Via[0-1]_600:300_um")
+    (rule
+      (width 200)
+      (clearance 200)
+    )
+  )
+  (placement)
+  (library)
+  (network)
+  (wiring)
+)`) as DsnPcb
+
+  expect(dsnJson.structure.layers[0].property).toBeUndefined()
+
+  const dsnString = stringifyDsnJson(dsnJson)
+  expect(dsnString).toContain("(layer F.Cu")
+  expect(dsnString).not.toContain("(index undefined)")
+
+  const reparsedJson = parseDsnToDsnJson(dsnString) as DsnPcb
+  expect(reparsedJson.structure.layers).toEqual(dsnJson.structure.layers)
+})


### PR DESCRIPTION
Part of #54

/claim #54

## Summary
- Allow `stringifyDsnJson` to emit DSN layer records that do not include a `(property (index ...))` block.
- Preserve the existing property/index output when the parsed DSN layer has one.
- Add a focused round-trip regression for Freerouting-style layers containing only `(type signal)`.

## Why this is separate
Freerouting-generated DSN files in this repo, such as `tests/assets/testkicadproject/freeroutingTraceAdded.dsn`, omit layer property/index blocks. `parseDsnToDsnJson` accepts them, but `stringifyDsnJson` currently crashes by assuming `layer.property.index` always exists. This is a narrow stringifier data-preservation fix and does not overlap with the active boundary shape, class metadata, padstack shape, via, rotation, or Smoothie geometry fixes.

## Verification
- `bun test tests/dsn-pcb/stringify-dsn-json.test.ts`
- `bun test`
- `bun x biome check lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts tests/dsn-pcb/stringify-dsn-json.test.ts`
- `bun x tsc --noEmit`
- `bun run build`
- `git diff --check`