### PR TITLE
Preserve session base design metadata

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-session.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-session.ts
@@ -8,7 +8,7 @@ export const stringifyDsnSession = (session: DsnSession): string => {
   result += `(session ${session.filename}\n`
 
   // Base design
-  result += `${indent}(base_design ${session.filename})\n`
+  result += `${indent}(base_design ${JSON.stringify(session.base_design ?? session.filename)})\n`
 
   // Placement section
   result += `${indent}(placement\n`

--- a/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
@@ -1043,6 +1043,16 @@ function processSessionNode(ast: ASTNode): DsnSession {
     },
   }
 
+  const baseDesignNode = ast.children!.find(
+    (child) =>
+      child.type === "List" &&
+      child.children?.[0].type === "Atom" &&
+      child.children[0].value === "base_design",
+  )
+  if (baseDesignNode?.children?.[1]?.type === "Atom") {
+    session.base_design = String(baseDesignNode.children[1].value)
+  }
+
   // Extract placement section
   const placementNode = ast.children!.find(
     (child) =>

--- a/lib/dsn-pcb/types.ts
+++ b/lib/dsn-pcb/types.ts
@@ -293,6 +293,7 @@ export interface DsnSession {
   is_dsn_session: true
   is_dsn_pcb?: false
   filename: string
+  base_design?: string
   placement: {
     resolution: Resolution
     components: Array<ComponentPlacement>

--- a/tests/dsn-pcb/stringify-dsn-session.test.ts
+++ b/tests/dsn-pcb/stringify-dsn-session.test.ts
@@ -25,3 +25,26 @@ test("stringify session file", () => {
   expect(reparsedNet.name).toBe(originalNet.name)
   expect(reparsedNet.wires).toHaveLength(originalNet.wires.length)
 })
+
+test("stringify session preserves base design", () => {
+  const sessionJson = parseDsnToDsnJson(`(session routed-output.ses
+    (base_design "input-board.dsn")
+    (placement
+      (resolution um 10)
+    )
+    (was_is)
+    (routes
+      (resolution um 10)
+      (parser
+        (host_cad "freerouting")
+        (host_version "1.0")
+      )
+      (network_out)
+    )
+  )`) as DsnSession
+
+  const stringified = stringifyDsnSession(sessionJson)
+  const reparsed = parseDsnToDsnJson(stringified) as DsnSession
+
+  expect(reparsed.base_design).toBe("input-board.dsn")
+})


### PR DESCRIPTION
Summary
- Parse DSN session `(base_design ...)` into `DsnSession.base_design`.
- Preserve that value when stringifying sessions instead of always writing the session filename as the base design.
- Add regression coverage proving distinct session filename and base design values survive parse -> stringify -> parse.

Bounty
/claim #54

Verification
- `bun test tests/dsn-pcb/stringify-dsn-session.test.ts`
- `bunx biome check lib/dsn-pcb/types.ts lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-session.ts tests/dsn-pcb/stringify-dsn-session.test.ts`
- `bunx tsc --noEmit`
- `bun test`
- `bun run build`
- `git diff --check`

Transparency note: AI-assisted with Codex; I reviewed the diff and verified it locally before submission.