### PR TITLE
Preserve DSN placement pin clearance classes

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
@@ -71,7 +71,14 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
     result += `${indent}${indent}(component ${stringifyValue(component.name)}\n`
     if (component.places) {
       component.places.forEach((place) => {
-        result += `${indent}${indent}${indent}(place ${place.refdes} ${place.x} ${place.y} ${place.side} ${place.rotation}${place.PN ? ` (PN ${stringifyValue(place.PN)})` : ""})\n`
+        const pinMetadata =
+          place.pins
+            ?.map(
+              (pin) =>
+                ` (pin ${stringifyValue(pin.pin_number)}${pin.clearance_class ? ` (clearance_class ${stringifyValue(pin.clearance_class)})` : ""})`,
+            )
+            .join("") ?? ""
+        result += `${indent}${indent}${indent}(place ${place.refdes} ${place.x} ${place.y} ${place.side} ${place.rotation}${place.PN ? ` (PN ${stringifyValue(place.PN)})` : ""}${pinMetadata})\n`
       })
     }
     result += `${indent}${indent})\n`

--- a/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
@@ -29,6 +29,7 @@ import type {
   PathShape,
   Pin,
   Placement,
+  PlacementPin,
   Places,
   PolygonShape,
   RectShape,
@@ -489,7 +490,19 @@ function processPlace(nodes: ASTNode[]): Places {
       node.children[1].type === "Atom"
     ) {
       places.PN = String(node.children[1].value)
-      break
+    }
+
+    if (
+      node.type === "List" &&
+      node.children &&
+      node.children[0].type === "Atom" &&
+      node.children[0].value === "pin"
+    ) {
+      const pin = processPlacementPin(node.children)
+      if (pin) {
+        places.pins ??= []
+        places.pins.push(pin)
+      }
     }
   }
 
@@ -499,6 +512,30 @@ function processPlace(nodes: ASTNode[]): Places {
   places.rotation = places.rotation || 0
 
   return places as Places
+}
+
+function processPlacementPin(nodes: ASTNode[]): PlacementPin | null {
+  const pinNumberNode = nodes[1]
+  if (pinNumberNode?.type !== "Atom") {
+    return null
+  }
+
+  const pin: PlacementPin = {
+    pin_number: pinNumberNode.value as number | string,
+  }
+
+  for (const node of nodes.slice(2)) {
+    if (
+      node.type === "List" &&
+      node.children?.[0]?.type === "Atom" &&
+      node.children[0].value === "clearance_class" &&
+      node.children[1]?.type === "Atom"
+    ) {
+      pin.clearance_class = String(node.children[1].value)
+    }
+  }
+
+  return pin
 }
 
 export function processLibrary(nodes: ASTNode[]): Library {

--- a/lib/dsn-pcb/types.ts
+++ b/lib/dsn-pcb/types.ts
@@ -92,7 +92,13 @@ export interface ComponentPlacement {
     y: number
     side: "front" | "back"
     rotation: number
+    pins?: Array<PlacementPin>
   }>
+}
+
+export interface PlacementPin {
+  pin_number: number | string
+  clearance_class?: string
 }
 
 export interface Parser {
@@ -171,6 +177,7 @@ export interface Places {
   side: string
   rotation: number
   PN: string
+  pins?: PlacementPin[]
 }
 
 export interface Library {

--- a/tests/dsn-pcb/stringify-dsn-json.test.ts
+++ b/tests/dsn-pcb/stringify-dsn-json.test.ts
@@ -17,3 +17,58 @@ test("stringify dsn json", () => {
   // Test that we can parse the generated string back to the same structure
   // expect(reparsedJson).toEqual(dsnJson)
 })
+
+test("stringify dsn json preserves placement pin clearance classes", () => {
+  const dsnJson = parseDsnToDsnJson(`(pcb "freerouting-output.dsn"
+  (parser
+    (string_quote ")
+    (space_in_quoted_tokens on)
+    (host_cad "freerouting")
+    (host_version "1.9")
+  )
+  (resolution um 10)
+  (unit um)
+  (structure
+    (layer F.Cu
+      (type signal)
+      (property
+        (index 0)
+      )
+    )
+    (boundary
+      (path pcb 0 0 0 1000 0 1000 1000 0 1000)
+    )
+    (via "Via[0-1]_600:300_um")
+    (rule
+      (width 200)
+      (clearance 200)
+    )
+  )
+  (placement
+    (component "R_0402"
+      (place R1 156105 -105000 front 0
+        (pin 1 (clearance_class "kicad_default"))
+        (pin 2 (clearance_class "fine_pitch"))
+      )
+    )
+  )
+  (library)
+  (network)
+  (wiring)
+)`) as DsnPcb
+
+  const place = dsnJson.placement.components[0].places[0]
+  expect(place.pins).toEqual([
+    { pin_number: 1, clearance_class: "kicad_default" },
+    { pin_number: 2, clearance_class: "fine_pitch" },
+  ])
+
+  const dsnString = stringifyDsnJson(dsnJson)
+  expect(dsnString).toContain('(pin 1 (clearance_class "kicad_default"))')
+  expect(dsnString).toContain('(pin 2 (clearance_class "fine_pitch"))')
+
+  const reparsedJson = parseDsnToDsnJson(dsnString) as DsnPcb
+  expect(reparsedJson.placement.components[0].places[0].pins).toEqual(
+    place.pins,
+  )
+})


### PR DESCRIPTION
Part of #54

/claim #54

## Summary
- Parse placement-level `(pin ... (clearance_class ...))` records into `place.pins`.
- Preserve that placement pin metadata when stringifying DSN JSON back to DSN.
- Add a focused round-trip regression for Freerouting-style placement pin clearance classes.

## Why this is separate
Freerouting-generated DSN files in this repo, such as `tests/assets/testkicadproject/freeroutingTraceAdded.dsn`, include placement pin clearance metadata under `place` records. The current parser accepts the file but silently drops those child `pin` records, so parse -> stringify loses per-pin clearance class metadata. This is distinct from active wire-level `clearance_class` / network-class metadata work because it targets placement pin metadata only.

## Verification
- `bun test tests/dsn-pcb/stringify-dsn-json.test.ts`
- `bun x biome check lib/dsn-pcb/types.ts lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts tests/dsn-pcb/stringify-dsn-json.test.ts`
- `bun x tsc --noEmit`
- `bun test`
- `bun run build`
- `git diff --check`