### PR TITLE
Preserve session library_out images

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-session.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-session.ts
@@ -4,6 +4,15 @@ export const stringifyDsnSession = (session: DsnSession): string => {
   const indent = "  "
   let result = ""
 
+  const stringifyCoordinates = (coordinates: number[]): string => {
+    return coordinates.join(" ")
+  }
+
+  const stringifyPath = (path: any, level: number): string => {
+    const padding = indent.repeat(level)
+    return `${padding}(path ${path.layer} ${path.width}  ${stringifyCoordinates(path.coordinates)})`
+  }
+
   // Start with session
   result += `(session ${session.filename}\n`
 
@@ -38,6 +47,16 @@ export const stringifyDsnSession = (session: DsnSession): string => {
   // Library_out subsection
   if (session.routes.library_out) {
     result += `${indent}${indent}(library_out \n`
+    session.routes.library_out.images.forEach((image) => {
+      result += `${indent}${indent}${indent}(image ${JSON.stringify(image.name)}\n`
+      image.outlines.forEach((outline) => {
+        result += `${indent}${indent}${indent}${indent}(outline ${stringifyPath(outline.path, 5)})\n`
+      })
+      image.pins.forEach((pin) => {
+        result += `${indent}${indent}${indent}${indent}(pin ${JSON.stringify(pin.padstack_name)} ${pin.pin_number} ${pin.x} ${pin.y})\n`
+      })
+      result += `${indent}${indent}${indent})\n`
+    })
     session.routes.library_out.padstacks.forEach((padstack) => {
       result += `${indent}${indent}${indent}(padstack ${JSON.stringify(padstack.name)}\n`
       padstack.shapes.forEach((shape) => {

--- a/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
@@ -1082,7 +1082,14 @@ function processSessionNode(ast: ASTNode): DsnSession {
     )
     if (libraryNode) {
       session.routes.library_out = {
-        images: [],
+        images: libraryNode
+          .children!.filter(
+            (child) =>
+              child.type === "List" &&
+              child.children?.[0].type === "Atom" &&
+              child.children[0].value === "image",
+          )
+          .map((imageNode) => processImage(imageNode.children!)),
         padstacks: libraryNode
           .children!.filter(
             (child) =>

--- a/tests/dsn-pcb/stringify-dsn-session.test.ts
+++ b/tests/dsn-pcb/stringify-dsn-session.test.ts
@@ -25,3 +25,34 @@ test("stringify session file", () => {
   expect(reparsedNet.name).toBe(originalNet.name)
   expect(reparsedNet.wires).toHaveLength(originalNet.wires.length)
 })
+
+test("stringify session preserves library_out images", () => {
+  const sessionJson = parseDsnToDsnJson(`(session board.ses
+    (base_design board.dsn)
+    (placement
+      (resolution um 10)
+    )
+    (was_is)
+    (routes
+      (resolution um 10)
+      (parser
+        (host_cad "freerouting")
+        (host_version "1.0")
+      )
+      (library_out
+        (image "LibImage"
+          (outline (path F.Cu 0 0 0 100 0))
+          (pin "RoundPad" 1 10 20)
+        )
+      )
+      (network_out)
+    )
+  )`) as DsnSession
+
+  const stringified = stringifyDsnSession(sessionJson)
+  const reparsed = parseDsnToDsnJson(stringified) as DsnSession
+
+  expect(reparsed.routes.library_out?.images).toEqual(
+    sessionJson.routes.library_out?.images,
+  )
+})


### PR DESCRIPTION
Summary
- Parse `image` entries from DSN session `routes.library_out` instead of dropping them.
- Emit `library_out.images` from `stringifyDsnSession`, including outlines and pins.
- Add regression coverage proving session `library_out` images survive parse -> stringify -> parse.

Bounty
/claim #54

Verification
- `bun test tests/dsn-pcb/stringify-dsn-session.test.ts`
- `bunx biome check lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-session.ts tests/dsn-pcb/stringify-dsn-session.test.ts`
- `bunx tsc --noEmit`
- `bun test`
- `bun run build`
- `git diff --check`

Transparency note: AI-assisted with Codex; I reviewed the diff and verified it locally before submission.