### PR TITLE
Quote session filenames when stringifying

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-session.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-session.ts
@@ -5,7 +5,7 @@ export const stringifyDsnSession = (session: DsnSession): string => {
   let result = ""
 
   // Start with session
-  result += `(session ${session.filename}\n`
+  result += `(session ${JSON.stringify(session.filename)}\n`
 
   // Base design
   result += `${indent}(base_design ${session.filename})\n`

--- a/tests/dsn-pcb/stringify-dsn-session.test.ts
+++ b/tests/dsn-pcb/stringify-dsn-session.test.ts
@@ -25,3 +25,26 @@ test("stringify session file", () => {
   expect(reparsedNet.name).toBe(originalNet.name)
   expect(reparsedNet.wires).toHaveLength(originalNet.wires.length)
 })
+
+test("stringify session preserves filenames with spaces", () => {
+  const sessionJson = parseDsnToDsnJson(`(session "routed output.ses"
+    (base_design board.dsn)
+    (placement
+      (resolution um 10)
+    )
+    (was_is)
+    (routes
+      (resolution um 10)
+      (parser
+        (host_cad "freerouting")
+        (host_version "1.0")
+      )
+      (network_out)
+    )
+  )`) as DsnSession
+
+  const stringified = stringifyDsnSession(sessionJson)
+  const reparsed = parseDsnToDsnJson(stringified) as DsnSession
+
+  expect(reparsed.filename).toBe("routed output.ses")
+})


### PR DESCRIPTION
Summary
- Quote the top-level DSN session filename in `stringifyDsnSession`.
- Add a regression proving a quoted session filename containing spaces survives parse -> stringify -> parse.
- Keep this scoped to the session filename field, separate from DSN PCB string escaping and other session metadata PRs.

Bounty
/claim #54

Verification
- `bun test tests/dsn-pcb/stringify-dsn-session.test.ts`
- `bunx biome check lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-session.ts tests/dsn-pcb/stringify-dsn-session.test.ts`
- `bunx tsc --noEmit`
- `bun test`
- `bun run build`
- `git diff --check`

Transparency note: AI-assisted with Codex; I reviewed the diff and verified it locally before submission.