### PR TITLE
Parse SPECCTRA circ shape aliases

### DIFF
--- a/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
@@ -683,6 +683,7 @@ function processShape(nodes: ASTNode[]): Shape {
         case "polygon":
           return processPolygonShape(shapeContentNode.children!)
         case "circle":
+        case "circ":
           return processCircleShape(shapeContentNode.children!)
         case "rect":
           return processRectShape(shapeContentNode.children!)
@@ -764,7 +765,7 @@ function processCircleShape(nodes: ASTNode[]): CircleShape {
     shapeType: "circle",
   }
 
-  // Handle both direct circle nodes and nested shape nodes
+  // Handle both direct circle/circ nodes and nested shape nodes
   const shapeNodes = nodes[0].value === "shape" ? nodes[1].children! : nodes
 
   if (

--- a/tests/dsn-pcb/parse-circ-shape-alias.test.ts
+++ b/tests/dsn-pcb/parse-circ-shape-alias.test.ts
@@ -1,0 +1,71 @@
+import { expect, test } from "bun:test"
+import { type DsnPcb, parseDsnToDsnJson, stringifyDsnJson } from "lib"
+
+const circAliasDsn = `(pcb circ-alias.dsn
+  (parser
+    (string_quote ")
+    (space_in_quoted_tokens on)
+    (host_cad "test")
+    (host_version "1")
+  )
+  (resolution um 10)
+  (unit um)
+  (structure
+    (layer F.Cu
+      (type signal)
+      (property
+        (index 0)
+      )
+    )
+    (layer B.Cu
+      (type signal)
+      (property
+        (index 1)
+      )
+    )
+    (boundary
+      (path pcb 0 0 0 1000 0 1000 1000 0 1000 0 0)
+    )
+    (via ViaAlias)
+    (rule
+      (width 100)
+      (clearance 100)
+    )
+  )
+  (placement)
+  (library
+    (padstack ViaAlias
+      (shape (circ F.Cu 600))
+      (shape (circ B.Cu 600))
+      (attach off)
+    )
+  )
+  (network)
+  (wiring)
+)`
+
+test("parses SPECCTRA circ shape aliases as circle shapes", () => {
+  const dsnJson = parseDsnToDsnJson(circAliasDsn) as DsnPcb
+  const [padstack] = dsnJson.library.padstacks
+
+  expect(padstack.shapes).toHaveLength(2)
+  expect(padstack.shapes.map((shape) => shape.shapeType)).toEqual([
+    "circle",
+    "circle",
+  ])
+  expect(padstack.shapes).toEqual([
+    { shapeType: "circle", layer: "F.Cu", diameter: 600 },
+    { shapeType: "circle", layer: "B.Cu", diameter: 600 },
+  ])
+})
+
+test("round-trips circ aliases through normalized circle output", () => {
+  const dsnJson = parseDsnToDsnJson(circAliasDsn) as DsnPcb
+  const dsnString = stringifyDsnJson(dsnJson)
+  const reparsedJson = parseDsnToDsnJson(dsnString) as DsnPcb
+
+  expect(dsnString).toContain("(shape (circle F.Cu 600))")
+  expect(reparsedJson.library.padstacks[0].shapes).toEqual(
+    dsnJson.library.padstacks[0].shapes,
+  )
+})


### PR DESCRIPTION
Fixes a focused DSN parser compatibility gap under #54.

`/claim #54`

SPECCTRA sample files can use `circ` as the circle shape keyword, for example `(shape (circ L1 30))`, but the parser only dispatched `circle`. This accepts `circ` in the existing circle shape path and normalizes it to the current `CircleShape` JSON representation, so downstream conversion and stringification continue to use `shapeType: "circle"`.

Added regression coverage for:
- parsing `(shape (circ ...))` padstack shapes
- parse -> stringify -> parse round-trip with normalized `(shape (circle ...))` output

AI-assisted with Codex; I reviewed the change and ran the checks locally.

Verification:
- `bun test tests/dsn-pcb/parse-circ-shape-alias.test.ts`
- `bun x biome check lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts tests/dsn-pcb/parse-circ-shape-alias.test.ts`
- `bun x tsc --noEmit`
- `bun run build`
- `bun test`
- `git diff --check`