### PR TITLE
Quote PCB filenames when stringifying

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
@@ -27,7 +27,7 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
   }
 
   // Start with pcb
-  result += `(pcb ${dsnJson.filename ? dsnJson.filename : "./converted_dsn.dsn"}\n`
+  result += `(pcb ${stringifyValue(dsnJson.filename || "./converted_dsn.dsn")}\n`
 
   // Parser section
   result += `${indent}(parser\n`

--- a/tests/dsn-pcb/stringify-dsn-json.test.ts
+++ b/tests/dsn-pcb/stringify-dsn-json.test.ts
@@ -17,3 +17,43 @@ test("stringify dsn json", () => {
   // Test that we can parse the generated string back to the same structure
   // expect(reparsedJson).toEqual(dsnJson)
 })
+
+test("stringify dsn json preserves filenames with spaces", () => {
+  const dsnJson = parseDsnToDsnJson(`(pcb "routed board.dsn"
+    (parser
+      (string_quote ")
+      (space_in_quoted_tokens on)
+      (host_cad "KiCad")
+      (host_version "1.0")
+    )
+    (resolution um 10)
+    (unit um)
+    (structure
+      (layer F.Cu
+        (type signal)
+        (property
+          (index 0)
+        )
+      )
+      (boundary
+        (path F.Cu 0 0 0 1000 0 1000 1000 0 1000 0 0)
+      )
+      (via "Via[0-1]_600:300_um")
+      (rule
+        (width 100)
+        (clearance 100)
+      )
+    )
+    (placement)
+    (library)
+    (network)
+    (wiring)
+  )`) as DsnPcb
+
+  const dsnString = stringifyDsnJson(dsnJson)
+  const reparsedJson = parseDsnToDsnJson(dsnString) as DsnPcb
+
+  expect(dsnJson.filename).toBe("routed board.dsn")
+  expect(dsnString).toStartWith('(pcb "routed board.dsn"')
+  expect(reparsedJson.filename).toBe("routed board.dsn")
+})


### PR DESCRIPTION
Summary
- Quote the top-level DSN PCB filename in `stringifyDsnJson`.
- Add a regression proving a quoted PCB filename containing spaces survives parse -> stringify -> parse.
- Keep this scoped to DSN PCB filenames, separate from PR #286 session filename quoting and PR #275 parser string-quote/string escaping.

Bounty
/claim #54

Verification
- `bun test tests/dsn-pcb/stringify-dsn-json.test.ts`
- `bunx biome check lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts tests/dsn-pcb/stringify-dsn-json.test.ts`
- `bunx tsc --noEmit`
- `bun test`
- `bun run build`
- `git diff --check`

Transparency note: AI-assisted with Codex; I reviewed the diff and verified it locally before submission.