### PR TITLE
Preserve padstack hole metadata in DSN round trips

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
@@ -26,6 +26,17 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
     return `${padding}(path ${path.layer} ${path.width}  ${stringifyCoordinates(path.coordinates)})`
   }
 
+  const stringifyPadstackHole = (hole: any): string => {
+    if (!hole) return ""
+    if (hole.shape === "circle") {
+      return `(hole (circle ${hole.diameter}))`
+    }
+    if (hole.shape === "square" || hole.shape === "oval") {
+      return `(hole (${hole.shape} ${hole.width} ${hole.height}))`
+    }
+    return ""
+  }
+
   // Start with pcb
   result += `(pcb ${dsnJson.filename ? dsnJson.filename : "./converted_dsn.dsn"}\n`
 
@@ -101,6 +112,10 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
         result += `${indent}${indent}${indent}(shape (path ${shape.layer} ${shape.width} ${stringifyCoordinates(shape.coordinates)}))\n`
       }
     })
+    const hole = stringifyPadstackHole(padstack.hole)
+    if (hole) {
+      result += `${indent}${indent}${indent}${hole}\n`
+    }
     result += `${indent}${indent}${indent}(attach ${padstack.attach})\n`
     result += `${indent}${indent})\n`
   })

--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-session.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-session.ts
@@ -4,6 +4,17 @@ export const stringifyDsnSession = (session: DsnSession): string => {
   const indent = "  "
   let result = ""
 
+  const stringifyPadstackHole = (hole: any): string => {
+    if (!hole) return ""
+    if (hole.shape === "circle") {
+      return `(hole (circle ${hole.diameter}))`
+    }
+    if (hole.shape === "square" || hole.shape === "oval") {
+      return `(hole (${hole.shape} ${hole.width} ${hole.height}))`
+    }
+    return ""
+  }
+
   // Start with session
   result += `(session ${session.filename}\n`
 
@@ -47,6 +58,10 @@ export const stringifyDsnSession = (session: DsnSession): string => {
           result += `${indent}${indent}${indent}${indent})\n`
         }
       })
+      const hole = stringifyPadstackHole(padstack.hole)
+      if (hole) {
+        result += `${indent}${indent}${indent}${indent}${hole}\n`
+      }
       result += `${indent}${indent}${indent}${indent}(attach ${padstack.attach})\n`
       result += `${indent}${indent}${indent})\n`
     })

--- a/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
@@ -655,6 +655,8 @@ function processPadstack(nodes: ASTNode[]): Padstack {
         const key = keyNode.value
         if (key === "shape") {
           padstack.shapes!.push(processShape(node.children!))
+        } else if (key === "hole") {
+          padstack.hole = processPadstackHole(node.children!)
         } else if (key === "attach") {
           if (rest[0].type === "Atom" && typeof rest[0].value === "string") {
             padstack.attach = rest[0].value
@@ -665,6 +667,39 @@ function processPadstack(nodes: ASTNode[]): Padstack {
   })
 
   return padstack as Padstack
+}
+
+function processPadstackHole(nodes: ASTNode[]): Padstack["hole"] {
+  const isNested = nodes[1]?.type === "List" && !!nodes[1].children
+  const holeNodes = isNested ? nodes[1].children! : nodes
+  const shapeNode = holeNodes[isNested ? 0 : 1]
+
+  if (shapeNode?.type !== "Atom" || typeof shapeNode.value !== "string") {
+    throw new Error("Invalid padstack hole format: missing hole shape")
+  }
+
+  const shape = shapeNode.value
+  if (shape !== "circle" && shape !== "square" && shape !== "oval") {
+    throw new Error(`Unsupported padstack hole shape: ${shape}`)
+  }
+
+  const numericValues = holeNodes
+    .slice(isNested ? 1 : 2)
+    .filter((node) => node.type === "Atom" && typeof node.value === "number")
+    .map((node) => node.value as number)
+
+  if (shape === "circle") {
+    if (numericValues[0] === undefined) {
+      throw new Error("Invalid circular padstack hole format: missing diameter")
+    }
+    return { shape, diameter: numericValues[0] }
+  }
+
+  if (numericValues[0] === undefined || numericValues[1] === undefined) {
+    throw new Error(`Invalid ${shape} padstack hole format: missing dimensions`)
+  }
+
+  return { shape, width: numericValues[0], height: numericValues[1] }
 }
 
 function processShape(nodes: ASTNode[]): Shape {

--- a/tests/dsn-pcb/stringify-dsn-json.test.ts
+++ b/tests/dsn-pcb/stringify-dsn-json.test.ts
@@ -17,3 +17,55 @@ test("stringify dsn json", () => {
   // Test that we can parse the generated string back to the same structure
   // expect(reparsedJson).toEqual(dsnJson)
 })
+
+test("stringify dsn json preserves padstack hole metadata", () => {
+  const dsnJson: DsnPcb = {
+    is_dsn_pcb: true,
+    filename: "hole-test.dsn",
+    parser: {
+      string_quote: '"',
+      space_in_quoted_tokens: "on",
+      host_cad: "test",
+      host_version: "test",
+    },
+    resolution: { unit: "um", value: 10 },
+    unit: "um",
+    structure: {
+      layers: [
+        { name: "F.Cu", type: "signal", property: { index: 0 } },
+        { name: "B.Cu", type: "signal", property: { index: 1 } },
+      ],
+      boundary: {
+        path: { layer: "pcb", width: 0, coordinates: [0, 0, 1000, 0] },
+      },
+      via: "Via[0-1]_600:300_um",
+      rule: { width: 100, clearances: [] },
+    },
+    placement: { components: [] },
+    library: {
+      images: [],
+      padstacks: [
+        {
+          name: "Via[0-1]_600:300_um",
+          shapes: [
+            { shapeType: "circle", layer: "F.Cu", diameter: 600 },
+            { shapeType: "circle", layer: "B.Cu", diameter: 600 },
+          ],
+          hole: { shape: "circle", diameter: 300 },
+          attach: "off",
+        },
+      ],
+    },
+    network: { nets: [], classes: [] },
+    wiring: { wires: [] },
+  }
+
+  const dsnString = stringifyDsnJson(dsnJson)
+  expect(dsnString).toContain("(hole (circle 300))")
+
+  const reparsedJson = parseDsnToDsnJson(dsnString) as DsnPcb
+  expect(reparsedJson.library.padstacks[0].hole).toEqual({
+    shape: "circle",
+    diameter: 300,
+  })
+})

--- a/tests/dsn-pcb/stringify-dsn-session.test.ts
+++ b/tests/dsn-pcb/stringify-dsn-session.test.ts
@@ -25,3 +25,47 @@ test("stringify session file", () => {
   expect(reparsedNet.name).toBe(originalNet.name)
   expect(reparsedNet.wires).toHaveLength(originalNet.wires.length)
 })
+
+test("stringify session file preserves library_out padstack holes", () => {
+  const sessionJson: DsnSession = {
+    is_dsn_session: true,
+    filename: "hole-test.ses",
+    placement: {
+      resolution: { unit: "um", value: 10 },
+      components: [],
+    },
+    routes: {
+      resolution: { unit: "um", value: 10 },
+      parser: {
+        string_quote: '"',
+        space_in_quoted_tokens: "on",
+        host_cad: "test",
+        host_version: "test",
+      },
+      library_out: {
+        images: [],
+        padstacks: [
+          {
+            name: "Via[0-1]_600:300_um",
+            shapes: [
+              { shapeType: "circle", layer: "F.Cu", diameter: 600 },
+              { shapeType: "circle", layer: "B.Cu", diameter: 600 },
+            ],
+            hole: { shape: "circle", diameter: 300 },
+            attach: "off",
+          },
+        ],
+      },
+      network_out: { nets: [] },
+    },
+  }
+
+  const stringified = stringifyDsnSession(sessionJson)
+  expect(stringified).toContain("(hole (circle 300))")
+
+  const reparsed = parseDsnToDsnJson(stringified) as DsnSession
+  expect(reparsed.routes.library_out?.padstacks[0].hole).toEqual({
+    shape: "circle",
+    diameter: 300,
+  })
+})


### PR DESCRIPTION
Fixes another focused DSN round-trip data-loss gap for #54.

Padstacks can already carry drill hole metadata in the internal `Padstack.hole` model, and plated-hole/via export paths populate it, but both DSN stringifiers dropped that metadata. The parser also ignored `(hole ...)` entries, so generated DSN/session files could not preserve explicit padstack drill dimensions across parse -> stringify -> parse.

Changes:
- Parse padstack `(hole (circle ...))`, `(hole (oval ... ...))`, and `(hole (square ... ...))` metadata.
- Emit padstack hole metadata from `stringifyDsnJson`.
- Emit session `library_out` padstack hole metadata from `stringifyDsnSession`.
- Add focused PCB and session round-trip regressions.

Verification:
- `npm run build`
- `npx bun test tests/dsn-pcb/stringify-dsn-json.test.ts tests/dsn-pcb/stringify-dsn-session.test.ts`