### PR TITLE
Quote session placement identifiers

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-session.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-session.ts
@@ -14,9 +14,9 @@ export const stringifyDsnSession = (session: DsnSession): string => {
   result += `${indent}(placement\n`
   result += `${indent}${indent}(resolution ${session.placement.resolution.unit} ${session.placement.resolution.value})\n`
   session.placement.components.forEach((component) => {
-    result += `${indent}${indent}(component ${component.name}\n`
+    result += `${indent}${indent}(component ${JSON.stringify(component.name)}\n`
     component.places.forEach((place) => {
-      result += `${indent}${indent}${indent}(place ${place.refdes} ${place.x} ${place.y} ${place.side} ${place.rotation})\n`
+      result += `${indent}${indent}${indent}(place ${JSON.stringify(place.refdes)} ${place.x} ${place.y} ${place.side} ${place.rotation})\n`
     })
     result += `${indent}${indent})\n`
   })

--- a/tests/dsn-pcb/stringify-dsn-session.test.ts
+++ b/tests/dsn-pcb/stringify-dsn-session.test.ts
@@ -25,3 +25,36 @@ test("stringify session file", () => {
   expect(reparsedNet.name).toBe(originalNet.name)
   expect(reparsedNet.wires).toHaveLength(originalNet.wires.length)
 })
+
+test("stringify session preserves placement identifiers with spaces", () => {
+  const sessionJson = parseDsnToDsnJson(`(session routed.ses
+    (base_design board.dsn)
+    (placement
+      (resolution um 10)
+      (component "USB Connector"
+        (place "J 1" 1250 2500 front 90)
+      )
+    )
+    (was_is)
+    (routes
+      (resolution um 10)
+      (parser
+        (host_cad "freerouting")
+        (host_version "1.0")
+      )
+      (network_out)
+    )
+  )`) as DsnSession
+
+  const stringified = stringifyDsnSession(sessionJson)
+  const reparsed = parseDsnToDsnJson(stringified) as DsnSession
+  const component = reparsed.placement.components[0]
+  const place = component.places[0]
+
+  expect(component.name).toBe("USB Connector")
+  expect(place.refdes).toBe("J 1")
+  expect(place.x).toBe(1250)
+  expect(place.y).toBe(2500)
+  expect(place.side).toBe("front")
+  expect(place.rotation).toBe(90)
+})


### PR DESCRIPTION
Summary
- Quote DSN session placement component names and refdes values in `stringifyDsnSession`.
- Add a regression proving quoted placement identifiers containing spaces keep their coordinates through parse -> stringify -> parse.
- Keep this scoped to session placement identifiers, separate from PR #286 session filename quoting, PR #275 DSN PCB string escaping, and PR #280 placement PN metadata.

Bounty
/claim #54

Verification
- `bun test tests/dsn-pcb/stringify-dsn-session.test.ts`
- `bunx biome check lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-session.ts tests/dsn-pcb/stringify-dsn-session.test.ts`
- `bunx tsc --noEmit`
- `bun test`
- `bun run build`
- `git diff --check`

Transparency note: AI-assisted with Codex; I reviewed the diff and verified it locally before submission.