### PR TITLE
Preserve DSN autoroute settings

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
@@ -26,6 +26,69 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
     return `${padding}(path ${path.layer} ${path.width}  ${stringifyCoordinates(path.coordinates)})`
   }
 
+  const stringifyAutorouteSettings = (
+    settings: NonNullable<DsnPcb["structure"]["autoroute_settings"]>,
+    level: number,
+  ): string => {
+    const padding = indent.repeat(level)
+    const childPadding = indent.repeat(level + 1)
+    const lines = [`${padding}(autoroute_settings`]
+
+    if (settings.fanout !== undefined) {
+      lines.push(`${childPadding}(fanout ${settings.fanout})`)
+    }
+    if (settings.autoroute !== undefined) {
+      lines.push(`${childPadding}(autoroute ${settings.autoroute})`)
+    }
+    if (settings.postroute !== undefined) {
+      lines.push(`${childPadding}(postroute ${settings.postroute})`)
+    }
+    if (settings.vias !== undefined) {
+      lines.push(`${childPadding}(vias ${settings.vias})`)
+    }
+    if (settings.via_costs !== undefined) {
+      lines.push(`${childPadding}(via_costs ${settings.via_costs})`)
+    }
+    if (settings.plane_via_costs !== undefined) {
+      lines.push(`${childPadding}(plane_via_costs ${settings.plane_via_costs})`)
+    }
+    if (settings.start_ripup_costs !== undefined) {
+      lines.push(
+        `${childPadding}(start_ripup_costs ${settings.start_ripup_costs})`,
+      )
+    }
+    if (settings.start_pass_no !== undefined) {
+      lines.push(`${childPadding}(start_pass_no ${settings.start_pass_no})`)
+    }
+
+    settings.layer_rules.forEach((layerRule) => {
+      lines.push(`${childPadding}(layer_rule ${layerRule.layer}`)
+      const layerRulePadding = indent.repeat(level + 2)
+      if (layerRule.active !== undefined) {
+        lines.push(`${layerRulePadding}(active ${layerRule.active})`)
+      }
+      if (layerRule.preferred_direction !== undefined) {
+        lines.push(
+          `${layerRulePadding}(preferred_direction ${layerRule.preferred_direction})`,
+        )
+      }
+      if (layerRule.preferred_direction_trace_costs !== undefined) {
+        lines.push(
+          `${layerRulePadding}(preferred_direction_trace_costs ${layerRule.preferred_direction_trace_costs})`,
+        )
+      }
+      if (layerRule.against_preferred_direction_trace_costs !== undefined) {
+        lines.push(
+          `${layerRulePadding}(against_preferred_direction_trace_costs ${layerRule.against_preferred_direction_trace_costs})`,
+        )
+      }
+      lines.push(`${childPadding})`)
+    })
+
+    lines.push(`${padding})`)
+    return lines.join("\n")
+  }
+
   // Start with pcb
   result += `(pcb ${dsnJson.filename ? dsnJson.filename : "./converted_dsn.dsn"}\n`
 
@@ -63,6 +126,9 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
     result += `${indent}${indent}${indent}(clearance ${clearance.value}${clearance.type ? ` (type ${clearance.type})` : ""})\n`
   })
   result += `${indent}${indent})\n`
+  if (dsnJson.structure.autoroute_settings) {
+    result += `${stringifyAutorouteSettings(dsnJson.structure.autoroute_settings, 2)}\n`
+  }
   result += `${indent})\n`
 
   // Placement section

--- a/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
@@ -7,6 +7,7 @@ import {
   tokenizeDsn,
 } from "../../common/parse-sexpr"
 import type {
+  AutorouteSettings,
   Boundary,
   CircleShape,
   Circuit,
@@ -19,6 +20,7 @@ import type {
   DsnSession,
   Image,
   Layer,
+  LayerRule,
   Library,
   Net,
   Network,
@@ -236,12 +238,87 @@ export function processStructure(nodes: ASTNode[]): Structure {
           case "rule":
             structure.rule = processRule(node.children!.slice(1))
             break
+          case "autoroute_settings":
+            structure.autoroute_settings = processAutorouteSettings(
+              node.children!.slice(1),
+            )
+            break
         }
       }
     }
   })
 
   return structure as Structure
+}
+
+function getAtomValue(node: ASTNode | undefined): string | number | undefined {
+  if (node?.type !== "Atom") return undefined
+  if (typeof node.value === "string" || typeof node.value === "number") {
+    return node.value
+  }
+  return undefined
+}
+
+function processAutorouteSettings(nodes: ASTNode[]): AutorouteSettings {
+  const settings: AutorouteSettings = {
+    layer_rules: [],
+  }
+
+  nodes.forEach((node) => {
+    if (node.type !== "List") return
+
+    const [keyNode, valueNode] = node.children!
+    if (keyNode.type !== "Atom" || typeof keyNode.value !== "string") return
+
+    const value = getAtomValue(valueNode)
+    switch (keyNode.value) {
+      case "fanout":
+      case "autoroute":
+      case "postroute":
+      case "vias":
+        if (value !== undefined) settings[keyNode.value] = String(value)
+        break
+      case "via_costs":
+      case "plane_via_costs":
+      case "start_ripup_costs":
+      case "start_pass_no":
+        if (typeof value === "number") settings[keyNode.value] = value
+        break
+      case "layer_rule":
+        settings.layer_rules.push(processLayerRule(node.children!))
+        break
+    }
+  })
+
+  return settings
+}
+
+function processLayerRule(nodes: ASTNode[]): LayerRule {
+  const layerRule: Partial<LayerRule> = {}
+
+  const layer = getAtomValue(nodes[1])
+  if (layer !== undefined) layerRule.layer = String(layer)
+
+  nodes.slice(2).forEach((node) => {
+    if (node.type !== "List") return
+
+    const [keyNode, valueNode] = node.children!
+    if (keyNode.type !== "Atom" || typeof keyNode.value !== "string") return
+
+    const value = getAtomValue(valueNode)
+    switch (keyNode.value) {
+      case "active":
+      case "preferred_direction":
+        if (value !== undefined) layerRule[keyNode.value] = String(value)
+        break
+      case "preferred_direction_trace_costs":
+      case "against_preferred_direction_trace_costs":
+        if (typeof value === "number") layerRule[keyNode.value] = value
+        break
+    }
+  })
+
+  return layerRule as LayerRule
 }
 
 function processLayer(nodes: ASTNode[]): Layer {

--- a/lib/dsn-pcb/types.ts
+++ b/lib/dsn-pcb/types.ts
@@ -38,6 +38,7 @@ export interface DsnPcb {
       }>
       width: number
     }
+    autoroute_settings?: AutorouteSettings
   }
   placement: {
     components: Array<ComponentPlacement>
@@ -112,6 +113,27 @@ export interface Structure {
   boundary: Boundary
   via: string
   rule: Rule
+  autoroute_settings?: AutorouteSettings
+}
+
+export interface AutorouteSettings {
+  fanout?: string
+  autoroute?: string
+  postroute?: string
+  vias?: string
+  via_costs?: number
+  plane_via_costs?: number
+  start_ripup_costs?: number
+  start_pass_no?: number
+  layer_rules: LayerRule[]
+}
+
+export interface LayerRule {
+  layer: string
+  active?: string
+  preferred_direction?: string
+  preferred_direction_trace_costs?: number
+  against_preferred_direction_trace_costs?: number
 }
 
 export interface Layer {

--- a/tests/dsn-pcb/dsn-autoroute-settings.test.ts
+++ b/tests/dsn-pcb/dsn-autoroute-settings.test.ts
@@ -1,0 +1,72 @@
+import { expect, test } from "bun:test"
+import { type DsnPcb, parseDsnToDsnJson, stringifyDsnJson } from "lib"
+
+test("preserves autoroute settings and layer rules when stringifying dsn json", () => {
+  const dsnString = `(pcb "router-output.dsn"
+  (parser
+    (string_quote ")
+    (space_in_quoted_tokens on)
+    (host_cad "KiCad's Pcbnew")
+    (host_version "8.0")
+  )
+  (resolution um 10)
+  (unit um)
+  (structure
+    (layer F.Cu
+      (type signal)
+      (property
+        (index 0)
+      )
+    )
+    (layer B.Cu
+      (type signal)
+      (property
+        (index 1)
+      )
+    )
+    (boundary
+      (path pcb 0 0 0 1000 0 1000 1000 0 1000 0 0)
+    )
+    (via "Via[0-1]_600:300_um")
+    (rule
+      (width 200)
+      (clearance 200)
+    )
+    (autoroute_settings
+      (fanout off)
+      (autoroute on)
+      (postroute on)
+      (vias on)
+      (via_costs 50)
+      (plane_via_costs 5)
+      (start_ripup_costs 100)
+      (start_pass_no 4)
+      (layer_rule F.Cu
+        (active on)
+        (preferred_direction horizontal)
+        (preferred_direction_trace_costs 1.0)
+        (against_preferred_direction_trace_costs 2.7)
+      )
+      (layer_rule B.Cu
+        (active on)
+        (preferred_direction vertical)
+        (preferred_direction_trace_costs 1.0)
+        (against_preferred_direction_trace_costs 1.6)
+      )
+    )
+  )
+  (placement)
+  (library)
+  (network)
+  (wiring)
+)`
+
+  const dsnJson = parseDsnToDsnJson(dsnString) as DsnPcb
+  const dsnOutput = stringifyDsnJson(dsnJson)
+  const reparsedJson = parseDsnToDsnJson(dsnOutput) as DsnPcb
+
+  expect(dsnOutput).toContain("(autoroute_settings")
+  expect(reparsedJson.structure.autoroute_settings).toEqual(
+    dsnJson.structure.autoroute_settings,
+  )
+})


### PR DESCRIPTION
/claim #54

## Summary

- Preserve DSN `structure` autoroute settings through parse -> stringify -> parse.
- Parse and emit Freerouting/KiCad fields such as `fanout`, `autoroute`, `postroute`, `vias`, route costs, and per-layer `layer_rule` preferences.
- Add a focused regression test for `autoroute_settings` and two layer rules.

## Verification

- `bun test tests\dsn-pcb\dsn-autoroute-settings.test.ts`
- `bun x biome check lib\dsn-pcb\types.ts lib\dsn-pcb\dsn-json-to-circuit-json\parse-dsn-to-dsn-json.ts lib\dsn-pcb\circuit-json-to-dsn-json\stringify-dsn-json.ts tests\dsn-pcb\dsn-autoroute-settings.test.ts`
- `bun x tsc --noEmit`
- `bun run build`
- `git diff --check`

I also ran `bun test` locally on Windows. It gets through the new regression but the full suite has existing Windows-environment failures unrelated to this change: two debug helper mkdir paths include an absolute Windows path under `debug-files`, and `stringify-dsn-json.test.ts` compares CRLF fixture parser text against LF stringified output.