### PR TITLE
Preserve top-level network via rules

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
@@ -115,6 +115,11 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
     }
     result += `${indent}${indent})\n`
   })
+  dsnJson.network.via_rules?.forEach((viaRule) => {
+    result += `${indent}${indent}(via_rule\n`
+    result += `${indent}${indent}${indent}${stringifyValue(viaRule.name)} ${stringifyValue(viaRule.padstack)}\n`
+    result += `${indent}${indent})\n`
+  })
   dsnJson.network.classes.forEach((cls) => {
     result += `${indent}${indent}(class ${stringifyValue(cls.name)} ${stringifyValue(cls.description)}${cls.net_names.map((n) => ` ${stringifyValue(n)}`).join("")}\n`
     result += `${indent}${indent}${indent}(circuit\n`

--- a/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
@@ -36,6 +36,7 @@ import type {
   Rule,
   Shape,
   Structure,
+  ViaRule,
   Wire,
   Wiring,
 } from "../types"
@@ -796,6 +797,7 @@ function processCircleShape(nodes: ASTNode[]): CircleShape {
 export function processNetwork(nodes: ASTNode[]): Network {
   const network: Partial<Network> = {
     nets: [],
+    via_rules: [],
     classes: [],
   }
 
@@ -806,6 +808,8 @@ export function processNetwork(nodes: ASTNode[]): Network {
         const key = keyNode.value
         if (key === "net") {
           network.nets!.push(processNet(node.children!))
+        } else if (key === "via_rule") {
+          network.via_rules!.push(processViaRule(node.children!))
         } else if (key === "class") {
           network.classes!.push(processClass(node.children!))
         }
@@ -840,6 +844,13 @@ function processNet(nodes: ASTNode[]): Net {
     }
   })
   return net as Net
+}
+
+function processViaRule(nodes: ASTNode[]): ViaRule {
+  return {
+    name: nodes[1]?.value?.toString() ?? "",
+    padstack: nodes[2]?.value?.toString() ?? "",
+  }
 }
 
 function processClass(nodes: ASTNode[]): Class {

--- a/lib/dsn-pcb/types.ts
+++ b/lib/dsn-pcb/types.ts
@@ -51,6 +51,10 @@ export interface DsnPcb {
       name: string
       pins: string[]
     }>
+    via_rules?: Array<{
+      name: string
+      padstack: string
+    }>
     classes: Array<{
       name: string
       description: string
@@ -244,12 +248,18 @@ export interface PathShape extends BaseShape {
 
 export interface Network {
   nets: Net[]
+  via_rules?: ViaRule[]
   classes: Class[]
 }
 
 export interface Net {
   name: string
   pins: string[]
+}
+
+export interface ViaRule {
+  name: string
+  padstack: string
 }
 
 export interface Class {

--- a/tests/dsn-pcb/stringify-dsn-json.test.ts
+++ b/tests/dsn-pcb/stringify-dsn-json.test.ts
@@ -17,3 +17,63 @@ test("stringify dsn json", () => {
   // Test that we can parse the generated string back to the same structure
   // expect(reparsedJson).toEqual(dsnJson)
 })
+
+test("preserves top-level network via rules", () => {
+  const dsnWithViaRules = `(pcb via-rule-test
+  (parser
+    (string_quote "")
+    (space_in_quoted_tokens on)
+    (host_cad "fixture")
+    (host_version "1")
+  )
+  (resolution um 10)
+  (unit um)
+  (structure
+    (layer F.Cu
+      (type signal)
+      (property
+        (index 0)
+      )
+    )
+    (via "Via[0-1]_600:300_um")
+    (rule
+      (width 100)
+      (clearance 100)
+    )
+  )
+  (placement)
+  (library)
+  (network
+    (net GND
+      (pins U1-1)
+    )
+    (via_rule
+      default "Via[0-1]_600:300_um"
+    )
+    (via_rule
+      "fine_pitch" "Via[0-1]_300:150_um"
+    )
+    (class default "" GND
+      (circuit
+        (use_via default)
+      )
+      (rule
+        (width 100)
+        (clearance 100)
+      )
+    )
+  )
+  (wiring)
+)`
+
+  const dsnJson = parseDsnToDsnJson(dsnWithViaRules) as DsnPcb
+
+  expect(dsnJson.network.via_rules).toEqual([
+    { name: "default", padstack: "Via[0-1]_600:300_um" },
+    { name: "fine_pitch", padstack: "Via[0-1]_300:150_um" },
+  ])
+
+  const reparsedJson = parseDsnToDsnJson(stringifyDsnJson(dsnJson)) as DsnPcb
+
+  expect(reparsedJson.network.via_rules).toEqual(dsnJson.network.via_rules)
+})


### PR DESCRIPTION
/claim #54

## Summary
- add `network.via_rules` to the DSN PCB JSON model
- parse top-level Freerouting-style `(via_rule name padstack)` entries from `network`
- stringify preserved top-level via rules back into DSN output
- add a focused parse -> stringify -> parse regression for top-level network via rules

## Why
Freerouting/KiCad DSN files can define top-level network via rules and then reference them from class circuit metadata. `processNetwork` currently keeps nets and classes but drops those top-level via rule definitions, so parse -> stringify -> parse loses routing metadata.

## Verification
- `bun x biome check lib\\dsn-pcb\\types.ts lib\\dsn-pcb\\dsn-json-to-circuit-json\\parse-dsn-to-dsn-json.ts lib\\dsn-pcb\\circuit-json-to-dsn-json\\stringify-dsn-json.ts tests\\dsn-pcb\\stringify-dsn-json.test.ts`
- `bun x tsc --noEmit`
- `git diff --check`
- `bun test tests\\dsn-pcb\\stringify-dsn-json.test.ts -t "preserves top-level network via rules"`
- `bun test tests\\repros\\repro7-smoothie-board.test.ts`
- `bun test tests\\dsn-pcb\\multi-layer-support.test.ts`
- `bun test tests\\dsn-pcb\\parse-dsn-json-to-circuit-json.test.ts`

Note: the full `tests/dsn-pcb/stringify-dsn-json.test.ts` file still has an existing unrelated `string_quote` round-trip failure that is already covered by separate work.