### PR TITLE
Quote PCB placement refdes when stringifying

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
@@ -71,7 +71,7 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
     result += `${indent}${indent}(component ${stringifyValue(component.name)}\n`
     if (component.places) {
       component.places.forEach((place) => {
-        result += `${indent}${indent}${indent}(place ${place.refdes} ${place.x} ${place.y} ${place.side} ${place.rotation}${place.PN ? ` (PN ${stringifyValue(place.PN)})` : ""})\n`
+        result += `${indent}${indent}${indent}(place ${stringifyValue(place.refdes)} ${place.x} ${place.y} ${place.side} ${place.rotation}${place.PN ? ` (PN ${stringifyValue(place.PN)})` : ""})\n`
       })
     }
     result += `${indent}${indent})\n`

--- a/tests/dsn-pcb/stringify-dsn-json.test.ts
+++ b/tests/dsn-pcb/stringify-dsn-json.test.ts
@@ -17,3 +17,50 @@ test("stringify dsn json", () => {
   // Test that we can parse the generated string back to the same structure
   // expect(reparsedJson).toEqual(dsnJson)
 })
+
+test("stringify dsn json preserves placement refdes with spaces", () => {
+  const dsnJson = parseDsnToDsnJson(`(pcb board.dsn
+    (parser
+      (string_quote ")
+      (space_in_quoted_tokens on)
+      (host_cad "KiCad")
+      (host_version "1.0")
+    )
+    (resolution um 10)
+    (unit um)
+    (structure
+      (layer F.Cu
+        (type signal)
+        (property
+          (index 0)
+        )
+      )
+      (boundary
+        (path F.Cu 0 0 0 1000 0 1000 1000 0 1000 0 0)
+      )
+      (via "Via[0-1]_600:300_um")
+      (rule
+        (width 100)
+        (clearance 100)
+      )
+    )
+    (placement
+      (component "USB Connector"
+        (place "J 1" 1250 2500 front 90)
+      )
+    )
+    (library)
+    (network)
+    (wiring)
+  )`) as DsnPcb
+
+  const dsnString = stringifyDsnJson(dsnJson)
+  const reparsedJson = parseDsnToDsnJson(dsnString) as DsnPcb
+  const place = reparsedJson.placement.components[0].places[0]
+
+  expect(place.refdes).toBe("J 1")
+  expect(place.x).toBe(1250)
+  expect(place.y).toBe(2500)
+  expect(place.side).toBe("front")
+  expect(place.rotation).toBe(90)
+})

--- a/tests/repros/repro15-dsn-scaling.test.tsx
+++ b/tests/repros/repro15-dsn-scaling.test.tsx
@@ -50,6 +50,6 @@ test("repro-coordinates-10x-too-large-with-circuit", async () => {
   expect(dsnString).toContain("(resolution um 10)")
 
   // Verify faulty coordinates (confirming the bug exists)
-  expect(dsnString).toContain("(place R1_source_component_0 -4000 0 front 0")
-  expect(dsnString).toContain("(place R2_source_component_1 4000 0 front 0")
+  expect(dsnString).toContain('(place "R1_source_component_0" -4000 0 front 0')
+  expect(dsnString).toContain('(place "R2_source_component_1" 4000 0 front 0')
 })


### PR DESCRIPTION
Summary
- Quote DSN PCB placement refdes values in `stringifyDsnJson`.
- Add a regression proving a quoted refdes containing spaces keeps its placement coordinates through parse -> stringify -> parse.
- Update an existing scaling-output assertion to expect the now-quoted refdes.
- Keep this scoped to DSN PCB placement refdes values, separate from PR #290 session placement identifiers and PR #275 parser string-quote/string escaping.

Bounty
/claim #54

Verification
- `bun test tests/dsn-pcb/stringify-dsn-json.test.ts tests/repros/repro15-dsn-scaling.test.tsx`
- `bunx biome check lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts tests/dsn-pcb/stringify-dsn-json.test.ts tests/repros/repro15-dsn-scaling.test.tsx`
- `bunx tsc --noEmit`
- `bun test`
- `bun run build`
- `git diff --check`

Transparency note: AI-assisted with Codex; I reviewed the diff and verified it locally before submission.