### PR TITLE
Quote network pin references when stringifying

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
@@ -111,7 +111,7 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
   dsnJson.network.nets.forEach((net) => {
     result += `${indent}${indent}(net ${stringifyValue(net.name)}\n`
     if (net.pins.length > 0) {
-      result += `${indent}${indent}${indent}(pins ${net.pins.join(" ")})\n`
+      result += `${indent}${indent}${indent}(pins ${net.pins.map(stringifyValue).join(" ")})\n`
     }
     result += `${indent}${indent})\n`
   })

--- a/tests/dsn-pcb/stringify-dsn-json.test.ts
+++ b/tests/dsn-pcb/stringify-dsn-json.test.ts
@@ -17,3 +17,47 @@ test("stringify dsn json", () => {
   // Test that we can parse the generated string back to the same structure
   // expect(reparsedJson).toEqual(dsnJson)
 })
+
+test("stringify dsn json preserves quoted network pin references", () => {
+  const dsnJson = parseDsnToDsnJson(`(pcb board.dsn
+    (parser
+      (string_quote ")
+      (space_in_quoted_tokens on)
+      (host_cad "KiCad")
+      (host_version "1.0")
+    )
+    (resolution um 10)
+    (unit um)
+    (structure
+      (layer F.Cu
+        (type signal)
+        (property
+          (index 0)
+        )
+      )
+      (boundary
+        (path F.Cu 0 0 0 1000 0 1000 1000 0 1000 0 0)
+      )
+      (via "Via[0-1]_600:300_um")
+      (rule
+        (width 100)
+        (clearance 100)
+      )
+    )
+    (placement)
+    (library)
+    (network
+      (net "Signal A"
+        (pins "J 1-1" "U 1-A")
+      )
+    )
+    (wiring)
+  )`) as DsnPcb
+
+  const dsnString = stringifyDsnJson(dsnJson)
+  const reparsedJson = parseDsnToDsnJson(dsnString) as DsnPcb
+  const net = reparsedJson.network.nets[0]
+
+  expect(dsnString).toContain('(pins "J 1-1" "U 1-A")')
+  expect(net.pins).toEqual(["J 1-1", "U 1-A"])
+})


### PR DESCRIPTION
Summary
- Quote DSN PCB network pin references when emitting `(pins ...)` lists from `stringifyDsnJson`.
- Add a regression proving quoted pin references containing spaces survive parse -> stringify -> parse without splitting.
- Keep this scoped to DSN PCB network pin stringification, separate from older quoted-pin import/connection work, PR #292 top-level network via_rule metadata, and PR #275 parser string-quote handling.

Bounty
/claim #54

Verification
- `bun test tests/dsn-pcb/stringify-dsn-json.test.ts`
- `bunx biome check lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts tests/dsn-pcb/stringify-dsn-json.test.ts`
- `bunx tsc --noEmit`
- `bun test`
- `bun run build`
- `git diff --check`

Transparency note: AI-assisted with Codex; I reviewed the diff and verified it locally before submission.