### PR TITLE
Quote library image pin identifiers

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
@@ -86,7 +86,7 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
       result += `${indent}${indent}${indent}(outline ${stringifyPath(outline.path, 4)})\n`
     })
     image.pins.forEach((pin) => {
-      result += `${indent}${indent}${indent}(pin ${pin.padstack_name} ${pin.pin_number} ${pin.x} ${pin.y})\n`
+      result += `${indent}${indent}${indent}(pin ${stringifyValue(pin.padstack_name)} ${stringifyValue(pin.pin_number)} ${pin.x} ${pin.y})\n`
     })
     result += `${indent}${indent})\n`
   })

--- a/tests/dsn-pcb/stringify-dsn-json.test.ts
+++ b/tests/dsn-pcb/stringify-dsn-json.test.ts
@@ -17,3 +17,50 @@ test("stringify dsn json", () => {
   // Test that we can parse the generated string back to the same structure
   // expect(reparsedJson).toEqual(dsnJson)
 })
+
+test("stringify dsn json preserves library image pin identifiers with spaces", () => {
+  const dsnJson = parseDsnToDsnJson(`(pcb board.dsn
+    (parser
+      (string_quote ")
+      (space_in_quoted_tokens on)
+      (host_cad "KiCad")
+      (host_version "1.0")
+    )
+    (resolution um 10)
+    (unit um)
+    (structure
+      (layer F.Cu
+        (type signal)
+        (property
+          (index 0)
+        )
+      )
+      (boundary
+        (path F.Cu 0 0 0 1000 0 1000 1000 0 1000 0 0)
+      )
+      (via "Via[0-1]_600:300_um")
+      (rule
+        (width 100)
+        (clearance 100)
+      )
+    )
+    (placement)
+    (library
+      (image "USB Connector"
+        (pin "Pad Stack A" "Pin A" 125 250)
+      )
+    )
+    (network)
+    (wiring)
+  )`) as DsnPcb
+
+  const dsnString = stringifyDsnJson(dsnJson)
+  const reparsedJson = parseDsnToDsnJson(dsnString) as DsnPcb
+  const pin = reparsedJson.library.images[0].pins[0]
+
+  expect(dsnString).toContain('(pin "Pad Stack A" "Pin A" 125 250)')
+  expect(pin.padstack_name).toBe("Pad Stack A")
+  expect(pin.pin_number).toBe("Pin A")
+  expect(pin.x).toBe(125)
+  expect(pin.y).toBe(250)
+})


### PR DESCRIPTION
Summary
- Quote DSN PCB library image pin padstack names and string pin identifiers in `stringifyDsnJson`.
- Add a regression proving quoted image pin identifiers containing spaces survive parse -> stringify -> parse without splitting.
- Keep this scoped to DSN PCB library image pin stringification, separate from placement-pin metadata work and PR #294 network pin references.

Bounty
/claim #54

Verification
- `bun test tests/dsn-pcb/stringify-dsn-json.test.ts`
- `bunx biome check lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts tests/dsn-pcb/stringify-dsn-json.test.ts`
- `bunx tsc --noEmit`
- `bun test`
- `bun run build`
- `git diff --check`

Transparency note: AI-assisted with Codex; I reviewed the diff and verified it locally before submission.