### PR TITLE
Preserve placement pin clearance metadata

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
@@ -71,7 +71,16 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
     result += `${indent}${indent}(component ${stringifyValue(component.name)}\n`
     if (component.places) {
       component.places.forEach((place) => {
-        result += `${indent}${indent}${indent}(place ${place.refdes} ${place.x} ${place.y} ${place.side} ${place.rotation}${place.PN ? ` (PN ${stringifyValue(place.PN)})` : ""})\n`
+        const placePrefix = `${indent}${indent}${indent}(place ${place.refdes} ${place.x} ${place.y} ${place.side} ${place.rotation}${place.PN ? ` (PN ${stringifyValue(place.PN)})` : ""}`
+        if (place.pins?.length) {
+          result += `${placePrefix}\n`
+          place.pins.forEach((pin) => {
+            result += `${indent}${indent}${indent}${indent}(pin ${stringifyValue(pin.pin_number)}${pin.clearance_class ? ` (clearance_class ${stringifyValue(pin.clearance_class)})` : ""})\n`
+          })
+          result += `${indent}${indent}${indent})\n`
+        } else {
+          result += `${placePrefix})\n`
+        }
       })
     }
     result += `${indent}${indent})\n`

--- a/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
@@ -29,6 +29,7 @@ import type {
   PathShape,
   Pin,
   Placement,
+  PlacementPin,
   Places,
   PolygonShape,
   RectShape,
@@ -477,7 +478,9 @@ function processPlace(nodes: ASTNode[]): Places {
     }
   }
 
-  // Process optional PN (part number) if present
+  const placementPins: PlacementPin[] = []
+
+  // Process optional PN (part number) and per-pin metadata if present
   for (let i = coordIndex + 4; i < nodes.length; i++) {
     const node = nodes[i]
     if (
@@ -489,8 +492,19 @@ function processPlace(nodes: ASTNode[]): Places {
       node.children[1].type === "Atom"
     ) {
       places.PN = String(node.children[1].value)
-      break
+    } else if (
+      node.type === "List" &&
+      node.children &&
+      node.children[0].type === "Atom" &&
+      node.children[0].value === "pin"
+    ) {
+      const pin = processPlacementPin(node.children)
+      if (pin) placementPins.push(pin)
     }
+  }
+
+  if (placementPins.length > 0) {
+    places.pins = placementPins
   }
 
   // Set default values if not present
@@ -499,6 +513,35 @@ function processPlace(nodes: ASTNode[]): Places {
   places.rotation = places.rotation || 0
 
   return places as Places
+}
+
+function processPlacementPin(nodes: ASTNode[]): PlacementPin | null {
+  const pinNumberNode = nodes[1]
+  if (
+    !pinNumberNode ||
+    pinNumberNode.type !== "Atom" ||
+    (typeof pinNumberNode.value !== "number" &&
+      typeof pinNumberNode.value !== "string")
+  ) {
+    return null
+  }
+
+  const pin: PlacementPin = {
+    pin_number: pinNumberNode.value,
+  }
+
+  nodes.slice(2).forEach((node) => {
+    if (
+      node.type === "List" &&
+      node.children?.[0]?.type === "Atom" &&
+      node.children[0].value === "clearance_class" &&
+      node.children[1]?.type === "Atom"
+    ) {
+      pin.clearance_class = String(node.children[1].value)
+    }
+  })
+
+  return pin
 }
 
 export function processLibrary(nodes: ASTNode[]): Library {

--- a/lib/dsn-pcb/types.ts
+++ b/lib/dsn-pcb/types.ts
@@ -92,7 +92,13 @@ export interface ComponentPlacement {
     y: number
     side: "front" | "back"
     rotation: number
+    pins?: PlacementPin[]
   }>
+}
+
+export interface PlacementPin {
+  pin_number: number | string
+  clearance_class?: string
 }
 
 export interface Parser {
@@ -171,6 +177,7 @@ export interface Places {
   side: string
   rotation: number
   PN: string
+  pins?: PlacementPin[]
 }
 
 export interface Library {

--- a/tests/dsn-pcb/dsn-placement-pin-clearance-class.test.ts
+++ b/tests/dsn-pcb/dsn-placement-pin-clearance-class.test.ts
@@ -1,0 +1,68 @@
+import { expect, test } from "bun:test"
+import { type DsnPcb, parseDsnToDsnJson, stringifyDsnJson } from "lib"
+
+const dsnWithPlacementPinClearance = `(pcb "pin-clearance.dsn"
+  (parser
+    (string_quote ")
+    (space_in_quoted_tokens on)
+    (host_cad "KiCad's Pcbnew")
+    (host_version "fixture")
+  )
+  (resolution um 10)
+  (unit um)
+  (structure
+    (layer F.Cu
+      (type signal)
+      (property
+        (index 0)
+      )
+    )
+    (boundary
+      (path pcb 0 0 0 1000 0 1000 1000 0 1000 0 0)
+    )
+    (via "Via[0-1]_600:300_um")
+    (rule
+      (width 200)
+      (clearance 100)
+    )
+  )
+  (placement
+    (component "Resistor_SMD:R_0402_1005Metric"
+      (place
+        R1 100 200 front 90
+        (pin 1 (clearance_class "fine_pitch"))
+        (pin A (clearance_class default))
+      )
+    )
+  )
+  (library
+    (image "Resistor_SMD:R_0402_1005Metric")
+    (padstack "Via[0-1]_600:300_um"
+      (shape (circle F.Cu 600))
+      (attach off)
+    )
+  )
+  (network
+    (net "Net-(R1-Pad1)"
+      (pins R1-1)
+    )
+  )
+  (wiring)
+)`
+
+test("preserves placement pin clearance classes", () => {
+  const parsed = parseDsnToDsnJson(dsnWithPlacementPinClearance) as DsnPcb
+
+  const place = parsed.placement.components[0].places[0]
+  expect(place.pins).toEqual([
+    { pin_number: 1, clearance_class: "fine_pitch" },
+    { pin_number: "A", clearance_class: "default" },
+  ])
+
+  const stringified = stringifyDsnJson(parsed)
+  expect(stringified).toContain('(pin 1 (clearance_class "fine_pitch"))')
+  expect(stringified).toContain('(pin "A" (clearance_class "default"))')
+
+  const reparsed = parseDsnToDsnJson(stringified) as DsnPcb
+  expect(reparsed.placement.components[0].places[0].pins).toEqual(place.pins)
+})


### PR DESCRIPTION
/claim #54

## Summary
- Preserve nested placement pin metadata such as `(pin 1 (clearance_class "kicad_default"))` when parsing DSN PCB placement blocks.
- Re-emit preserved placement pin records from `stringifyDsnJson` so they survive parse -> stringify -> parse.
- Add a focused regression covering numeric and string placement pin identifiers.

## Verification
- `bun test tests\\dsn-pcb\\dsn-placement-pin-clearance-class.test.ts`
- `bun x biome check lib\\dsn-pcb\\types.ts lib\\dsn-pcb\\dsn-json-to-circuit-json\\parse-dsn-to-dsn-json.ts lib\\dsn-pcb\\circuit-json-to-dsn-json\\stringify-dsn-json.ts tests\\dsn-pcb\\dsn-placement-pin-clearance-class.test.ts`
- `bun x tsc --noEmit`
- `bun run build`

## Note
`bun test tests\\dsn-pcb` currently fails on this Windows checkout from existing issues outside this change: two debug-file path `ENOENT` failures using absolute test paths, plus the existing `string_quote` parser/stringifier mismatch in `stringify-dsn-json.test.ts`.

AI-assisted contribution; scope kept intentionally small and test-backed.