### PR TITLE
Preserve DSN session was_is mappings

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-session.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-session.ts
@@ -23,7 +23,11 @@ export const stringifyDsnSession = (session: DsnSession): string => {
   result += `${indent})\n`
 
   // Was_is section (if needed)
-  result += `${indent}(was_is\n${indent})\n`
+  result += `${indent}(was_is\n`
+  session.was_is?.forEach((mapping) => {
+    result += `${indent}${indent}${mapping}\n`
+  })
+  result += `${indent})\n`
 
   // Routes section
   result += `${indent}(routes \n`

--- a/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
@@ -1065,6 +1065,16 @@ function processSessionNode(ast: ASTNode): DsnSession {
     ).components
   }
 
+  const wasIsNode = ast.children!.find(
+    (child) =>
+      child.type === "List" &&
+      child.children?.[0].type === "Atom" &&
+      child.children[0].value === "was_is",
+  )
+  if (wasIsNode) {
+    session.was_is = wasIsNode.children!.slice(1).map(stringifyAstNode)
+  }
+
   // Extract routes section
   const routesNode = ast.children!.find(
     (child) =>
@@ -1144,6 +1154,19 @@ function processSessionNode(ast: ASTNode): DsnSession {
   }
 
   return session
+}
+
+function stringifyAstNode(node: ASTNode): string {
+  if (node.type === "Atom") {
+    if (typeof node.value === "string") {
+      return /[\s()"]/.test(node.value) || node.value === ""
+        ? JSON.stringify(node.value)
+        : node.value
+    }
+    return String(node.value)
+  }
+
+  return `(${node.children!.map(stringifyAstNode).join(" ")})`
 }
 
 function processPathShape(nodes: ASTNode[]): PathShape {

--- a/lib/dsn-pcb/types.ts
+++ b/lib/dsn-pcb/types.ts
@@ -293,6 +293,7 @@ export interface DsnSession {
   is_dsn_session: true
   is_dsn_pcb?: false
   filename: string
+  was_is?: string[]
   placement: {
     resolution: Resolution
     components: Array<ComponentPlacement>

--- a/tests/dsn-pcb/stringify-dsn-session.test.ts
+++ b/tests/dsn-pcb/stringify-dsn-session.test.ts
@@ -25,3 +25,29 @@ test("stringify session file", () => {
   expect(reparsedNet.name).toBe(originalNet.name)
   expect(reparsedNet.wires).toHaveLength(originalNet.wires.length)
 })
+
+test("stringify session file preserves was_is mappings", () => {
+  const sessionWithWasIs = `(session routed.ses
+  (base_design board.dsn)
+  (placement
+    (resolution um 10)
+  )
+  (was_is
+    (component U1 U1_RENAMED)
+    (net "Net With Spaces" "Net_Renamed")
+  )
+  (routes
+    (resolution um 10)
+    (network_out)
+  )
+)`
+
+  const sessionJson = parseDsnToDsnJson(sessionWithWasIs) as DsnSession
+  const stringified = stringifyDsnSession(sessionJson)
+  const reparsed = parseDsnToDsnJson(stringified) as DsnSession
+
+  expect(reparsed.was_is).toEqual([
+    "(component U1 U1_RENAMED)",
+    '(net "Net With Spaces" Net_Renamed)',
+  ])
+})


### PR DESCRIPTION
## Summary
- Preserve DSN session `was_is` child mappings when parsing session files.
- Emit preserved `was_is` mappings from `stringifyDsnSession` instead of always writing an empty section.
- Add focused parse -> stringify -> parse coverage for component and net mapping entries.

## Bounty
/claim #54

## Verification
- `bun test tests/dsn-pcb/stringify-dsn-session.test.ts`
- `bun x biome check lib/dsn-pcb/types.ts lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-session.ts tests/dsn-pcb/stringify-dsn-session.test.ts`
- `bun x tsc --noEmit`
- `bun test`
- `bun run build`
- `git diff --check`

Transparency note: AI-assisted with Codex. I reviewed the diff and verified it locally before submission.