### PR TITLE
Merge session library_out images

### DIFF
--- a/lib/dsn-pcb/dsn-json-to-circuit-json/merge-dsn-session-into-dsn-pcb.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/merge-dsn-session-into-dsn-pcb.ts
@@ -54,5 +54,18 @@ export function mergeDsnSessionIntoDsnPcb(
     })
   }
 
+  // Add any images from session's library_out to PCB's library
+  if (dsnSession.routes?.library_out?.images) {
+    const existingImageNames = new Set(
+      mergedPcb.library.images.map((image) => image.name),
+    )
+
+    dsnSession.routes.library_out.images.forEach((image) => {
+      if (!existingImageNames.has(image.name)) {
+        mergedPcb.library.images.push(image)
+      }
+    })
+  }
+
   return mergedPcb
 }

--- a/tests/dsn-pcb/merge-dsn-session-library-images.test.ts
+++ b/tests/dsn-pcb/merge-dsn-session-library-images.test.ts
@@ -1,0 +1,84 @@
+import { expect, test } from "bun:test"
+import { type DsnPcb, type DsnSession, mergeDsnSessionIntoDsnPcb } from "lib"
+
+const makeBasePcb = (): DsnPcb => ({
+  is_dsn_pcb: true,
+  filename: "board.dsn",
+  parser: {
+    string_quote: "",
+    host_version: "",
+    space_in_quoted_tokens: "",
+    host_cad: "",
+  },
+  resolution: { unit: "um", value: 10 },
+  unit: "um",
+  structure: {
+    layers: [],
+    boundary: { path: { layer: "pcb", width: 0, coordinates: [] } },
+    via: "",
+    rule: { width: 0, clearances: [] },
+  },
+  placement: { components: [] },
+  library: {
+    images: [{ name: "ExistingImage", outlines: [], pins: [] }],
+    padstacks: [],
+  },
+  network: { nets: [], classes: [] },
+  wiring: { wires: [] },
+})
+
+const makeSession = (): DsnSession => ({
+  is_dsn_session: true,
+  filename: "board.ses",
+  placement: {
+    resolution: { unit: "um", value: 10 },
+    components: [],
+  },
+  routes: {
+    resolution: { unit: "um", value: 10 },
+    parser: {
+      string_quote: "",
+      host_version: "",
+      space_in_quoted_tokens: "",
+      host_cad: "",
+    },
+    library_out: {
+      images: [
+        { name: "ExistingImage", outlines: [], pins: [] },
+        {
+          name: "SessionImage",
+          outlines: [
+            {
+              path: {
+                layer: "F.Cu",
+                width: 0,
+                coordinates: [0, 0, 100, 0, 100, 100],
+              },
+            },
+          ],
+          pins: [{ padstack_name: "PadA", pin_number: 1, x: 10, y: 20 }],
+        },
+      ],
+      padstacks: [],
+    },
+    network_out: { nets: [] },
+  },
+})
+
+test("merge dsn session preserves library_out images", () => {
+  const mergedPcb = mergeDsnSessionIntoDsnPcb(makeBasePcb(), makeSession())
+
+  expect(mergedPcb.library.images.map((image) => image.name)).toEqual([
+    "ExistingImage",
+    "SessionImage",
+  ])
+  expect(mergedPcb.library.images[1].outlines[0].path.coordinates).toEqual([
+    0, 0, 100, 0, 100, 100,
+  ])
+  expect(mergedPcb.library.images[1].pins[0]).toEqual({
+    padstack_name: "PadA",
+    pin_number: 1,
+    x: 10,
+    y: 20,
+  })
+})


### PR DESCRIPTION
Summary
- Merge missing `routes.library_out.images` from DSN sessions into the PCB library.
- Keep existing PCB library images unchanged and avoid duplicating images with the same name.
- Add focused regression coverage for the merge path.
- Keep this scoped to `mergeDsnSessionIntoDsnPcb`, separate from PR #285 session `library_out.image` parse/stringify work and DSN PCB image-outline/keepout import work.

Bounty
/claim #54

Verification
- `bun test tests/dsn-pcb/merge-dsn-session-library-images.test.ts`
- `bunx biome check lib/dsn-pcb/dsn-json-to-circuit-json/merge-dsn-session-into-dsn-pcb.ts tests/dsn-pcb/merge-dsn-session-library-images.test.ts`
- `bunx tsc --noEmit`
- `bun test`
- `bun run build`
- `git diff --check`

Transparency note: AI-assisted with Codex; I reviewed the diff and verified it locally before submission.