### PR TITLE
Preserve session wire metadata

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-session.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-session.ts
@@ -63,6 +63,12 @@ export const stringifyDsnSession = (session: DsnSession): string => {
         result += `${indent}${indent}${indent}${indent}${indent}(path ${wire.path.layer} ${wire.path.width}\n`
         result += `${indent}${indent}${indent}${indent}${indent}${indent}${wire.path.coordinates.join(" ")}\n`
         result += `${indent}${indent}${indent}${indent}${indent})\n`
+        if (wire.clearance_class) {
+          result += `${indent}${indent}${indent}${indent}${indent}(clearance_class ${JSON.stringify(wire.clearance_class)})\n`
+        }
+        if (wire.type && wire.type !== "route") {
+          result += `${indent}${indent}${indent}${indent}${indent}(type ${wire.type})\n`
+        }
         result += `${indent}${indent}${indent}${indent})\n`
       }
     })

--- a/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
@@ -1128,9 +1128,8 @@ function processSessionNode(ast: ASTNode): DsnSession {
         const net = {
           name: netName,
           wires: wireNodes.map((wireNode) => ({
-            path: processPath(wireNode.children!.slice(1)),
+            ...processWire(wireNode.children!),
             net: netName,
-            type: "route",
           })),
           vias: viaNodes.map((viaNode) => ({
             x: viaNode.children![2].value as number,

--- a/tests/dsn-pcb/stringify-dsn-session.test.ts
+++ b/tests/dsn-pcb/stringify-dsn-session.test.ts
@@ -25,3 +25,43 @@ test("stringify session file", () => {
   expect(reparsedNet.name).toBe(originalNet.name)
   expect(reparsedNet.wires).toHaveLength(originalNet.wires.length)
 })
+
+test("stringify session preserves network_out wire metadata", () => {
+  const sessionJson = parseDsnToDsnJson(`(session routed.ses
+    (base_design board.dsn)
+    (placement
+      (resolution um 10)
+    )
+    (was_is)
+    (routes
+      (resolution um 10)
+      (parser
+        (host_cad "freerouting")
+        (host_version "1.0")
+      )
+      (network_out
+        (net "Net 1"
+          (wire
+            (path F.Cu 200
+              0 0 1000 0
+            )
+            (clearance_class "tight class")
+            (type protect)
+          )
+        )
+      )
+    )
+  )`) as DsnSession
+
+  const stringified = stringifyDsnSession(sessionJson)
+  const reparsed = parseDsnToDsnJson(stringified) as DsnSession
+  const wire = reparsed.routes.network_out.nets[0].wires[0]
+
+  expect(wire.path).toEqual({
+    layer: "F.Cu",
+    width: 200,
+    coordinates: [0, 0, 1000, 0],
+  })
+  expect(wire.clearance_class).toBe("tight class")
+  expect(wire.type).toBe("protect")
+})


### PR DESCRIPTION
Summary
- Preserve DSN session `network_out` wire metadata through parse -> stringify -> parse.
- Reuse the existing DSN wire parser for session wires instead of keeping only `path` and hard-coding `type: "route"`.
- Emit preserved session wire `(clearance_class ...)` and non-default `(type ...)` metadata from `stringifyDsnSession`.
- Keep this scoped to DSN session `network_out` wire metadata, separate from PR #278 DSN PCB wire/class metadata and PR #268 session via stringification.

Bounty
/claim #54

Verification
- `bun test tests/dsn-pcb/stringify-dsn-session.test.ts`
- `bunx biome check lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-session.ts tests/dsn-pcb/stringify-dsn-session.test.ts`
- `bunx tsc --noEmit`
- `bun test`
- `bun run build`
- `git diff --check`

Transparency note: AI-assisted with Codex; I reviewed the diff and verified it locally before submission.