### PR TITLE
Default parsed net pins

### DIFF
--- a/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
@@ -816,7 +816,9 @@ export function processNetwork(nodes: ASTNode[]): Network {
 }
 
 function processNet(nodes: ASTNode[]): Net {
-  const net: Partial<Net> = {}
+  const net: Partial<Net> = {
+    pins: [],
+  }
   if (nodes[1].type === "Atom" && typeof nodes[1].value === "string") {
     net.name = nodes[1].value
   } else {

--- a/tests/dsn-pcb/stringify-dsn-json.test.ts
+++ b/tests/dsn-pcb/stringify-dsn-json.test.ts
@@ -17,3 +17,43 @@ test("stringify dsn json", () => {
   // Test that we can parse the generated string back to the same structure
   // expect(reparsedJson).toEqual(dsnJson)
 })
+
+test("stringify dsn json preserves nets without pins", () => {
+  const dsnJson = parseDsnToDsnJson(`(pcb empty-net.dsn
+  (parser
+    (string_quote ")
+    (space_in_quoted_tokens on)
+    (host_cad "KiCad")
+    (host_version "8")
+  )
+  (resolution um 10)
+  (unit um)
+  (structure
+    (layer F.Cu
+      (type signal)
+      (property
+        (index 0)
+      )
+    )
+    (via "Via[0-0]")
+    (rule
+      (width 100)
+    )
+  )
+  (placement)
+  (library)
+  (network
+    (net "N/C")
+  )
+  (wiring)
+)`) as DsnPcb
+
+  expect(dsnJson.network.nets[0]).toEqual({ name: "N/C", pins: [] })
+
+  const dsnString = stringifyDsnJson(dsnJson)
+  expect(dsnString).toContain('(net "N/C"')
+  expect(dsnString).not.toContain("(pins")
+
+  const reparsedJson = parseDsnToDsnJson(dsnString) as DsnPcb
+  expect(reparsedJson.network.nets[0]).toEqual({ name: "N/C", pins: [] })
+})


### PR DESCRIPTION
Summary
- Default parsed DSN PCB nets to `pins: []` when a `(net ...)` has no `(pins ...)` child.
- Prevent `stringifyDsnJson` from crashing on parse -> stringify for empty-pin nets.
- Add focused coverage proving empty-pin nets round-trip without emitting a bogus pins block.
- Keep this scoped to missing network pin arrays, separate from PR #294 pin quoting and class/metadata PRs.

Bounty
/claim #54

Verification
- `bun test tests/dsn-pcb/stringify-dsn-json.test.ts`
- `bunx biome check lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts tests/dsn-pcb/stringify-dsn-json.test.ts`
- `bunx tsc --noEmit`
- `bun test`
- `bun run build`
- `git diff --check`

Transparency note: AI-assisted with Codex; I reviewed the diff and verified it locally before submission.