### PR TITLE
Scale merged session wire widths

### DIFF
--- a/lib/dsn-pcb/dsn-json-to-circuit-json/merge-dsn-session-into-dsn-pcb.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/merge-dsn-session-into-dsn-pcb.ts
@@ -30,6 +30,7 @@ export function mergeDsnSessionIntoDsnPcb(
                 ...wire.path,
                 // DsnSession represents the coordinates in ses units, which are
                 // 10x larger than the um units used in the DsnPcb files
+                width: wire.path.width / 10,
                 coordinates: wire.path.coordinates.map((c) => c / 10),
               },
               net: sessionNet.name,

--- a/tests/dsn-pcb/merge-dsn-session-into-dsn-pcb.test.ts
+++ b/tests/dsn-pcb/merge-dsn-session-into-dsn-pcb.test.ts
@@ -1,0 +1,91 @@
+import { expect, test } from "bun:test"
+import { type DsnPcb, type DsnSession, mergeDsnSessionIntoDsnPcb } from "lib"
+
+test("merge session scales wire widths with coordinates", () => {
+  const dsnPcb: DsnPcb = {
+    is_dsn_pcb: true,
+    filename: "board.dsn",
+    parser: {
+      string_quote: '"',
+      space_in_quoted_tokens: "on",
+      host_cad: "KiCad",
+      host_version: "8",
+    },
+    resolution: { unit: "um", value: 10 },
+    unit: "um",
+    structure: {
+      layers: [
+        { name: "F.Cu", type: "signal", property: { index: 0 } },
+        { name: "B.Cu", type: "signal", property: { index: 1 } },
+      ],
+      boundary: {
+        path: {
+          layer: "pcb",
+          width: 0,
+          coordinates: [0, 0, 1000, 0, 1000, 1000, 0, 1000, 0, 0],
+        },
+      },
+      via: "Via[0-1]_600:300_um",
+      rule: { clearances: [], width: 100 },
+    },
+    placement: { components: [] },
+    library: { images: [], padstacks: [] },
+    network: {
+      nets: [{ name: "N1", pins: [] }],
+      classes: [
+        {
+          name: "default",
+          description: "",
+          net_names: ["N1"],
+          circuit: { use_via: "Via[0-1]_600:300_um" },
+          rule: { clearances: [], width: 100 },
+        },
+      ],
+    },
+    wiring: { wires: [] },
+  }
+
+  const dsnSession: DsnSession = {
+    is_dsn_session: true,
+    filename: "board.ses",
+    placement: {
+      resolution: { unit: "um", value: 10 },
+      components: [],
+    },
+    routes: {
+      resolution: { unit: "um", value: 10 },
+      parser: {
+        string_quote: '"',
+        space_in_quoted_tokens: "on",
+        host_cad: "Freerouting",
+        host_version: "1",
+      },
+      network_out: {
+        nets: [
+          {
+            name: "N1",
+            wires: [
+              {
+                path: {
+                  layer: "F.Cu",
+                  width: 2500,
+                  coordinates: [0, 0, 10000, 0],
+                },
+                net: "N1",
+                type: "route",
+              },
+            ],
+          },
+        ],
+      },
+    },
+  }
+
+  const mergedPcb = mergeDsnSessionIntoDsnPcb(dsnPcb, dsnSession)
+
+  expect(mergedPcb.wiring.wires[0].path).toEqual({
+    layer: "F.Cu",
+    width: 250,
+    coordinates: [0, 0, 1000, 0],
+  })
+})


### PR DESCRIPTION
Summary
- Scale session wire `path.width` by the same 10x factor already used for session wire coordinates when merging `network_out` routes into PCB `wiring`.
- Prevent merged session routes from landing correctly but becoming 10x too wide.
- Add focused merge coverage for session wire width and coordinate scaling.
- Keep this scoped to session merge wire width scaling, separate from PR #273 placement scaling and the route/via preservation PRs.

Bounty
/claim #54

Verification
- `bun test tests/dsn-pcb/merge-dsn-session-into-dsn-pcb.test.ts`
- `bunx biome check lib/dsn-pcb/dsn-json-to-circuit-json/merge-dsn-session-into-dsn-pcb.ts tests/dsn-pcb/merge-dsn-session-into-dsn-pcb.test.ts`
- `bunx tsc --noEmit`
- `bun test`
- `bun run build`
- `git diff --check`

Transparency note: AI-assisted with Codex; I reviewed the diff and verified it locally before submission.