### PR TITLE
Preserve descriptionless DSN class names

### DIFF
--- a/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
@@ -844,18 +844,26 @@ function processNet(nodes: ASTNode[]): Net {
 
 function processClass(nodes: ASTNode[]): Class {
   const classObj: Partial<Class> = {}
-  if (
-    nodes[1].type === "Atom" &&
-    typeof nodes[1].value === "string" &&
-    nodes[2].type === "Atom" &&
-    typeof nodes[2].value === "string"
-  ) {
+
+  if (nodes[1].type === "Atom" && typeof nodes[1].value === "string") {
     classObj.name = nodes[1].value
-    classObj.description = nodes[2].value
   }
 
-  // The next nodes until 'circuit' are net names
-  let i = 3
+  let i = 2
+  const maybeDescriptionNode = nodes[i]
+  if (
+    maybeDescriptionNode?.type === "Atom" &&
+    typeof maybeDescriptionNode.value === "string"
+  ) {
+    const maybeDescription = maybeDescriptionNode.value
+    if (maybeDescription === "" || /\s/.test(maybeDescription)) {
+      classObj.description = maybeDescription
+      i++
+    }
+  }
+  classObj.description ??= ""
+
+  // The next atom nodes until class metadata/rules are net names.
   classObj.net_names = []
   while (
     i < nodes.length &&

--- a/tests/dsn-pcb/stringify-dsn-json.test.ts
+++ b/tests/dsn-pcb/stringify-dsn-json.test.ts
@@ -17,3 +17,70 @@ test("stringify dsn json", () => {
   // Test that we can parse the generated string back to the same structure
   // expect(reparsedJson).toEqual(dsnJson)
 })
+
+test("descriptionless network classes preserve their names", () => {
+  const dsn = `(pcb board
+  (parser
+    (string_quote ")
+    (space_in_quoted_tokens on)
+    (host_cad "KiCad's Pcbnew")
+    (host_version "9.0")
+  )
+  (resolution um 10)
+  (unit um)
+  (structure
+    (layer F.Cu
+      (type signal)
+      (property
+        (index 0)
+      )
+    )
+    (boundary
+      (path F.Cu 0 0 0 1000 1000)
+    )
+    (via Via[0-1]_600:300_um)
+    (rule
+      (width 100)
+    )
+  )
+  (placement)
+  (library)
+  (network
+    (net "N1"
+      (pins "U1-1")
+    )
+    (class default
+      (rule
+        (width 100)
+      )
+      (circuit
+        (use_via Via[0-1]_600:300_um)
+      )
+    )
+    (class "kicad_default"
+      "N1"
+      (rule
+        (width 100)
+      )
+      (circuit
+        (use_via Via[0-1]_600:300_um)
+      )
+    )
+  )
+  (wiring)
+)`
+
+  const dsnJson = parseDsnToDsnJson(dsn) as DsnPcb
+  expect(dsnJson.network.classes[0].name).toBe("default")
+  expect(dsnJson.network.classes[0].description).toBe("")
+  expect(dsnJson.network.classes[1].name).toBe("kicad_default")
+  expect(dsnJson.network.classes[1].description).toBe("")
+  expect(dsnJson.network.classes[1].net_names).toEqual(["N1"])
+
+  const reparsedJson = parseDsnToDsnJson(stringifyDsnJson(dsnJson)) as DsnPcb
+  expect(reparsedJson.network.classes[0].name).toBe("default")
+  expect(reparsedJson.network.classes[0].description).toBe("")
+  expect(reparsedJson.network.classes[1].name).toBe("kicad_default")
+  expect(reparsedJson.network.classes[1].description).toBe("")
+  expect(reparsedJson.network.classes[1].net_names).toEqual(["N1"])
+})


### PR DESCRIPTION
Part of #54

/claim #54

## Summary
- Parse DSN network class names independently from optional descriptions
- Treat descriptionless classes as `description: ""` instead of dropping the class name
- Preserve following atom tokens as net names for classes like `(class "kicad_default" "N1" ...)`
- Add focused parse -> stringify -> parse coverage for descriptionless classes

## Validation
- `npx --yes bun tmp-descriptionless-class-check.ts` (temporary direct parser/stringifier smoke; removed after run)
- `npx biome check lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts tests/dsn-pcb/stringify-dsn-json.test.ts`
- `npx tsc --noEmit`
- `git diff --check`

Note: `npx --yes bun test tests/dsn-pcb/stringify-dsn-json.test.ts` is currently blocked in this Windows environment by the repo preload importing `sharp` (`Cannot find module '../build/Release/sharp-win32-x64.node'`). The focused direct smoke covers the changed parser/stringifier path without loading that preload.