### PR TITLE
Preserve DSN layer routing metadata

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
@@ -46,6 +46,12 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
   dsnJson.structure.layers.forEach((layer) => {
     result += `${indent}${indent}(layer ${layer.name}\n`
     result += `${indent}${indent}${indent}(type ${layer.type})\n`
+    if (layer.direction) {
+      result += `${indent}${indent}${indent}(direction ${layer.direction})\n`
+    }
+    if (layer.cost !== undefined) {
+      result += `${indent}${indent}${indent}(cost ${layer.cost})\n`
+    }
     result += `${indent}${indent}${indent}(property\n`
     result += `${indent}${indent}${indent}${indent}(index ${layer.property.index})\n`
     result += `${indent}${indent}${indent})\n`

--- a/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
@@ -261,6 +261,16 @@ function processLayer(nodes: ASTNode[]): Layer {
               layer.type = rest[0].value
             }
             break
+          case "direction":
+            if (rest[0].type === "Atom" && typeof rest[0].value === "string") {
+              layer.direction = rest[0].value
+            }
+            break
+          case "cost":
+            if (rest[0].type === "Atom" && typeof rest[0].value === "number") {
+              layer.cost = rest[0].value
+            }
+            break
           case "property":
             layer.property = processProperty(rest)
             break

--- a/lib/dsn-pcb/types.ts
+++ b/lib/dsn-pcb/types.ts
@@ -19,6 +19,8 @@ export interface DsnPcb {
     layers: Array<{
       name: string
       type: string
+      direction?: string
+      cost?: number
       property: {
         index: number
       }
@@ -117,6 +119,8 @@ export interface Structure {
 export interface Layer {
   name: string
   type: string
+  direction?: string
+  cost?: number
   property: {
     index: number
   }

--- a/tests/dsn-pcb/stringify-dsn-json.test.ts
+++ b/tests/dsn-pcb/stringify-dsn-json.test.ts
@@ -17,3 +17,49 @@ test("stringify dsn json", () => {
   // Test that we can parse the generated string back to the same structure
   // expect(reparsedJson).toEqual(dsnJson)
 })
+
+test("stringify dsn json preserves layer direction and cost", () => {
+  const dsnJson = parseDsnToDsnJson(`(pcb "layer-metadata.dsn"
+  (parser
+    (string_quote ")
+    (space_in_quoted_tokens on)
+    (host_cad "freerouting")
+    (host_version "1.9")
+  )
+  (resolution um 10)
+  (unit um)
+  (structure
+    (layer F.Cu
+      (type signal)
+      (direction horizontal)
+      (cost 7)
+      (property
+        (index 0)
+      )
+    )
+    (boundary
+      (path pcb 0 0 0 1000 0 1000 1000 0 1000)
+    )
+    (via "Via[0-1]_600:300_um")
+    (rule
+      (width 200)
+      (clearance 200)
+    )
+  )
+  (placement)
+  (library)
+  (network)
+  (wiring)
+)`) as DsnPcb
+
+  expect(dsnJson.structure.layers[0].direction).toBe("horizontal")
+  expect(dsnJson.structure.layers[0].cost).toBe(7)
+
+  const dsnString = stringifyDsnJson(dsnJson)
+  expect(dsnString).toContain("(direction horizontal)")
+  expect(dsnString).toContain("(cost 7)")
+
+  const reparsedJson = parseDsnToDsnJson(dsnString) as DsnPcb
+  expect(reparsedJson.structure.layers[0].direction).toBe("horizontal")
+  expect(reparsedJson.structure.layers[0].cost).toBe(7)
+})


### PR DESCRIPTION
### Context

/claim #54

DSN structure layers can carry routing metadata such as `(direction horizontal)` and `(cost 7)`. The current parser keeps only the layer `type` and `property`, so these hints are lost when a DSN file is parsed to JSON and stringified back.

This is scoped separately from the active layer-count, missing-property, class `use_layer`, wire layer-name, autoroute settings, and boundary-shape PRs.

### Changes

- Add optional `direction` and `cost` fields to DSN layer JSON.
- Parse `(direction ...)` and `(cost ...)` from structure layer blocks.
- Emit preserved layer direction/cost metadata from `stringifyDsnJson`.
- Add a focused regression proving parse -> stringify -> parse keeps both fields.

### Verification

- `bun --eval` direct parse/stringify round-trip for layer direction/cost
- `bun x biome check lib/dsn-pcb/types.ts lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts tests/dsn-pcb/stringify-dsn-json.test.ts`
- `git diff --check -- lib/dsn-pcb/types.ts lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts tests/dsn-pcb/stringify-dsn-json.test.ts`
