### PR TITLE
Preserve DSN library image side metadata

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
@@ -82,6 +82,9 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
   result += `${indent}(library\n`
   dsnJson.library.images.forEach((image) => {
     result += `${indent}${indent}(image ${stringifyValue(image.name)}\n`
+    if (image.side) {
+      result += `${indent}${indent}${indent}(side ${stringifyValue(image.side)})\n`
+    }
     image.outlines.forEach((outline) => {
       result += `${indent}${indent}${indent}(outline ${stringifyPath(outline.path, 4)})\n`
     })

--- a/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
@@ -545,6 +545,12 @@ function processImage(nodes: ASTNode[]): Image {
         } else if (key === "pin") {
           const pin = processPin(node.children!)
           if (pin) image.pins!.push(pin)
+        } else if (
+          key === "side" &&
+          rest[0]?.type === "Atom" &&
+          typeof rest[0].value === "string"
+        ) {
+          image.side = rest[0].value
         }
       }
     }

--- a/lib/dsn-pcb/types.ts
+++ b/lib/dsn-pcb/types.ts
@@ -180,6 +180,7 @@ export interface Library {
 
 export interface Image {
   name: string
+  side?: string
   outlines: Outline[]
   pins: Pin[]
 }

--- a/tests/dsn-pcb/stringify-dsn-json.test.ts
+++ b/tests/dsn-pcb/stringify-dsn-json.test.ts
@@ -17,3 +17,63 @@ test("stringify dsn json", () => {
   // Test that we can parse the generated string back to the same structure
   // expect(reparsedJson).toEqual(dsnJson)
 })
+
+test("preserves library image side metadata when stringifying", () => {
+  const dsnJson = parseDsnToDsnJson(`(pcb image-side.dsn
+  (parser
+    (string_quote ")
+    (space_in_quoted_tokens on)
+    (host_cad "KiCad's Pcbnew")
+    (host_version "9.0")
+  )
+  (resolution um 10)
+  (unit um)
+  (structure
+    (layer F.Cu
+      (type signal)
+      (property
+        (index 0)
+      )
+    )
+    (boundary
+      (path pcb 0 0 0 1000 0 1000 1000 0 1000 0 0)
+    )
+    (via Via[0-1]_600:300_um)
+    (rule
+      (width 100)
+      (clearance 50)
+    )
+  )
+  (placement)
+  (library
+    (image "Back Side Footprint"
+      (side back)
+      (pin Pad_1 1 0 0)
+    )
+    (padstack Pad_1
+      (shape (circle F.Cu 100))
+      (attach off)
+    )
+  )
+  (network
+    (class kicad_default ""
+      (circuit
+        (use_via Via[0-1]_600:300_um)
+      )
+      (rule
+        (width 100)
+        (clearance 50)
+      )
+    )
+  )
+  (wiring)
+)`) as DsnPcb
+
+  expect(dsnJson.library.images[0].side).toBe("back")
+
+  const dsnString = stringifyDsnJson(dsnJson)
+  expect(dsnString).toContain('(side "back")')
+
+  const reparsedJson = parseDsnToDsnJson(dsnString) as DsnPcb
+  expect(reparsedJson.library.images[0].side).toBe("back")
+})


### PR DESCRIPTION
Summary
- Parse optional DSN PCB library image `(side ...)` metadata into the image JSON model.
- Emit preserved image side metadata from `stringifyDsnJson` so parse -> stringify -> parse keeps Freerouting/KiCad image-side records.
- Add focused regression coverage for a back-side library image.
- Keep this scoped to image-level side metadata, separate from image outline/keepout, placement-pin, quoting, and session image PRs.

Bounty
/claim #54

Verification
- bun test tests/dsn-pcb/stringify-dsn-json.test.ts
- bun test
- bunx tsc --noEmit
- bunx biome check lib/dsn-pcb/types.ts lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts tests/dsn-pcb/stringify-dsn-json.test.ts
- bun run build
- git diff --check

Transparency note: AI-assisted with Codex; I reviewed the diff and verified it locally before submission.