### PR TITLE
Preserve DSN structure via lists

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
@@ -56,7 +56,11 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
     result += `${indent}${indent}${indent}${stringifyPath(dsnJson.structure.boundary.path, 0)}\n`
     result += `${indent}${indent})\n`
   }
-  result += `${indent}${indent}(via ${stringifyValue(dsnJson.structure.via)})\n`
+  const structureVias =
+    dsnJson.structure.vias && dsnJson.structure.vias.length > 0
+      ? dsnJson.structure.vias
+      : [dsnJson.structure.via]
+  result += `${indent}${indent}(via ${structureVias.map(stringifyValue).join(" ")})\n`
   result += `${indent}${indent}(rule\n`
   result += `${indent}${indent}${indent}(width ${dsnJson.structure.rule.width})\n`
   dsnJson.structure.rule.clearances.forEach((clearance) => {

--- a/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
@@ -226,11 +226,18 @@ export function processStructure(nodes: ASTNode[]): Structure {
             structure.boundary = processBoundary(node.children!.slice(1))
             break
           case "via":
-            if (
-              node.children![1].type === "Atom" &&
-              typeof node.children![1].value === "string"
-            ) {
-              structure.via = node.children![1].value
+            {
+              const vias = node
+                .children!.slice(1)
+                .filter(
+                  (child) =>
+                    child.type === "Atom" && typeof child.value === "string",
+                )
+                .map((child) => child.value as string)
+              if (vias.length > 0) {
+                structure.vias = vias
+                structure.via = vias[0]
+              }
             }
             break
           case "rule":

--- a/lib/dsn-pcb/types.ts
+++ b/lib/dsn-pcb/types.ts
@@ -31,6 +31,7 @@ export interface DsnPcb {
       }
     }
     via: string
+    vias?: string[]
     rule: {
       clearances: Array<{
         value: number
@@ -111,6 +112,7 @@ export interface Structure {
   layers: Layer[]
   boundary: Boundary
   via: string
+  vias?: string[]
   rule: Rule
 }
 

--- a/tests/dsn-pcb/stringify-dsn-json.test.ts
+++ b/tests/dsn-pcb/stringify-dsn-json.test.ts
@@ -17,3 +17,67 @@ test("stringify dsn json", () => {
   // Test that we can parse the generated string back to the same structure
   // expect(reparsedJson).toEqual(dsnJson)
 })
+
+test("preserves multiple structure via padstacks when stringifying", () => {
+  const dsnJson = parseDsnToDsnJson(`(pcb structure-vias.dsn
+  (parser
+    (string_quote ")
+    (space_in_quoted_tokens on)
+    (host_cad "KiCad's Pcbnew")
+    (host_version "9.0")
+  )
+  (resolution um 10)
+  (unit um)
+  (structure
+    (layer F.Cu
+      (type signal)
+      (property
+        (index 0)
+      )
+    )
+    (boundary
+      (path pcb 0 0 0 1000 0 1000 1000 0 1000 0 0)
+    )
+    (via Via_Default "Via[0-1]_600:300_um" default)
+    (rule
+      (width 100)
+      (clearance 50)
+    )
+  )
+  (placement)
+  (library
+    (padstack Via_Default
+      (shape (circle F.Cu 100))
+      (attach off)
+    )
+  )
+  (network
+    (class kicad_default ""
+      (circuit
+        (use_via Via_Default)
+      )
+      (rule
+        (width 100)
+        (clearance 50)
+      )
+    )
+  )
+  (wiring)
+)`) as DsnPcb
+
+  expect(dsnJson.structure.via).toBe("Via_Default")
+  expect(dsnJson.structure.vias).toEqual([
+    "Via_Default",
+    "Via[0-1]_600:300_um",
+    "default",
+  ])
+
+  const dsnString = stringifyDsnJson(dsnJson)
+  expect(dsnString).toContain(
+    '(via "Via_Default" "Via[0-1]_600:300_um" "default")',
+  )
+
+  const reparsedJson = parseDsnToDsnJson(dsnString) as DsnPcb
+  expect(reparsedJson.structure.via).toBe("Via_Default")
+  expect(reparsedJson.structure.vias).toEqual(dsnJson.structure.vias)
+})


### PR DESCRIPTION
Summary
- Parse all names in DSN PCB structure `(via ...)` records into a new optional `structure.vias` list.
- Keep `structure.via` as the first via name for existing callers.
- Emit the preserved via list from `stringifyDsnJson` so Freerouting/KiCad via padstack lists survive parse -> stringify -> parse.
- Add focused regression coverage for a multi-name structure via record.
- Keep this scoped to structure-level via metadata, separate from via dimensions, top-level network via_rule, session vias, and layer-routing PRs.

Bounty
/claim #54

Verification
- bun test tests/dsn-pcb/stringify-dsn-json.test.ts
- bun test
- bunx tsc --noEmit
- bunx biome check lib/dsn-pcb/types.ts lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts tests/dsn-pcb/stringify-dsn-json.test.ts
- bun run build
- git diff --check

Transparency note: AI-assisted with Codex; I reviewed the diff and verified it locally before submission.