### PR TITLE
Preserve DSN structure control metadata

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
@@ -63,6 +63,14 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
     result += `${indent}${indent}${indent}(clearance ${clearance.value}${clearance.type ? ` (type ${clearance.type})` : ""})\n`
   })
   result += `${indent}${indent})\n`
+  if (dsnJson.structure.snap_angle) {
+    result += `${indent}${indent}(snap_angle ${stringifyValue(dsnJson.structure.snap_angle)})\n`
+  }
+  if (dsnJson.structure.control?.via_at_smd) {
+    result += `${indent}${indent}(control\n`
+    result += `${indent}${indent}${indent}(via_at_smd ${stringifyValue(dsnJson.structure.control.via_at_smd)})\n`
+    result += `${indent}${indent})\n`
+  }
   result += `${indent})\n`
 
   // Placement section

--- a/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
@@ -236,12 +236,42 @@ export function processStructure(nodes: ASTNode[]): Structure {
           case "rule":
             structure.rule = processRule(node.children!.slice(1))
             break
+          case "snap_angle":
+            if (
+              node.children![1]?.type === "Atom" &&
+              typeof node.children![1].value === "string"
+            ) {
+              structure.snap_angle = node.children![1].value
+            }
+            break
+          case "control":
+            structure.control = processControl(node.children!.slice(1))
+            break
         }
       }
     }
   })
 
   return structure as Structure
+}
+
+function processControl(nodes: ASTNode[]): Structure["control"] {
+  const control: NonNullable<Structure["control"]> = {}
+
+  nodes.forEach((node) => {
+    if (node.type !== "List") return
+    const [keyNode, valueNode] = node.children!
+    if (
+      keyNode.type === "Atom" &&
+      keyNode.value === "via_at_smd" &&
+      valueNode?.type === "Atom" &&
+      typeof valueNode.value === "string"
+    ) {
+      control.via_at_smd = valueNode.value
+    }
+  })
+
+  return control
 }
 
 function processLayer(nodes: ASTNode[]): Layer {

--- a/lib/dsn-pcb/types.ts
+++ b/lib/dsn-pcb/types.ts
@@ -31,6 +31,10 @@ export interface DsnPcb {
       }
     }
     via: string
+    snap_angle?: string
+    control?: {
+      via_at_smd?: string
+    }
     rule: {
       clearances: Array<{
         value: number
@@ -111,6 +115,10 @@ export interface Structure {
   layers: Layer[]
   boundary: Boundary
   via: string
+  snap_angle?: string
+  control?: {
+    via_at_smd?: string
+  }
   rule: Rule
 }
 

--- a/tests/dsn-pcb/stringify-dsn-json.test.ts
+++ b/tests/dsn-pcb/stringify-dsn-json.test.ts
@@ -17,3 +17,61 @@ test("stringify dsn json", () => {
   // Test that we can parse the generated string back to the same structure
   // expect(reparsedJson).toEqual(dsnJson)
 })
+
+test("preserves structure snap angle and control metadata", () => {
+  const dsnJson = parseDsnToDsnJson(`(pcb structure-control.dsn
+  (parser
+    (string_quote ")
+    (space_in_quoted_tokens on)
+    (host_cad "KiCad's Pcbnew")
+    (host_version "9.0")
+  )
+  (resolution um 10)
+  (unit um)
+  (structure
+    (layer F.Cu
+      (type signal)
+      (property
+        (index 0)
+      )
+    )
+    (boundary
+      (path pcb 0 0 0 1000 0 1000 1000 0 1000 0 0)
+    )
+    (via Via[0-1]_600:300_um)
+    (rule
+      (width 100)
+      (clearance 50)
+    )
+    (snap_angle fortyfive_degree)
+    (control
+      (via_at_smd off)
+    )
+  )
+  (placement)
+  (library)
+  (network
+    (class kicad_default ""
+      (circuit
+        (use_via Via[0-1]_600:300_um)
+      )
+      (rule
+        (width 100)
+        (clearance 50)
+      )
+    )
+  )
+  (wiring)
+)`) as DsnPcb
+
+  expect(dsnJson.structure.snap_angle).toBe("fortyfive_degree")
+  expect(dsnJson.structure.control?.via_at_smd).toBe("off")
+
+  const dsnString = stringifyDsnJson(dsnJson)
+  expect(dsnString).toContain('(snap_angle "fortyfive_degree")')
+  expect(dsnString).toContain('(via_at_smd "off")')
+
+  const reparsedJson = parseDsnToDsnJson(dsnString) as DsnPcb
+  expect(reparsedJson.structure.snap_angle).toBe("fortyfive_degree")
+  expect(reparsedJson.structure.control?.via_at_smd).toBe("off")
+})


### PR DESCRIPTION
Summary
- Parse optional DSN PCB structure `(snap_angle ...)` metadata.
- Parse optional `(control (via_at_smd ...))` metadata from structure blocks.
- Emit preserved snap angle and control metadata from `stringifyDsnJson` so Freerouting/KiCad structure records survive parse -> stringify -> parse.
- Add focused regression coverage for both records.
- Keep this scoped to structure control metadata, separate from autoroute_settings, layer routing metadata, boundary shapes, and structure via-list PRs.

Bounty
/claim #54

Verification
- bun test tests/dsn-pcb/stringify-dsn-json.test.ts
- bun test
- bunx tsc --noEmit
- bunx biome check lib/dsn-pcb/types.ts lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts tests/dsn-pcb/stringify-dsn-json.test.ts
- bun run build
- git diff --check

Transparency note: AI-assisted with Codex; I reviewed the diff and verified it locally before submission.