### PR TITLE
Preserve Freerouting parser marker

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
@@ -35,6 +35,9 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
   result += `${indent}${indent}(space_in_quoted_tokens on)\n`
   result += `${indent}${indent}(host_cad "KiCad's Pcbnew")\n`
   result += `${indent}${indent}(host_version "${dsnJson.parser.host_version}")\n`
+  if (dsnJson.parser.generated_by_freerouting) {
+    result += `${indent}${indent}(generated_by_freerouting)\n`
+  }
   result += `${indent})\n`
 
   // Resolution and unit

--- a/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
@@ -160,6 +160,13 @@ export function processPCB(nodes: ASTNode[]): DsnPcb {
 export function processParser(nodes: ASTNode[]): ParserType {
   const parser: Partial<ParserType> = {}
   nodes.forEach((node) => {
+    if (node.type === "List" && node.children?.[0]?.type === "Atom") {
+      const key = node.children[0].value
+      if (key === "generated_by_freerouting") {
+        parser.generated_by_freerouting = true
+        return
+      }
+    }
     if (node.type === "List" && node.children && node.children.length >= 2) {
       const [keyNode, valueNode] = node.children
       if (

--- a/lib/dsn-pcb/types.ts
+++ b/lib/dsn-pcb/types.ts
@@ -9,6 +9,7 @@ export interface DsnPcb {
     host_version: string
     space_in_quoted_tokens: string
     host_cad: string
+    generated_by_freerouting?: boolean
   }
   resolution: {
     unit: string
@@ -100,6 +101,7 @@ export interface Parser {
   space_in_quoted_tokens: string
   host_cad: string
   host_version: string
+  generated_by_freerouting?: boolean
 }
 
 export interface Resolution {

--- a/tests/dsn-pcb/stringify-dsn-json.test.ts
+++ b/tests/dsn-pcb/stringify-dsn-json.test.ts
@@ -17,3 +17,55 @@ test("stringify dsn json", () => {
   // Test that we can parse the generated string back to the same structure
   // expect(reparsedJson).toEqual(dsnJson)
 })
+
+test("preserves generated_by_freerouting parser marker", () => {
+  const dsnJson = parseDsnToDsnJson(`(pcb freerouting-marker.dsn
+  (parser
+    (string_quote ")
+    (space_in_quoted_tokens on)
+    (host_cad "KiCad's Pcbnew")
+    (host_version "9.0")
+    (generated_by_freerouting)
+  )
+  (resolution um 10)
+  (unit um)
+  (structure
+    (layer F.Cu
+      (type signal)
+      (property
+        (index 0)
+      )
+    )
+    (boundary
+      (path pcb 0 0 0 1000 0 1000 1000 0 1000 0 0)
+    )
+    (via Via[0-1]_600:300_um)
+    (rule
+      (width 100)
+      (clearance 50)
+    )
+  )
+  (placement)
+  (library)
+  (network
+    (class kicad_default ""
+      (circuit
+        (use_via Via[0-1]_600:300_um)
+      )
+      (rule
+        (width 100)
+        (clearance 50)
+      )
+    )
+  )
+  (wiring)
+)`) as DsnPcb
+
+  expect(dsnJson.parser.generated_by_freerouting).toBe(true)
+
+  const dsnString = stringifyDsnJson(dsnJson)
+  expect(dsnString).toContain("(generated_by_freerouting)")
+
+  const reparsedJson = parseDsnToDsnJson(dsnString) as DsnPcb
+  expect(reparsedJson.parser.generated_by_freerouting).toBe(true)
+})


### PR DESCRIPTION
Summary
- Parse marker-only DSN parser records for `(generated_by_freerouting)`.
- Add an optional boolean parser field and emit the marker from `stringifyDsnJson` when present.
- Add focused parse -> stringify -> parse coverage proving the marker survives.
- Keep this scoped to the Freerouting marker only, separate from PR #275 string_quote/string escaping/parser value handling and structure metadata PRs.

Bounty
/claim #54

Verification
- bun test tests/dsn-pcb/stringify-dsn-json.test.ts
- bun test
- bunx tsc --noEmit
- bunx biome check lib/dsn-pcb/types.ts lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts tests/dsn-pcb/stringify-dsn-json.test.ts
- bun run build
- git diff --check

Transparency note: AI-assisted with Codex; I reviewed the diff and verified it locally before submission.