### PR TITLE
Preserve empty parser host versions

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
@@ -34,7 +34,7 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
   result += `${indent}${indent}(string_quote ")\n`
   result += `${indent}${indent}(space_in_quoted_tokens on)\n`
   result += `${indent}${indent}(host_cad "KiCad's Pcbnew")\n`
-  result += `${indent}${indent}(host_version "${dsnJson.parser.host_version}")\n`
+  result += `${indent}${indent}(host_version "${dsnJson.parser.host_version ?? ""}")\n`
   result += `${indent})\n`
 
   // Resolution and unit

--- a/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
@@ -160,6 +160,15 @@ export function processPCB(nodes: ASTNode[]): DsnPcb {
 export function processParser(nodes: ASTNode[]): ParserType {
   const parser: Partial<ParserType> = {}
   nodes.forEach((node) => {
+    if (
+      node.type === "List" &&
+      node.children?.length === 1 &&
+      node.children[0]?.type === "Atom" &&
+      node.children[0].value === "host_version"
+    ) {
+      parser.host_version = ""
+      return
+    }
     if (node.type === "List" && node.children && node.children.length >= 2) {
       const [keyNode, valueNode] = node.children
       if (

--- a/tests/dsn-pcb/stringify-dsn-json.test.ts
+++ b/tests/dsn-pcb/stringify-dsn-json.test.ts
@@ -17,3 +17,55 @@ test("stringify dsn json", () => {
   // Test that we can parse the generated string back to the same structure
   // expect(reparsedJson).toEqual(dsnJson)
 })
+
+test("preserves empty parser host version", () => {
+  const dsnJson = parseDsnToDsnJson(`(pcb empty-host-version.dsn
+  (parser
+    (string_quote ")
+    (space_in_quoted_tokens on)
+    (host_cad "KiCad's Pcbnew")
+    (host_version )
+  )
+  (resolution um 10)
+  (unit um)
+  (structure
+    (layer F.Cu
+      (type signal)
+      (property
+        (index 0)
+      )
+    )
+    (boundary
+      (path pcb 0 0 0 1000 0 1000 1000 0 1000 0 0)
+    )
+    (via Via[0-1]_600:300_um)
+    (rule
+      (width 100)
+      (clearance 50)
+    )
+  )
+  (placement)
+  (library)
+  (network
+    (class kicad_default ""
+      (circuit
+        (use_via Via[0-1]_600:300_um)
+      )
+      (rule
+        (width 100)
+        (clearance 50)
+      )
+    )
+  )
+  (wiring)
+)`) as DsnPcb
+
+  expect(dsnJson.parser.host_version).toBe("")
+
+  const dsnString = stringifyDsnJson(dsnJson)
+  expect(dsnString).toContain('(host_version "")')
+  expect(dsnString).not.toContain("undefined")
+
+  const reparsedJson = parseDsnToDsnJson(dsnString) as DsnPcb
+  expect(reparsedJson.parser.host_version).toBe("")
+})


### PR DESCRIPTION
Summary
- Treat empty DSN PCB parser `(host_version )` records as an empty string during parsing.
- Avoid emitting `"undefined"` from `stringifyDsnJson` when the parser host version was empty or missing.
- Add focused parse -> stringify -> parse coverage for the Freerouting/KiCad empty host_version shape.
- Keep this scoped to empty host_version only, separate from PR #275 string_quote/string escaping/general parser-value handling and PR #310 generated_by_freerouting marker handling.

Bounty
/claim #54

Verification
- bun test tests/dsn-pcb/stringify-dsn-json.test.ts
- bun test
- bunx tsc --noEmit
- bunx biome check lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts tests/dsn-pcb/stringify-dsn-json.test.ts
- bun run build
- git diff --check

Transparency note: AI-assisted with Codex; I reviewed the diff and verified it locally before submission.