### PR TITLE
Omit missing DSN wire types

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
@@ -138,7 +138,7 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
     if (wire.type === "via") {
       result += `${indent}${indent}(via ${stringifyPath(wire.path, 3)}(net ${stringifyValue(wire.net)}))\n`
     } else {
-      result += `${indent}${indent}(wire ${stringifyPath(wire.path, 3)}(net ${stringifyValue(wire.net)})(type ${wire.type}))\n`
+      result += `${indent}${indent}(wire ${stringifyPath(wire.path, 3)}(net ${stringifyValue(wire.net)})${wire.type ? `(type ${wire.type})` : ""})\n`
     }
   })
   result += `${indent})\n`

--- a/tests/dsn-pcb/stringify-dsn-json.test.ts
+++ b/tests/dsn-pcb/stringify-dsn-json.test.ts
@@ -17,3 +17,66 @@ test("stringify dsn json", () => {
   // Test that we can parse the generated string back to the same structure
   // expect(reparsedJson).toEqual(dsnJson)
 })
+
+test("omits missing wire type when stringifying", () => {
+  const dsnJson = parseDsnToDsnJson(`(pcb missing-wire-type.dsn
+  (parser
+    (string_quote ")
+    (space_in_quoted_tokens on)
+    (host_cad "KiCad's Pcbnew")
+    (host_version "9.0")
+  )
+  (resolution um 10)
+  (unit um)
+  (structure
+    (layer F.Cu
+      (type signal)
+      (property
+        (index 0)
+      )
+    )
+    (boundary
+      (path pcb 0 0 0 1000 0 1000 1000 0 1000 0 0)
+    )
+    (via Via[0-1]_600:300_um)
+    (rule
+      (width 100)
+      (clearance 50)
+    )
+  )
+  (placement)
+  (library)
+  (network
+    (net N1
+      (pins)
+    )
+    (class kicad_default "" N1
+      (circuit
+        (use_via Via[0-1]_600:300_um)
+      )
+      (rule
+        (width 100)
+        (clearance 50)
+      )
+    )
+  )
+  (wiring
+    (wire
+      (path F.Cu 100 0 0 1000 0)
+      (net N1)
+    )
+  )
+)`) as DsnPcb
+
+  expect(dsnJson.wiring.wires[0].type).toBeUndefined()
+
+  const dsnString = stringifyDsnJson(dsnJson)
+  expect(dsnString).not.toContain("undefined")
+  expect(dsnString).not.toContain("(type undefined)")
+  expect(dsnString).toContain(
+    '(wire       (path F.Cu 100  0 0 1000 0)(net "N1"))',
+  )
+
+  const reparsedJson = parseDsnToDsnJson(dsnString) as DsnPcb
+  expect(reparsedJson.wiring.wires[0].type).toBeUndefined()
+})


### PR DESCRIPTION
Summary
- Stop `stringifyDsnJson` from emitting `(type undefined)` for parsed DSN PCB wires that do not include a `(type ...)` child.
- Keep existing typed wires unchanged.
- Add focused parse -> stringify -> parse coverage for an untyped wire.
- Keep this scoped to missing DSN PCB wire type stringification, separate from wire clearance metadata, session wire metadata, and route/via preservation PRs.

Bounty
/claim #54

Verification
- bun test tests/dsn-pcb/stringify-dsn-json.test.ts
- bun test
- bunx tsc --noEmit
- bunx biome check lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts tests/dsn-pcb/stringify-dsn-json.test.ts
- bun run build
- git diff --check

Transparency note: AI-assisted with Codex; I reviewed the diff and verified it locally before submission.