### PR TITLE
Deduplicate merged session padstacks

### DIFF
--- a/lib/dsn-pcb/dsn-json-to-circuit-json/merge-dsn-session-into-dsn-pcb.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/merge-dsn-session-into-dsn-pcb.ts
@@ -50,6 +50,7 @@ export function mergeDsnSessionIntoDsnPcb(
     dsnSession.routes.library_out.padstacks.forEach((padstack) => {
       if (!existingPadstackNames.has(padstack.name)) {
         mergedPcb.library.padstacks.push(padstack)
+        existingPadstackNames.add(padstack.name)
       }
     })
   }

--- a/tests/dsn-pcb/merge-dsn-session-padstacks.test.ts
+++ b/tests/dsn-pcb/merge-dsn-session-padstacks.test.ts
@@ -1,0 +1,75 @@
+import { expect, test } from "bun:test"
+import { type DsnPcb, type DsnSession, mergeDsnSessionIntoDsnPcb } from "lib"
+
+const circlePadstack = (name: string, attach = "off") => ({
+  name,
+  shapes: [{ shapeType: "circle" as const, layer: "F.Cu", diameter: 600 }],
+  attach,
+})
+
+const basePcb: DsnPcb = {
+  is_dsn_pcb: true,
+  filename: "board.dsn",
+  parser: {
+    string_quote: "",
+    host_version: "",
+    space_in_quoted_tokens: "",
+    host_cad: "",
+  },
+  resolution: { unit: "um", value: 10 },
+  unit: "um",
+  structure: {
+    layers: [],
+    boundary: { path: { layer: "pcb", width: 0, coordinates: [] } },
+    via: "",
+    rule: { width: 0, clearances: [] },
+  },
+  placement: { components: [] },
+  library: {
+    images: [],
+    padstacks: [circlePadstack("ExistingVia")],
+  },
+  network: { nets: [], classes: [] },
+  wiring: { wires: [] },
+}
+
+test("deduplicates new session library padstacks when merging", () => {
+  const session: DsnSession = {
+    is_dsn_session: true,
+    filename: "board.ses",
+    placement: {
+      resolution: { unit: "um", value: 10 },
+      components: [],
+    },
+    routes: {
+      resolution: { unit: "um", value: 10 },
+      parser: {
+        string_quote: "",
+        host_version: "",
+        space_in_quoted_tokens: "",
+        host_cad: "",
+      },
+      library_out: {
+        images: [],
+        padstacks: [
+          circlePadstack("ExistingVia"),
+          circlePadstack("NewVia", "off"),
+          circlePadstack("NewVia", "on"),
+        ],
+      },
+      network_out: { nets: [] },
+    },
+  }
+
+  const mergedPcb = mergeDsnSessionIntoDsnPcb(basePcb, session)
+  const newViaPadstacks = mergedPcb.library.padstacks.filter(
+    (padstack) => padstack.name === "NewVia",
+  )
+
+  expect(mergedPcb.library.padstacks.map((padstack) => padstack.name)).toEqual([
+    "ExistingVia",
+    "NewVia",
+  ])
+  expect(newViaPadstacks).toHaveLength(1)
+  expect(newViaPadstacks[0].attach).toBe("off")
+})


### PR DESCRIPTION
Summary
- Deduplicate new session `library_out.padstacks` by name while merging into a DSN PCB library.
- Keep existing PCB padstacks unchanged and preserve the first new session definition when the same padstack appears more than once in a session.
- Add focused merge coverage for duplicate session padstacks.

Bounty
/claim #54

Verification
- bun test tests/dsn-pcb/merge-dsn-session-padstacks.test.ts
- bunx biome check lib/dsn-pcb/dsn-json-to-circuit-json/merge-dsn-session-into-dsn-pcb.ts tests/dsn-pcb/merge-dsn-session-padstacks.test.ts
- bun test
- bunx tsc --noEmit
- bun run build
- git diff --check

Transparency note: AI-assisted with Codex; I reviewed the diff and verified it locally before submission.