### PR TITLE
Preserve DSN top-level network via definitions

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
@@ -115,6 +115,13 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
     }
     result += `${indent}${indent})\n`
   })
+  dsnJson.network.vias?.forEach((via) => {
+    result += `${indent}${indent}(via ${stringifyValue(via.name)} ${stringifyValue(via.padstack)}`
+    if (via.clearance_class) {
+      result += ` ${stringifyValue(via.clearance_class)}`
+    }
+    result += `)\n`
+  })
   dsnJson.network.classes.forEach((cls) => {
     result += `${indent}${indent}(class ${stringifyValue(cls.name)} ${stringifyValue(cls.description)}${cls.net_names.map((n) => ` ${stringifyValue(n)}`).join("")}\n`
     result += `${indent}${indent}${indent}(circuit\n`

--- a/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
@@ -22,6 +22,7 @@ import type {
   Library,
   Net,
   Network,
+  NetworkVia,
   Outline,
   Padstack,
   Parser as ParserType,
@@ -796,6 +797,7 @@ function processCircleShape(nodes: ASTNode[]): CircleShape {
 export function processNetwork(nodes: ASTNode[]): Network {
   const network: Partial<Network> = {
     nets: [],
+    vias: [],
     classes: [],
   }
 
@@ -806,6 +808,8 @@ export function processNetwork(nodes: ASTNode[]): Network {
         const key = keyNode.value
         if (key === "net") {
           network.nets!.push(processNet(node.children!))
+        } else if (key === "via") {
+          network.vias!.push(processNetworkVia(node.children!))
         } else if (key === "class") {
           network.classes!.push(processClass(node.children!))
         }
@@ -813,6 +817,24 @@ export function processNetwork(nodes: ASTNode[]): Network {
     }
   })
   return network as Network
+}
+
+function processNetworkVia(nodes: ASTNode[]): NetworkVia {
+  const networkVia: Partial<NetworkVia> = {}
+
+  if (nodes[1]?.type === "Atom") {
+    networkVia.name = String(nodes[1].value)
+  }
+
+  if (nodes[2]?.type === "Atom") {
+    networkVia.padstack = String(nodes[2].value)
+  }
+
+  if (nodes[3]?.type === "Atom") {
+    networkVia.clearance_class = String(nodes[3].value)
+  }
+
+  return networkVia as NetworkVia
 }
 
 function processNet(nodes: ASTNode[]): Net {

--- a/lib/dsn-pcb/types.ts
+++ b/lib/dsn-pcb/types.ts
@@ -51,6 +51,7 @@ export interface DsnPcb {
       name: string
       pins: string[]
     }>
+    vias?: NetworkVia[]
     classes: Array<{
       name: string
       description: string
@@ -244,12 +245,19 @@ export interface PathShape extends BaseShape {
 
 export interface Network {
   nets: Net[]
+  vias?: NetworkVia[]
   classes: Class[]
 }
 
 export interface Net {
   name: string
   pins: string[]
+}
+
+export interface NetworkVia {
+  name: string
+  padstack: string
+  clearance_class?: string
 }
 
 export interface Class {

--- a/tests/dsn-pcb/dsn-network-vias.test.ts
+++ b/tests/dsn-pcb/dsn-network-vias.test.ts
@@ -1,0 +1,63 @@
+import { expect, test } from "bun:test"
+import { type DsnPcb, parseDsnToDsnJson, stringifyDsnJson } from "lib"
+
+const dsnWithNetworkVias = `(pcb "network-vias.dsn"
+  (parser
+    (string_quote ")
+    (space_in_quoted_tokens on)
+    (host_cad "KiCad's Pcbnew")
+    (host_version "")
+  )
+  (resolution um 10)
+  (unit um)
+  (structure
+    (layer F.Cu
+      (type signal)
+      (property
+        (index 0)
+      )
+    )
+    (layer B.Cu
+      (type signal)
+      (property
+        (index 1)
+      )
+    )
+    (boundary
+      (path pcb 0 0 0 1000 0 1000 1000 0 1000 0 0)
+    )
+    (via "Via[0-1]_600:300_um")
+    (rule
+      (width 200)
+      (clearance 200)
+    )
+  )
+  (placement)
+  (library)
+  (network
+    (via "Via[0-1]_600:300_um" "Via[0-1]_600:300_um" default)
+    (via "Via[0-1]_600:300_um-kicad_default" "Via[0-1]_600:300_um" default)
+  )
+  (wiring)
+)`
+
+test("preserve top-level DSN network via definitions", () => {
+  const parsed = parseDsnToDsnJson(dsnWithNetworkVias) as DsnPcb
+
+  expect(parsed.network.vias).toEqual([
+    {
+      name: "Via[0-1]_600:300_um",
+      padstack: "Via[0-1]_600:300_um",
+      clearance_class: "default",
+    },
+    {
+      name: "Via[0-1]_600:300_um-kicad_default",
+      padstack: "Via[0-1]_600:300_um",
+      clearance_class: "default",
+    },
+  ])
+
+  const reparsed = parseDsnToDsnJson(stringifyDsnJson(parsed)) as DsnPcb
+
+  expect(reparsed.network.vias).toEqual(parsed.network.vias)
+})


### PR DESCRIPTION
## Summary
- add a small `network.vias` DSN JSON field for top-level network via definitions
- parse top-level `(via name padstack clearance_class)` records from DSN network blocks
- stringify preserved network via definitions back into DSN output
- add a focused round-trip regression proving the via definitions survive parse -> stringify -> parse

## Why
This is a small DSN JSON round-trip gap separate from PR #292 top-level `via_rule` metadata and the active structure-via/via-dimension work. Freerouting-style DSN files can define top-level network vias before `via_rule` and class records, but `processNetwork` currently drops those definitions entirely.

/claim #54

## Verification
- `bun test tests/dsn-pcb/dsn-network-vias.test.ts`
- `bun test tests/dsn-pcb/stringify-dsn-json.test.ts`
- `bunx tsc --noEmit`
- `bunx biome check lib/dsn-pcb/types.ts lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts tests/dsn-pcb/dsn-network-vias.test.ts`
- `bun run build`
- `git diff --check`
