### PR TITLE
Preserve DSN network net numbers

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
@@ -109,7 +109,11 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
   // Network section
   result += `${indent}(network\n`
   dsnJson.network.nets.forEach((net) => {
-    result += `${indent}${indent}(net ${stringifyValue(net.name)}\n`
+    result += `${indent}${indent}(net ${stringifyValue(net.name)}`
+    if (net.net_number !== undefined) {
+      result += ` ${net.net_number}`
+    }
+    result += `\n`
     if (net.pins.length > 0) {
       result += `${indent}${indent}${indent}(pins ${net.pins.join(" ")})\n`
     }

--- a/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
@@ -824,7 +824,13 @@ function processNet(nodes: ASTNode[]): Net {
     debug("net name was not a string", net.name)
   }
 
-  nodes.slice(2).forEach((node) => {
+  let metadataStartIndex = 2
+  if (nodes[2]?.type === "Atom" && typeof nodes[2].value === "number") {
+    net.net_number = nodes[2].value
+    metadataStartIndex = 3
+  }
+
+  nodes.slice(metadataStartIndex).forEach((node) => {
     if (
       node.type === "List" &&
       node.children![0].type === "Atom" &&

--- a/lib/dsn-pcb/types.ts
+++ b/lib/dsn-pcb/types.ts
@@ -49,6 +49,7 @@ export interface DsnPcb {
   network: {
     nets: Array<{
       name: string
+      net_number?: number
       pins: string[]
     }>
     classes: Array<{
@@ -249,6 +250,7 @@ export interface Network {
 
 export interface Net {
   name: string
+  net_number?: number
   pins: string[]
 }
 

--- a/tests/dsn-pcb/dsn-network-net-number.test.ts
+++ b/tests/dsn-pcb/dsn-network-net-number.test.ts
@@ -1,0 +1,62 @@
+import { expect, test } from "bun:test"
+import { type DsnPcb, parseDsnToDsnJson, stringifyDsnJson } from "lib"
+
+const dsnWithNetNumber = `(pcb "network-net-number.dsn"
+  (parser
+    (string_quote ")
+    (space_in_quoted_tokens on)
+    (host_cad "KiCad's Pcbnew")
+    (host_version "")
+  )
+  (resolution um 10)
+  (unit um)
+  (structure
+    (layer F.Cu
+      (type signal)
+      (property
+        (index 0)
+      )
+    )
+    (layer B.Cu
+      (type signal)
+      (property
+        (index 1)
+      )
+    )
+    (boundary
+      (path pcb 0 0 0 1000 0 1000 1000 0 1000 0 0)
+    )
+    (via "Via[0-1]_600:300_um")
+    (rule
+      (width 200)
+      (clearance 200)
+    )
+  )
+  (placement)
+  (library)
+  (network
+    (net "Net-(R1-Pad1)" 7
+      (pins
+        C1-1
+        R1-1
+      )
+    )
+  )
+  (wiring)
+)`
+
+test("preserve optional DSN network net numbers", () => {
+  const parsed = parseDsnToDsnJson(dsnWithNetNumber) as DsnPcb
+
+  expect(parsed.network.nets).toEqual([
+    {
+      name: "Net-(R1-Pad1)",
+      net_number: 7,
+      pins: ["C1-1", "R1-1"],
+    },
+  ])
+
+  const reparsed = parseDsnToDsnJson(stringifyDsnJson(parsed)) as DsnPcb
+
+  expect(reparsed.network.nets).toEqual(parsed.network.nets)
+})


### PR DESCRIPTION
## Summary
- add an optional `net_number` field to DSN network nets
- parse numeric `(net name 7 ...)` metadata in `processNet`
- emit preserved net numbers from `stringifyDsnJson`
- add a focused regression proving net numbers survive parse -> stringify -> parse

## Why
This is a tiny DSN JSON round-trip gap separate from PR #302 default parsed net pins, PR #294 network pin quoting, and the via metadata work. Freerouting-style DSN files can include an optional numeric token immediately after the net name, but the current parser drops it and the stringifier cannot write it back.

/claim #54

## Verification
- `bun test tests/dsn-pcb/dsn-network-net-number.test.ts`
- `bun test tests/dsn-pcb/stringify-dsn-json.test.ts`
- `bunx tsc --noEmit`
- `bunx biome check lib/dsn-pcb/types.ts lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts tests/dsn-pcb/dsn-network-net-number.test.ts`
- `bun run build`
- `git diff --check`
