### PR TITLE
Preserve nonnumeric port labels in DSN export

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/process-nets.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/process-nets.ts
@@ -1,5 +1,6 @@
 import { su } from "@tscircuit/soup-util"
 import type { AnyCircuitElement, SourceTrace } from "circuit-json"
+import { getSourcePortPinLabel } from "lib/utils/get-source-port-pin-label"
 import type { DsnPcb } from "../types"
 
 export function processNets(circuitElements: AnyCircuitElement[], pcb: DsnPcb) {
@@ -30,13 +31,11 @@ export function processNets(circuitElements: AnyCircuitElement[], pcb: DsnPcb) {
         if (sourcePort && "source_component_id" in sourcePort) {
           const componentName =
             componentNameMap.get(sourcePort.source_component_id ?? "") || ""
-          const pinNumber = sourcePort.port_hints?.find(
-            (hint) => !Number.isNaN(Number(hint)),
-          )
+          const pinNumber = getSourcePortPinLabel(sourcePort)
 
           padsBySourcePortId.set(sourcePort.source_port_id, {
             componentName: `${componentName}_${sourcePort.source_component_id}`,
-            pinNumber,
+            pinNumber: String(pinNumber),
             sourcePortId: sourcePort.source_port_id,
           })
         }

--- a/lib/dsn-pcb/circuit-json-to-dsn-json/process-plated-holes.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/process-plated-holes.ts
@@ -1,9 +1,5 @@
 import { su } from "@tscircuit/soup-util"
-import type {
-  AnyCircuitElement,
-  SourceComponentBase,
-  SourcePort,
-} from "circuit-json"
+import type { AnyCircuitElement, SourceComponentBase } from "circuit-json"
 import {
   createCircularHoleRectangularPadstack,
   createCircularPadstack,
@@ -12,6 +8,7 @@ import {
 import { getComponentValue } from "lib/utils/get-component-value"
 import { getFootprintName } from "lib/utils/get-footprint-name"
 import { getPadstackName } from "lib/utils/get-padstack-name"
+import { getSourcePortPinLabel } from "lib/utils/get-source-port-pin-label"
 import { applyToPoint, scale } from "transformation-matrix"
 import type { ComponentGroup, DsnPcb, Image, Pin } from "../types"
 
@@ -114,11 +111,6 @@ export function processPlatedHoles(
     return () => current++
   }
 
-  function findNumericHint(port?: SourcePort): number | undefined {
-    const hint = port?.port_hints?.find((h) => !Number.isNaN(Number(h)))
-    return hint !== undefined ? Number(hint) : undefined
-  }
-
   /**
    * MAIN
    */
@@ -167,7 +159,7 @@ export function processPlatedHoles(
             .find((e) => e.source_port_id === pcbPort.source_port_id)
         : undefined
 
-      const pinNumber = findNumericHint(sourcePort) ?? nextPinNumber()
+      const pinNumber = getSourcePortPinLabel(sourcePort) ?? nextPinNumber()
 
       const pin: Pin = {
         padstack_name: padstackName,

--- a/lib/utils/create-pin-for-image.ts
+++ b/lib/utils/create-pin-for-image.ts
@@ -3,6 +3,7 @@ import type { PcbSmtPad } from "circuit-json"
 import type { PcbComponent, SourcePort } from "circuit-json"
 import type { Pin } from "lib"
 import { type PadstackNameArgs, getPadstackName } from "./get-padstack-name"
+import { getSourcePortPinLabel } from "./get-source-port-pin-label"
 
 export function createPinForImage(
   pad: any,
@@ -23,8 +24,7 @@ export function createPinForImage(
 
   return {
     padstack_name: getPadstackName(padstackParams),
-    pin_number:
-      sourcePort.port_hints?.find((hint) => !Number.isNaN(Number(hint))) || 1,
+    pin_number: getSourcePortPinLabel(sourcePort) ?? 1,
     x: (pad.x - pcbComponent.center.x) * 1000,
     y: (pad.y - pcbComponent.center.y) * 1000,
   }

--- a/lib/utils/get-source-port-pin-label.ts
+++ b/lib/utils/get-source-port-pin-label.ts
@@ -1,0 +1,19 @@
+import type { SourcePort } from "circuit-json"
+
+export function getSourcePortPinLabel(
+  sourcePort: SourcePort | undefined,
+): string | number | undefined {
+  if (!sourcePort) return undefined
+
+  const numericHint = sourcePort.port_hints?.find(
+    (hint) => !Number.isNaN(Number(hint)),
+  )
+  if (numericHint !== undefined) return numericHint
+
+  return (
+    sourcePort.port_hints?.[0] ??
+    sourcePort.name ??
+    sourcePort.pin_number?.toString() ??
+    sourcePort.source_port_id
+  )
+}

--- a/tests/dsn-pcb/circuit-json-nonnumeric-port-labels.test.ts
+++ b/tests/dsn-pcb/circuit-json-nonnumeric-port-labels.test.ts
@@ -1,0 +1,95 @@
+import { expect, test } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { convertCircuitJsonToDsnJson } from "lib"
+
+test("exports nonnumeric source port labels to DSN pins and nets", () => {
+  const circuitJson: AnyCircuitElement[] = [
+    {
+      type: "pcb_board",
+      width: 10,
+      height: 10,
+      center: { x: 0, y: 0 },
+      num_layers: 2,
+    } as AnyCircuitElement,
+    {
+      type: "source_component",
+      source_component_id: "sc1",
+      name: "D1",
+      ftype: "simple_diode",
+    } as AnyCircuitElement,
+    {
+      type: "pcb_component",
+      pcb_component_id: "pc1",
+      source_component_id: "sc1",
+      center: { x: 0, y: 0 },
+      rotation: 0,
+    } as AnyCircuitElement,
+    {
+      type: "source_port",
+      source_port_id: "spA",
+      source_component_id: "sc1",
+      name: "A",
+      port_hints: ["A"],
+    } as AnyCircuitElement,
+    {
+      type: "source_port",
+      source_port_id: "spC",
+      source_component_id: "sc1",
+      name: "C",
+      port_hints: ["C"],
+    } as AnyCircuitElement,
+    {
+      type: "pcb_port",
+      pcb_port_id: "ppA",
+      pcb_component_id: "pc1",
+      source_port_id: "spA",
+    } as AnyCircuitElement,
+    {
+      type: "pcb_port",
+      pcb_port_id: "ppC",
+      pcb_component_id: "pc1",
+      source_port_id: "spC",
+    } as AnyCircuitElement,
+    {
+      type: "pcb_smtpad",
+      pcb_smtpad_id: "padA",
+      pcb_component_id: "pc1",
+      pcb_port_id: "ppA",
+      shape: "rect",
+      x: -0.5,
+      y: 0,
+      width: 0.4,
+      height: 0.6,
+      layer: "top",
+    } as AnyCircuitElement,
+    {
+      type: "pcb_smtpad",
+      pcb_smtpad_id: "padC",
+      pcb_component_id: "pc1",
+      pcb_port_id: "ppC",
+      shape: "rect",
+      x: 0.5,
+      y: 0,
+      width: 0.4,
+      height: 0.6,
+      layer: "top",
+    } as AnyCircuitElement,
+    {
+      type: "source_trace",
+      source_trace_id: "st1",
+      connected_source_port_ids: ["spA", "spC"],
+      connected_source_net_ids: [],
+    } as AnyCircuitElement,
+  ]
+
+  const dsnJson = convertCircuitJsonToDsnJson(circuitJson)
+
+  expect(dsnJson.library.images[0].pins.map((pin) => pin.pin_number)).toEqual([
+    "A",
+    "C",
+  ])
+  expect(dsnJson.network.nets[0]).toMatchObject({
+    name: "Net-(D1_sc1-PadA)",
+    pins: ["D1_sc1-A", "D1_sc1-C"],
+  })
+})

--- a/tests/dsn-pcb/circuit-json-nonnumeric-port-labels.test.ts
+++ b/tests/dsn-pcb/circuit-json-nonnumeric-port-labels.test.ts
@@ -93,3 +93,93 @@ test("exports nonnumeric source port labels to DSN pins and nets", () => {
     pins: ["D1_sc1-A", "D1_sc1-C"],
   })
 })
+
+test("exports nonnumeric plated-hole labels to DSN pins and nets", () => {
+  const circuitJson: AnyCircuitElement[] = [
+    {
+      type: "pcb_board",
+      width: 10,
+      height: 10,
+      center: { x: 0, y: 0 },
+      num_layers: 2,
+    } as AnyCircuitElement,
+    {
+      type: "source_component",
+      source_component_id: "sc1",
+      name: "J1",
+      ftype: "simple_resistor",
+    } as AnyCircuitElement,
+    {
+      type: "pcb_component",
+      pcb_component_id: "pc1",
+      source_component_id: "sc1",
+      center: { x: 0, y: 0 },
+      rotation: 0,
+    } as AnyCircuitElement,
+    {
+      type: "source_port",
+      source_port_id: "sp_plus",
+      source_component_id: "sc1",
+      name: "+",
+      port_hints: ["+"],
+    } as AnyCircuitElement,
+    {
+      type: "source_port",
+      source_port_id: "sp_minus",
+      source_component_id: "sc1",
+      name: "-",
+      port_hints: ["-"],
+    } as AnyCircuitElement,
+    {
+      type: "pcb_port",
+      pcb_port_id: "pp_plus",
+      pcb_component_id: "pc1",
+      source_port_id: "sp_plus",
+    } as AnyCircuitElement,
+    {
+      type: "pcb_port",
+      pcb_port_id: "pp_minus",
+      pcb_component_id: "pc1",
+      source_port_id: "sp_minus",
+    } as AnyCircuitElement,
+    {
+      type: "pcb_plated_hole",
+      pcb_plated_hole_id: "hole_plus",
+      pcb_component_id: "pc1",
+      pcb_port_id: "pp_plus",
+      shape: "circle",
+      x: -0.5,
+      y: 0,
+      outer_diameter: 1,
+      hole_diameter: 0.7,
+    } as AnyCircuitElement,
+    {
+      type: "pcb_plated_hole",
+      pcb_plated_hole_id: "hole_minus",
+      pcb_component_id: "pc1",
+      pcb_port_id: "pp_minus",
+      shape: "circle",
+      x: 0.5,
+      y: 0,
+      outer_diameter: 1,
+      hole_diameter: 0.7,
+    } as AnyCircuitElement,
+    {
+      type: "source_trace",
+      source_trace_id: "st1",
+      connected_source_port_ids: ["sp_plus", "sp_minus"],
+      connected_source_net_ids: [],
+    } as AnyCircuitElement,
+  ]
+
+  const dsnJson = convertCircuitJsonToDsnJson(circuitJson)
+
+  expect(dsnJson.library.images[0].pins.map((pin) => pin.pin_number)).toEqual([
+    "+",
+    "-",
+  ])
+  expect(dsnJson.network.nets[0]).toMatchObject({
+    name: "Net-(J1_sc1-Pad+)",
+    pins: ["J1_sc1-+", "J1_sc1--"],
+  })
+})


### PR DESCRIPTION
Summary
- Preserve nonnumeric Circuit JSON source-port labels such as `A` and `C` when exporting DSN library image pins and network pin references.
- Avoid crashing in `processNets` when a source port has no numeric `port_hints` entry.
- Share the source-port label fallback between image-pin generation and network generation, while keeping numeric hints unchanged.
- Add focused export coverage proving nonnumeric labels appear in both image pins and net pins.

Bounty
/claim #54

Verification
- bun test tests/dsn-pcb/circuit-json-nonnumeric-port-labels.test.ts
- bunx biome check lib/utils/get-source-port-pin-label.ts lib/utils/create-pin-for-image.ts lib/dsn-pcb/circuit-json-to-dsn-json/process-nets.ts tests/dsn-pcb/circuit-json-nonnumeric-port-labels.test.ts
- bun test
- bunx tsc --noEmit
- bun run build
- git diff --check

Transparency note: AI-assisted with Codex; I reviewed the diff and verified it locally before submission.