### PR TITLE
Export bottom placements as back side

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/process-components-and-pads.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/process-components-and-pads.ts
@@ -27,6 +27,7 @@ export function processComponentsAndPads(
       rotation: number
       value: string
       sourceComponent: SourceComponentBase | undefined
+      side: "front" | "back"
     }>
   >()
 
@@ -48,6 +49,11 @@ export function processComponentsAndPads(
       transformMmToUm,
       pcbComponent!.center,
     )
+    const side =
+      (pcbComponent as { layer?: string }).layer === "bottom" ||
+      pcb_smtpads.every((pad) => pad.layer === "bottom")
+        ? "back"
+        : "front"
 
     if (!componentsByFootprint.has(footprintName)) {
       componentsByFootprint.set(footprintName, [])
@@ -59,6 +65,7 @@ export function processComponentsAndPads(
       rotation: pcbComponent?.rotation || 0,
       value: getComponentValue(sourceComponent),
       sourceComponent,
+      side,
     })
   }
 
@@ -119,7 +126,7 @@ export function processComponentsAndPads(
         refdes: `${component.componentName}_${component.sourceComponent?.source_component_id}`,
         x: component.coordinates.x,
         y: component.coordinates.y,
-        side: "front" as const,
+        side: component.side,
         rotation: component.rotation % 90,
         PN: component.value,
       })),

--- a/tests/dsn-pcb/circuit-json-bottom-placement-side.test.ts
+++ b/tests/dsn-pcb/circuit-json-bottom-placement-side.test.ts
@@ -1,0 +1,62 @@
+import { expect, test } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { convertCircuitJsonToDsnJson } from "lib"
+
+test("exports bottom-layer SMT components as back-side DSN placements", () => {
+  const circuitJson: AnyCircuitElement[] = [
+    {
+      type: "pcb_board",
+      width: 10,
+      height: 10,
+      center: { x: 0, y: 0 },
+      num_layers: 2,
+    } as AnyCircuitElement,
+    {
+      type: "source_component",
+      source_component_id: "sc1",
+      name: "R1",
+      ftype: "simple_resistor",
+      resistance: 1000,
+    } as AnyCircuitElement,
+    {
+      type: "pcb_component",
+      pcb_component_id: "pc1",
+      source_component_id: "sc1",
+      center: { x: 0, y: 0 },
+      rotation: 0,
+      layer: "bottom",
+    } as AnyCircuitElement,
+    {
+      type: "source_port",
+      source_port_id: "sp1",
+      source_component_id: "sc1",
+      name: "pin1",
+      port_hints: ["1"],
+    } as AnyCircuitElement,
+    {
+      type: "pcb_port",
+      pcb_port_id: "pp1",
+      pcb_component_id: "pc1",
+      source_port_id: "sp1",
+    } as AnyCircuitElement,
+    {
+      type: "pcb_smtpad",
+      pcb_smtpad_id: "pad1",
+      pcb_component_id: "pc1",
+      pcb_port_id: "pp1",
+      shape: "rect",
+      x: 0,
+      y: 0,
+      width: 0.4,
+      height: 0.6,
+      layer: "bottom",
+    } as AnyCircuitElement,
+  ]
+
+  const dsnJson = convertCircuitJsonToDsnJson(circuitJson)
+
+  expect(dsnJson.placement.components[0].places[0].side).toBe("back")
+  expect(dsnJson.library.images[0].pins[0].padstack_name).toBe(
+    "RoundRect[B]Pad_400x600_um",
+  )
+})


### PR DESCRIPTION
Summary
- Export bottom-layer SMT component placements with DSN side `back` instead of always writing `front`.
- Infer bottom placement from `pcb_component.layer === "bottom"` or from SMT pads that are all on the bottom layer.
- Keep top/default placements unchanged and add focused coverage for a bottom-layer SMT component.

Bounty
/claim #54

Verification
- bun test tests/dsn-pcb/circuit-json-bottom-placement-side.test.ts
- bunx biome check lib/dsn-pcb/circuit-json-to-dsn-json/process-components-and-pads.ts tests/dsn-pcb/circuit-json-bottom-placement-side.test.ts
- bun test
- bunx tsc --noEmit
- bun run build
- git diff --check

Transparency note: AI-assisted with Codex; I reviewed the diff and verified it locally before submission.