### PR TITLE
Create layer-specific circular SMT padstacks

### DIFF
--- a/lib/utils/create-and-add-padstack-for-pcb-smtpad.ts
+++ b/lib/utils/create-and-add-padstack-for-pcb-smtpad.ts
@@ -2,7 +2,7 @@ import type { PcbSmtPad } from "circuit-json"
 import type { Padstack } from "lib"
 import type { DsnPcb } from "lib"
 import {
-  createCircularPadstack,
+  createCircularSmtPadstack,
   createRectangularPadstack,
 } from "./create-padstack"
 import { type PadstackNameArgs, getPadstackName } from "./get-padstack-name"
@@ -26,10 +26,10 @@ export function createAndAddPadstackFromPcbSmtPad(
 
   if (!processedPadstacks.has(padstackName)) {
     const padstack: Padstack = isCircle
-      ? createCircularPadstack(
+      ? createCircularSmtPadstack(
           padstackName,
           padstackParams.outerDiameter!,
-          padstackParams.holeDiameter!,
+          pad.layer,
         )
       : createRectangularPadstack(
           padstackName,

--- a/lib/utils/create-padstack.ts
+++ b/lib/utils/create-padstack.ts
@@ -23,6 +23,24 @@ export function createCircularPadstack(
   }
 }
 
+export function createCircularSmtPadstack(
+  name: string,
+  outerDiameter: number,
+  layer: PcbSmtPad["layer"],
+): Padstack {
+  return {
+    name,
+    shapes: [
+      {
+        shapeType: "circle" as const,
+        layer: layer === "bottom" ? "B.Cu" : "F.Cu",
+        diameter: outerDiameter,
+      },
+    ],
+    attach: "off",
+  }
+}
+
 export function createOvalPadstack(
   name: string,
   outerWidth: number,

--- a/tests/repros/repro11-smtpad-circle-shape.test.ts
+++ b/tests/repros/repro11-smtpad-circle-shape.test.ts
@@ -14,7 +14,12 @@ test("smtpad shape circle have correct padstack name", async () => {
   )
   expect(padstackName).toBeDefined()
   expect(padstackName?.length).toBe(1)
-  expect(padstackName?.[0].shapes.length).toBe(2)
-  expect(padstackName?.[0].hole?.shape).toBe("circle")
-  expect(padstackName?.[0].hole?.diameter).toBe(1600)
+  expect(padstackName?.[0].shapes).toEqual([
+    {
+      shapeType: "circle",
+      layer: "F.Cu",
+      diameter: 1600,
+    },
+  ])
+  expect(padstackName?.[0].hole).toBeUndefined()
 })


### PR DESCRIPTION
Summary
- Export circular SMT padstacks only on the SMT pad copper layer instead of using the through-hole/all-layer circular padstack helper.
- Avoid adding drill-hole metadata to circular SMT padstacks.
- Update the existing circular SMT regression to prove the generated `Round[T]...` padstack has only an `F.Cu` circle shape and no hole metadata.

Bounty
/claim #54

Verification
- bun test tests/repros/repro11-smtpad-circle-shape.test.ts
- bunx biome check lib/utils/create-padstack.ts lib/utils/create-and-add-padstack-for-pcb-smtpad.ts tests/repros/repro11-smtpad-circle-shape.test.ts
- bunx tsc --noEmit
- bun test
- bun run build
- git diff --check

Transparency note: AI-assisted with Codex; I reviewed the diff and verified it locally before submission.