### PR TITLE
Name oval plated-hole padstacks from outer size

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/process-plated-holes.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/process-plated-holes.ts
@@ -51,8 +51,8 @@ export function processPlatedHoles(
       case "pill": {
         const name = getPadstackName({
           shape: hole.shape,
-          width: hole.hole_width * 1000,
-          height: hole.hole_height * 1000,
+          width: hole.outer_width * 1000,
+          height: hole.outer_height * 1000,
           layer: "all",
         })
         if (!processedPadstacks.has(name)) {

--- a/tests/dsn-pcb/pill-shape-plated-hole-dimestion-check.test.ts
+++ b/tests/dsn-pcb/pill-shape-plated-hole-dimestion-check.test.ts
@@ -1,6 +1,10 @@
 import { expect, test } from "bun:test"
 import { convertCircuitJsonToPcbSvg } from "circuit-to-svg"
-import { convertCircuitJsonToDsnString, parseDsnToDsnJson } from "lib"
+import {
+  convertCircuitJsonToDsnJson,
+  convertCircuitJsonToDsnString,
+  parseDsnToDsnJson,
+} from "lib"
 import { convertDsnJsonToCircuitJson } from "../../lib/dsn-pcb/dsn-json-to-circuit-json/convert-dsn-json-to-circuit-json.ts"
 
 import type { AnyCircuitElement } from "circuit-json"
@@ -8,12 +12,27 @@ import type { DsnPcb } from "lib"
 import circuitJson from "../assets/repro/pill-shaped-plated-hole.json"
 
 test("check pill shape plated hole dimension", async () => {
+  const directDsnJson = convertCircuitJsonToDsnJson(
+    circuitJson as AnyCircuitElement[],
+  ) as DsnPcb
   // Getting the dsn file from the circuit json
   const dsnFile = convertCircuitJsonToDsnString(
     circuitJson as AnyCircuitElement[],
   )
 
   const dsnJson = parseDsnToDsnJson(dsnFile) as DsnPcb
+  expect(dsnJson.library.images[0].pins[0].padstack_name).toBe(
+    "Oval[A]Pad_1199.9976x1799.9964_um",
+  )
+  expect(
+    directDsnJson.library.padstacks.some(
+      (padstack) =>
+        padstack.name === "Oval[A]Pad_1199.9976x1799.9964_um" &&
+        padstack.hole?.width === 800 &&
+        padstack.hole?.height === 1400,
+    ),
+  ).toBe(true)
+
   const circuitJson2 = convertDsnJsonToCircuitJson(dsnJson)
 
   // TODO: udpate the test to convert this to plated_hole

--- a/tests/repros/repro-4-arduino-nano.test.ts
+++ b/tests/repros/repro-4-arduino-nano.test.ts
@@ -32,7 +32,7 @@ test("circuit json (arduino nano) -> dsn file", async () => {
   expect(usbcImage.pins[0].x).toBe(-1750.060000000076)
   expect(usbcImage.pins[0].y).toBe(2736.586449999919)
   expect(usbcImage.pins[19].padstack_name).toBe(
-    "Oval[A]Pad_799.9983999999998x1399.9972_um",
+    "Oval[A]Pad_1199.9976x1799.9964_um",
   )
   expect(usbcImage.pins[19].x).toBe(-4325)
   expect(usbcImage.pins[19].y).toBe(-2486.500599999971)


### PR DESCRIPTION
Summary
- Name oval/pill plated-hole padstacks from their outer copper pad dimensions instead of their drill dimensions.
- Keep the generated padstack hole metadata using the drill dimensions.
- Update focused plated-hole coverage and the Arduino Nano regression expectation for the corrected `Oval[A]Pad_...` name.

Bounty
/claim #54

Verification
- bun test tests/dsn-pcb/pill-shape-plated-hole-dimestion-check.test.ts tests/repros/repro-4-arduino-nano.test.ts
- bunx biome check lib/dsn-pcb/circuit-json-to-dsn-json/process-plated-holes.ts tests/dsn-pcb/pill-shape-plated-hole-dimestion-check.test.ts tests/repros/repro-4-arduino-nano.test.ts
- bunx tsc --noEmit
- bun test
- bun run build
- git diff --check

Transparency note: AI-assisted with Codex; I reviewed the diff and verified it locally before submission.