### PR TITLE
Preserve DSN wire net numbers

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
@@ -26,6 +26,12 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
     return `${padding}(path ${path.layer} ${path.width}  ${stringifyCoordinates(path.coordinates)})`
   }
 
+  const stringifyWireNet = (wire: any): string => {
+    const netNumber =
+      typeof wire.net_number === "number" ? ` ${wire.net_number}` : ""
+    return `(net ${stringifyValue(wire.net)}${netNumber})`
+  }
+
   // Start with pcb
   result += `(pcb ${dsnJson.filename ? dsnJson.filename : "./converted_dsn.dsn"}\n`
 
@@ -136,9 +142,9 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
   result += `${indent}(wiring\n`
   ;(dsnJson.wiring?.wires ?? []).forEach((wire) => {
     if (wire.type === "via") {
-      result += `${indent}${indent}(via ${stringifyPath(wire.path, 3)}(net ${stringifyValue(wire.net)}))\n`
+      result += `${indent}${indent}(via ${stringifyPath(wire.path, 3)}${stringifyWireNet(wire)})\n`
     } else {
-      result += `${indent}${indent}(wire ${stringifyPath(wire.path, 3)}(net ${stringifyValue(wire.net)})(type ${wire.type}))\n`
+      result += `${indent}${indent}(wire ${stringifyPath(wire.path, 3)}${stringifyWireNet(wire)}(type ${wire.type}))\n`
     }
   })
   result += `${indent})\n`

--- a/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
@@ -999,6 +999,9 @@ function processWire(nodes: ASTNode[]): Wire {
             if (rest[0].type === "Atom" && typeof rest[0].value === "string") {
               wire.net = rest[0].value
             }
+            if (rest[1]?.type === "Atom" && typeof rest[1].value === "number") {
+              wire.net_number = rest[1].value
+            }
             break
           case "clearance_class":
             if (rest[0].type === "Atom" && typeof rest[0].value === "string") {

--- a/lib/dsn-pcb/types.ts
+++ b/lib/dsn-pcb/types.ts
@@ -78,6 +78,7 @@ export interface DsnPcb {
         coordinates: number[]
       }
       net: string
+      net_number?: number
       type: string
     }>
   }
@@ -280,6 +281,7 @@ export interface Wire {
     coordinates: number[]
   }
   net?: string
+  net_number?: number
   clearance_class?: string
   type?: string
 }

--- a/tests/dsn-pcb/dsn-wire-net-number.test.ts
+++ b/tests/dsn-pcb/dsn-wire-net-number.test.ts
@@ -1,0 +1,56 @@
+import { expect, test } from "bun:test"
+import { type DsnPcb, parseDsnToDsnJson, stringifyDsnJson } from "lib"
+
+test("preserves wire net numbers during DSN JSON round trip", () => {
+  const dsn = `(pcb board.dsn
+  (parser
+    (string_quote ")
+    (space_in_quoted_tokens on)
+    (host_cad "KiCad's Pcbnew")
+    (host_version "9.0")
+  )
+  (resolution um 10)
+  (unit um)
+  (structure
+    (layer F.Cu
+      (type signal)
+      (property
+        (index 0)
+      )
+    )
+    (boundary
+      (path pcb 0 0 0 1000 0 1000 1000 0 1000 0 0)
+    )
+    (via "Via[0-1]_600:300_um")
+    (rule
+      (width 200)
+    )
+  )
+  (placement)
+  (library)
+  (network
+    (net "N1"
+      (pins U1-1)
+    )
+  )
+  (wiring
+    (wire
+      (path F.Cu 200 0 0 1000 0)
+      (net "N1" 7)
+      (type route)
+    )
+  )
+)
+`
+
+  const parsed = parseDsnToDsnJson(dsn) as DsnPcb
+  expect(parsed.wiring.wires[0].net).toBe("N1")
+  expect(parsed.wiring.wires[0].net_number).toBe(7)
+
+  const stringified = stringifyDsnJson(parsed)
+  expect(stringified).toContain('(net "N1" 7)')
+
+  const reparsed = parseDsnToDsnJson(stringified) as DsnPcb
+  expect(reparsed.wiring.wires[0].net).toBe("N1")
+  expect(reparsed.wiring.wires[0].net_number).toBe(7)
+})


### PR DESCRIPTION
## Summary
- preserve optional numeric wire net ids from DSN wiring `(net "NAME" 7)` records while parsing
- emit that optional wire net id again when stringifying DSN JSON
- add a focused parse -> stringify -> parse regression test

This is intentionally scoped to wire-level net metadata and does not touch top-level network net numbers from #316.

## Verification
- `npx --yes bun test tests/dsn-pcb/dsn-wire-net-number.test.ts`
- `npx --yes @biomejs/biome check lib/dsn-pcb/types.ts lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts tests/dsn-pcb/dsn-wire-net-number.test.ts`
- `npx tsc --noEmit`
- `npx --yes bun test`
- `npx --yes bun run build`

/claim #54

Transparency: AI-assisted with Codex; I reviewed the diff and ran the verification above.