### PR TITLE
Preserve clearance type strings

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
@@ -60,7 +60,7 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
   result += `${indent}${indent}(rule\n`
   result += `${indent}${indent}${indent}(width ${dsnJson.structure.rule.width})\n`
   dsnJson.structure.rule.clearances.forEach((clearance) => {
-    result += `${indent}${indent}${indent}(clearance ${clearance.value}${clearance.type ? ` (type ${clearance.type})` : ""})\n`
+    result += `${indent}${indent}${indent}(clearance ${clearance.value}${clearance.type ? ` (type ${stringifyValue(clearance.type)})` : ""})\n`
   })
   result += `${indent}${indent})\n`
   result += `${indent})\n`
@@ -124,7 +124,7 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
       result += `${indent}${indent}${indent}(rule\n`
       result += `${indent}${indent}${indent}${indent}(width ${cls.rule.width})\n`
       cls.rule.clearances.forEach((clearance) => {
-        result += `${indent}${indent}${indent}${indent}(clearance ${clearance.value}${clearance.type ? ` (type ${clearance.type})` : ""})\n`
+        result += `${indent}${indent}${indent}${indent}(clearance ${clearance.value}${clearance.type ? ` (type ${stringifyValue(clearance.type)})` : ""})\n`
       })
       result += `${indent}${indent}${indent})\n`
     }

--- a/tests/dsn-pcb/stringify-dsn-json.test.ts
+++ b/tests/dsn-pcb/stringify-dsn-json.test.ts
@@ -17,3 +17,91 @@ test("stringify dsn json", () => {
   // Test that we can parse the generated string back to the same structure
   // expect(reparsedJson).toEqual(dsnJson)
 })
+
+test("quotes clearance type names when stringifying", () => {
+  const dsnJson: DsnPcb = {
+    is_dsn_pcb: true,
+    filename: "clearance-types.dsn",
+    parser: {
+      string_quote: '"',
+      host_version: "",
+      space_in_quoted_tokens: "on",
+      host_cad: "test",
+    },
+    resolution: {
+      unit: "um",
+      value: 10,
+    },
+    unit: "um",
+    structure: {
+      layers: [
+        {
+          name: "F.Cu",
+          type: "signal",
+          property: {
+            index: 0,
+          },
+        },
+      ],
+      boundary: {
+        path: {
+          layer: "pcb",
+          width: 0,
+          coordinates: [0, 0, 1000, 0, 1000, 1000, 0, 1000, 0, 0],
+        },
+      },
+      via: "Via[0-0]_600:300_um",
+      rule: {
+        width: 200,
+        clearances: [
+          {
+            value: 200,
+            type: "kicad default",
+          },
+        ],
+      },
+    },
+    placement: {
+      components: [],
+    },
+    library: {
+      images: [],
+      padstacks: [],
+    },
+    network: {
+      nets: [],
+      classes: [
+        {
+          name: "default",
+          description: "",
+          net_names: [],
+          circuit: {
+            use_via: "Via[0-0]_600:300_um",
+          },
+          rule: {
+            width: 100,
+            clearances: [
+              {
+                value: 50,
+                type: "class gap",
+              },
+            ],
+          },
+        },
+      ],
+    },
+    wiring: {
+      wires: [],
+    },
+  }
+
+  const dsnString = stringifyDsnJson(dsnJson)
+  const reparsedJson = parseDsnToDsnJson(dsnString) as DsnPcb
+
+  expect(dsnString).toContain('(clearance 200 (type "kicad default"))')
+  expect(dsnString).toContain('(clearance 50 (type "class gap"))')
+  expect(reparsedJson.structure.rule.clearances[0].type).toBe("kicad default")
+  expect(reparsedJson.network.classes[0].rule.clearances[0].type).toBe(
+    "class gap",
+  )
+})


### PR DESCRIPTION
/claim #54

## Summary
- Quote DSN `clearance` type strings when stringifying structure rules and network class rules.
- Preserve type names containing spaces through parse -> stringify -> parse instead of emitting invalid/raw multi-token values.
- Add a focused regression covering both top-level structure rule clearances and class rule clearances.

## Why
DSN rule clearances can include typed metadata such as `(clearance 200 (type "kicad default"))`. The parser keeps the type value, but `stringifyDsnJson` wrote it as a raw token, so names that require quoting were split or changed when reparsed.

## Verification
- `bun test tests/dsn-pcb/stringify-dsn-json.test.ts -t "quotes clearance type names"`
- `bun x biome check lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts tests/dsn-pcb/stringify-dsn-json.test.ts`
- `git diff --check`
- `bun run build`
- `bun x tsc --noEmit`

Note: `bun test tests/dsn-pcb/stringify-dsn-json.test.ts` still fails on the existing unrelated `string_quote` parser/stringifier round-trip mismatch in the older fixture test.