### PR TITLE
Include drill size in rectangular padstack names

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/process-plated-holes.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/process-plated-holes.ts
@@ -72,6 +72,7 @@ export function processPlatedHoles(
           shape: "rect",
           width: hole.rect_pad_width * 1000,
           height: hole.rect_pad_height * 1000,
+          holeDiameter: hole.hole_diameter * 1000,
           layer: "all",
         })
         if (!processedPadstacks.has(name)) {

--- a/lib/utils/get-padstack-name.ts
+++ b/lib/utils/get-padstack-name.ts
@@ -31,6 +31,9 @@ export function getPadstackName({
     case "pill":
       return `Oval[${layerCode}]Pad_${width}x${height}_um`
     case "rect":
+      if (holeDiameter !== undefined) {
+        return `RoundRect[${layerCode}]Pad_${width}x${height}_${holeDiameter}_um`
+      }
       return `RoundRect[${layerCode}]Pad_${width}x${height}_um`
     default:
       return "default_pad"

--- a/tests/dsn-pcb/circular-hole-rect-padstack-name.test.ts
+++ b/tests/dsn-pcb/circular-hole-rect-padstack-name.test.ts
@@ -1,0 +1,69 @@
+import { expect, test } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { convertCircuitJsonToDsnJson } from "lib"
+
+test("keeps rectangular plated-hole padstacks distinct by drill diameter", () => {
+  const circuitJson: AnyCircuitElement[] = [
+    {
+      type: "pcb_board",
+      width: 10,
+      height: 10,
+      center: { x: 0, y: 0 },
+      num_layers: 2,
+    } as AnyCircuitElement,
+    {
+      type: "source_component",
+      source_component_id: "sc1",
+      name: "J1",
+      ftype: "simple_resistor",
+    } as AnyCircuitElement,
+    {
+      type: "pcb_component",
+      pcb_component_id: "pc1",
+      source_component_id: "sc1",
+      center: { x: 0, y: 0 },
+      rotation: 0,
+    } as AnyCircuitElement,
+    {
+      type: "pcb_plated_hole",
+      pcb_plated_hole_id: "hole_small",
+      pcb_component_id: "pc1",
+      shape: "circular_hole_with_rect_pad",
+      x: -0.5,
+      y: 0,
+      rect_pad_width: 1.6,
+      rect_pad_height: 1,
+      hole_diameter: 0.6,
+    } as AnyCircuitElement,
+    {
+      type: "pcb_plated_hole",
+      pcb_plated_hole_id: "hole_large",
+      pcb_component_id: "pc1",
+      shape: "circular_hole_with_rect_pad",
+      x: 0.5,
+      y: 0,
+      rect_pad_width: 1.6,
+      rect_pad_height: 1,
+      hole_diameter: 0.9,
+    } as AnyCircuitElement,
+  ]
+
+  const dsnJson = convertCircuitJsonToDsnJson(circuitJson)
+  const rectHolePadstacks = dsnJson.library.padstacks.filter((padstack) =>
+    padstack.name.startsWith("RoundRect[A]Pad_1600x1000_"),
+  )
+
+  expect(rectHolePadstacks.map((padstack) => padstack.name).sort()).toEqual([
+    "RoundRect[A]Pad_1600x1000_600_um",
+    "RoundRect[A]Pad_1600x1000_900_um",
+  ])
+  expect(
+    rectHolePadstacks.map((padstack) => padstack.hole?.diameter).sort(),
+  ).toEqual([600, 900])
+  expect(
+    dsnJson.library.images[0].pins.map((pin) => pin.padstack_name),
+  ).toEqual([
+    "RoundRect[A]Pad_1600x1000_600_um",
+    "RoundRect[A]Pad_1600x1000_900_um",
+  ])
+})


### PR DESCRIPTION
Summary
- Include the drill diameter in generated RoundRect padstack names for circular_hole_with_rect_pad plated holes.
- Prevent rectangular plated holes with the same outer pad size but different drill sizes from sharing one padstack definition.
- Add regression coverage proving distinct padstack names, hole diameters, and image pin references.

/claim #54

Verification
- bun test tests/dsn-pcb/circular-hole-rect-padstack-name.test.ts
- bunx biome check lib/utils/get-padstack-name.ts lib/dsn-pcb/circuit-json-to-dsn-json/process-plated-holes.ts tests/dsn-pcb/circular-hole-rect-padstack-name.test.ts
- bunx tsc --noEmit
- bun test
- bun run build
- git diff --check

Transparency note: AI-assisted with Codex; I reviewed the diff and verified it locally before submission.