### PR TITLE
Preserve DSN wiring via types

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
@@ -136,7 +136,7 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
   result += `${indent}(wiring\n`
   ;(dsnJson.wiring?.wires ?? []).forEach((wire) => {
     if (wire.type === "via") {
-      result += `${indent}${indent}(via ${stringifyPath(wire.path, 3)}(net ${stringifyValue(wire.net)}))\n`
+      result += `${indent}${indent}(via ${stringifyPath(wire.path, 3)}(net ${stringifyValue(wire.net)})${wire.via_type ? `(type ${wire.via_type})` : ""})\n`
     } else {
       result += `${indent}${indent}(wire ${stringifyPath(wire.path, 3)}(net ${stringifyValue(wire.net)})(type ${wire.type}))\n`
     }

--- a/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
@@ -959,6 +959,20 @@ function processVia(nodes: ASTNode[]): Wire | null {
     wire.net = String(netNode.children[1].value)
   }
 
+  const typeNode = nodes.find(
+    (node) =>
+      node.type === "List" &&
+      node.children?.[0]?.type === "Atom" &&
+      node.children[0].value === "type",
+  )
+
+  if (
+    typeNode?.children?.[1]?.type === "Atom" &&
+    typeof typeNode.children[1].value === "string"
+  ) {
+    wire.via_type = typeNode.children[1].value
+  }
+
   return wire as Wire
 }
 

--- a/lib/dsn-pcb/types.ts
+++ b/lib/dsn-pcb/types.ts
@@ -78,6 +78,7 @@ export interface DsnPcb {
         coordinates: number[]
       }
       net: string
+      via_type?: string
       type: string
     }>
   }
@@ -280,6 +281,7 @@ export interface Wire {
     coordinates: number[]
   }
   net?: string
+  via_type?: string
   clearance_class?: string
   type?: string
 }

--- a/tests/dsn-pcb/dsn-wiring-via-type.test.ts
+++ b/tests/dsn-pcb/dsn-wiring-via-type.test.ts
@@ -1,0 +1,55 @@
+import { expect, test } from "bun:test"
+import { type DsnPcb, parseDsnToDsnJson, stringifyDsnJson } from "lib"
+
+test("preserves wiring via type metadata during DSN JSON round trip", () => {
+  const dsn = `(pcb board.dsn
+  (parser
+    (string_quote ")
+    (space_in_quoted_tokens on)
+    (host_cad "KiCad's Pcbnew")
+    (host_version "9.0")
+  )
+  (resolution um 10)
+  (unit um)
+  (structure
+    (layer F.Cu
+      (type signal)
+      (property
+        (index 0)
+      )
+    )
+    (boundary
+      (path pcb 0 0 0 1000 0 1000 1000 0 1000 0 0)
+    )
+    (via "Via[0-1]_600:300_um")
+    (rule
+      (width 200)
+    )
+  )
+  (placement)
+  (library)
+  (network
+    (net "N1"
+      (pins U1-1)
+    )
+  )
+  (wiring
+    (via "Via[0-1]_600:300_um" 100 200
+      (net "N1")
+      (type protect)
+    )
+  )
+)
+`
+
+  const parsed = parseDsnToDsnJson(dsn) as DsnPcb
+  expect(parsed.wiring.wires[0].type).toBe("via")
+  expect(parsed.wiring.wires[0].via_type).toBe("protect")
+
+  const stringified = stringifyDsnJson(parsed)
+  expect(stringified).toContain("(type protect)")
+
+  const reparsed = parseDsnToDsnJson(stringified) as DsnPcb
+  expect(reparsed.wiring.wires[0].type).toBe("via")
+  expect(reparsed.wiring.wires[0].via_type).toBe("protect")
+})


### PR DESCRIPTION
## Summary
- preserve optional DSN PCB wiring-via `(type ...)` metadata while parsing
- stringify preserved wiring-via type metadata without changing the internal `type: "via"` marker
- add focused parse -> stringify -> parse coverage for Freerouting-style `(type protect)` vias

This is intentionally scoped to wiring-via type metadata. It does not touch via padstack dimensions, session vias, top-level network vias, wire metadata, or standard via record formatting from #276.

## Verification
- `npx --yes bun test tests/dsn-pcb/dsn-wiring-via-type.test.ts`
- `npx --yes @biomejs/biome check lib/dsn-pcb/types.ts lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts tests/dsn-pcb/dsn-wiring-via-type.test.ts`
- `npx tsc --noEmit`
- `npx --yes bun test`
- `npx --yes bun run build`
- `git diff --check`

/claim #54

Transparency: AI-assisted with Codex; I reviewed the diff and ran the verification above.