### PR TITLE
Export pill SMT pads as oval padstacks

### DIFF
--- a/lib/utils/create-and-add-padstack-for-pcb-smtpad.ts
+++ b/lib/utils/create-and-add-padstack-for-pcb-smtpad.ts
@@ -3,6 +3,7 @@ import type { Padstack } from "lib"
 import type { DsnPcb } from "lib"
 import {
   createCircularPadstack,
+  createOvalSmtPadstack,
   createRectangularPadstack,
 } from "./create-padstack"
 import { type PadstackNameArgs, getPadstackName } from "./get-padstack-name"
@@ -13,12 +14,14 @@ export function createAndAddPadstackFromPcbSmtPad(
   processedPadstacks: Set<string>,
 ): string {
   const isCircle = pad.shape === "circle"
+  const isPill = pad.shape === "pill"
+  const sizedPad = pad as PcbSmtPad & { width: number; height: number }
   const padstackParams: PadstackNameArgs = {
-    shape: isCircle ? "circle" : "rect",
+    shape: isCircle ? "circle" : isPill ? "pill" : "rect",
     outerDiameter: isCircle ? pad.radius * 1000 * 2 : undefined, // Radius to diameter
     holeDiameter: isCircle ? pad.radius * 1000 * 2 : undefined, // Radius to diameter
-    width: isCircle ? undefined : (pad as { width: number }).width * 1000,
-    height: isCircle ? undefined : (pad as { height: number }).height * 1000,
+    width: isCircle ? undefined : sizedPad.width * 1000,
+    height: isCircle ? undefined : sizedPad.height * 1000,
     layer: pad.layer as PcbSmtPad["layer"],
   }
 
@@ -31,12 +34,19 @@ export function createAndAddPadstackFromPcbSmtPad(
           padstackParams.outerDiameter!,
           padstackParams.holeDiameter!,
         )
-      : createRectangularPadstack(
-          padstackName,
-          padstackParams.width!,
-          padstackParams.height!,
-          pad.layer,
-        )
+      : isPill
+        ? createOvalSmtPadstack(
+            padstackName,
+            padstackParams.width!,
+            padstackParams.height!,
+            pad.layer,
+          )
+        : createRectangularPadstack(
+            padstackName,
+            padstackParams.width!,
+            padstackParams.height!,
+            pad.layer,
+          )
 
     pcb.library.padstacks.push(padstack)
     processedPadstacks.add(padstackName)

--- a/lib/utils/create-padstack.ts
+++ b/lib/utils/create-padstack.ts
@@ -55,6 +55,31 @@ export function createOvalPadstack(
   }
 }
 
+export function createOvalSmtPadstack(
+  name: string,
+  width: number,
+  height: number,
+  layer: PcbSmtPad["layer"],
+): Padstack {
+  const pathOffset = Math.abs(width - height) / 2
+  const isHorizontal = width > height
+
+  return {
+    name,
+    shapes: [
+      {
+        shapeType: "path",
+        layer: layer === "bottom" ? "B.Cu" : "F.Cu",
+        width: isHorizontal ? height : width,
+        coordinates: isHorizontal
+          ? [-pathOffset, 0, pathOffset, 0]
+          : [0, -pathOffset, 0, pathOffset],
+      },
+    ],
+    attach: "off",
+  }
+}
+
 export function createRectangularPadstack(
   name: string,
   width: number,

--- a/lib/utils/create-pin-for-image.ts
+++ b/lib/utils/create-pin-for-image.ts
@@ -12,8 +12,9 @@ export function createPinForImage(
   if (!sourcePort) return undefined
 
   const isCircle = pad.shape === "circle"
+  const isPill = pad.shape === "pill"
   const padstackParams: PadstackNameArgs = {
-    shape: isCircle ? "circle" : "rect",
+    shape: isCircle ? "circle" : isPill ? "pill" : "rect",
     outerDiameter: isCircle ? pad.radius * 1000 * 2 : undefined, // Radius to diameter
     holeDiameter: isCircle ? pad.radius * 1000 * 2 : undefined, // Radius to diameter
     width: isCircle ? undefined : pad.width * 1000,

--- a/tests/dsn-pcb/pill-smt-padstack-export.test.ts
+++ b/tests/dsn-pcb/pill-smt-padstack-export.test.ts
@@ -1,0 +1,76 @@
+import { expect, test } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { convertCircuitJsonToDsnJson } from "lib"
+
+test("exports pill SMT pads as oval layer padstacks", () => {
+  const circuitJson: AnyCircuitElement[] = [
+    {
+      type: "pcb_board",
+      width: 10,
+      height: 10,
+      center: { x: 0, y: 0 },
+      num_layers: 2,
+    } as AnyCircuitElement,
+    {
+      type: "source_component",
+      source_component_id: "sc1",
+      name: "LED1",
+      ftype: "simple_resistor",
+    } as AnyCircuitElement,
+    {
+      type: "pcb_component",
+      pcb_component_id: "pc1",
+      source_component_id: "sc1",
+      center: { x: 0, y: 0 },
+      rotation: 0,
+    } as AnyCircuitElement,
+    {
+      type: "source_port",
+      source_port_id: "sp1",
+      source_component_id: "sc1",
+      name: "1",
+      port_hints: ["1"],
+    } as AnyCircuitElement,
+    {
+      type: "pcb_port",
+      pcb_port_id: "pp1",
+      source_port_id: "sp1",
+      pcb_component_id: "pc1",
+      x: 0,
+      y: 0,
+      layers: ["top"],
+    } as AnyCircuitElement,
+    {
+      type: "pcb_smtpad",
+      pcb_smtpad_id: "pad1",
+      pcb_component_id: "pc1",
+      pcb_port_id: "pp1",
+      shape: "pill",
+      x: 0,
+      y: 0,
+      width: 1.6,
+      height: 0.8,
+      radius: 0.4,
+      layer: "top",
+    } as AnyCircuitElement,
+  ]
+
+  const dsnJson = convertCircuitJsonToDsnJson(circuitJson)
+  const padstack = dsnJson.library.padstacks.find(
+    (padstack) => padstack.name === "Oval[T]Pad_1600x800_um",
+  )
+
+  expect(padstack).toBeDefined()
+  expect(padstack?.hole).toBeUndefined()
+  expect(padstack?.shapes).toEqual([
+    {
+      shapeType: "path",
+      layer: "F.Cu",
+      width: 800,
+      coordinates: [-400, 0, 400, 0],
+    },
+  ])
+  expect(dsnJson.library.images[0].pins[0].padstack_name).toBe(
+    "Oval[T]Pad_1600x800_um",
+  )
+})


### PR DESCRIPTION
Summary
- Export `pcb_smtpad` entries with `shape: "pill"` as Oval layer-specific path padstacks instead of rectangular polygon padstacks.
- Keep pill SMT padstacks free of through-hole metadata while preserving the existing image pin padstack name link.
- Add focused Circuit JSON -> DSN JSON regression coverage for a top-layer pill SMT pad.

/claim #54

Verification
- bun test tests/dsn-pcb/pill-smt-padstack-export.test.ts
- bunx biome check lib/utils/create-padstack.ts lib/utils/create-and-add-padstack-for-pcb-smtpad.ts lib/utils/create-pin-for-image.ts tests/dsn-pcb/pill-smt-padstack-export.test.ts
- bunx tsc --noEmit
- bun test
- bun run build
- git diff --check

Transparency note: AI-assisted with Codex; I reviewed the diff and verified it locally before submission.