### PR TITLE
Export rotated SMT pad pin rotation

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
@@ -86,7 +86,8 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
       result += `${indent}${indent}${indent}(outline ${stringifyPath(outline.path, 4)})\n`
     })
     image.pins.forEach((pin) => {
-      result += `${indent}${indent}${indent}(pin ${pin.padstack_name} ${pin.pin_number} ${pin.x} ${pin.y})\n`
+      const rotation = pin.rotation ? `(rotate ${pin.rotation}) ` : ""
+      result += `${indent}${indent}${indent}(pin ${pin.padstack_name} ${rotation}${pin.pin_number} ${pin.x} ${pin.y})\n`
     })
     result += `${indent}${indent})\n`
   })

--- a/lib/dsn-pcb/types.ts
+++ b/lib/dsn-pcb/types.ts
@@ -191,6 +191,7 @@ export interface Outline {
 export interface Pin {
   padstack_name: string
   pin_number: number | string
+  rotation?: number
   x: number
   y: number
 }

--- a/lib/utils/create-pin-for-image.ts
+++ b/lib/utils/create-pin-for-image.ts
@@ -25,6 +25,7 @@ export function createPinForImage(
     padstack_name: getPadstackName(padstackParams),
     pin_number:
       sourcePort.port_hints?.find((hint) => !Number.isNaN(Number(hint))) || 1,
+    rotation: pad.shape === "rotated_rect" ? pad.ccw_rotation : undefined,
     x: (pad.x - pcbComponent.center.x) * 1000,
     y: (pad.y - pcbComponent.center.y) * 1000,
   }

--- a/tests/dsn-pcb/rotated-smt-pad-pin-export.test.ts
+++ b/tests/dsn-pcb/rotated-smt-pad-pin-export.test.ts
@@ -1,0 +1,71 @@
+import { expect, test } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { convertCircuitJsonToDsnJson, stringifyDsnJson } from "lib"
+
+test("exports rotated rectangular SMT pads with pin rotation", () => {
+  const circuitJson: AnyCircuitElement[] = [
+    {
+      type: "pcb_board",
+      width: 10,
+      height: 10,
+      center: { x: 0, y: 0 },
+      num_layers: 2,
+    } as AnyCircuitElement,
+    {
+      type: "source_component",
+      source_component_id: "sc1",
+      name: "U1",
+      ftype: "simple_chip",
+    } as AnyCircuitElement,
+    {
+      type: "pcb_component",
+      pcb_component_id: "pc1",
+      source_component_id: "sc1",
+      center: { x: 0, y: 0 },
+      rotation: 0,
+    } as AnyCircuitElement,
+    {
+      type: "source_port",
+      source_port_id: "sp1",
+      source_component_id: "sc1",
+      name: "1",
+      port_hints: ["1"],
+    } as AnyCircuitElement,
+    {
+      type: "pcb_port",
+      pcb_port_id: "pp1",
+      source_port_id: "sp1",
+      pcb_component_id: "pc1",
+      x: 0,
+      y: 0,
+      layers: ["top"],
+    } as AnyCircuitElement,
+    {
+      type: "pcb_smtpad",
+      pcb_smtpad_id: "pad1",
+      pcb_component_id: "pc1",
+      pcb_port_id: "pp1",
+      shape: "rotated_rect",
+      x: 0,
+      y: 0,
+      width: 1,
+      height: 0.5,
+      ccw_rotation: 90,
+      layer: "top",
+    } as AnyCircuitElement,
+  ]
+
+  const dsnJson = convertCircuitJsonToDsnJson(circuitJson)
+  const pin = dsnJson.library.images[0].pins[0]
+
+  expect(pin).toMatchObject({
+    padstack_name: "RoundRect[T]Pad_1000x500_um",
+    pin_number: "1",
+    rotation: 90,
+    x: 0,
+    y: 0,
+  })
+  expect(stringifyDsnJson(dsnJson)).toContain(
+    "(pin RoundRect[T]Pad_1000x500_um (rotate 90) 1 0 0)",
+  )
+})


### PR DESCRIPTION
Summary
- Preserve `ccw_rotation` from `rotated_rect` SMT pads as optional DSN image-pin rotation.
- Stringify pin-level `(rotate ...)` only when the image pin carries rotation metadata.
- Add focused Circuit JSON -> DSN JSON/string regression coverage proving `(rotate 90)` is emitted for a rotated SMT pad.

/claim #54

Verification
- bun test tests/dsn-pcb/rotated-smt-pad-pin-export.test.ts
- bunx biome check lib/dsn-pcb/types.ts lib/utils/create-pin-for-image.ts lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts tests/dsn-pcb/rotated-smt-pad-pin-export.test.ts
- bunx tsc --noEmit
- bun test
- bun run build
- git diff --check

Transparency note: AI-assisted with Codex; I reviewed the diff and verified it locally before submission.