### PR TITLE
Use source port pin numbers in DSN export

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/process-nets.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/process-nets.ts
@@ -1,6 +1,13 @@
 import { su } from "@tscircuit/soup-util"
-import type { AnyCircuitElement, SourceTrace } from "circuit-json"
+import type { AnyCircuitElement, SourcePort, SourceTrace } from "circuit-json"
 import type { DsnPcb } from "../types"
+
+function getNumericPortIdentifier(sourcePort: SourcePort): string | undefined {
+  const numericHint = sourcePort.port_hints?.find(
+    (hint) => !Number.isNaN(Number(hint)),
+  )
+  return numericHint ?? sourcePort.pin_number?.toString()
+}
 
 export function processNets(circuitElements: AnyCircuitElement[], pcb: DsnPcb) {
   const componentNameMap = new Map<string, string>()
@@ -30,9 +37,7 @@ export function processNets(circuitElements: AnyCircuitElement[], pcb: DsnPcb) {
         if (sourcePort && "source_component_id" in sourcePort) {
           const componentName =
             componentNameMap.get(sourcePort.source_component_id ?? "") || ""
-          const pinNumber = sourcePort.port_hints?.find(
-            (hint) => !Number.isNaN(Number(hint)),
-          )
+          const pinNumber = getNumericPortIdentifier(sourcePort)
 
           padsBySourcePortId.set(sourcePort.source_port_id, {
             componentName: `${componentName}_${sourcePort.source_component_id}`,

--- a/lib/utils/create-pin-for-image.ts
+++ b/lib/utils/create-pin-for-image.ts
@@ -20,11 +20,13 @@ export function createPinForImage(
     height: isCircle ? undefined : pad.height * 1000,
     layer: pad.layer as PcbSmtPad["layer"],
   }
+  const numericHint = sourcePort.port_hints?.find(
+    (hint) => !Number.isNaN(Number(hint)),
+  )
 
   return {
     padstack_name: getPadstackName(padstackParams),
-    pin_number:
-      sourcePort.port_hints?.find((hint) => !Number.isNaN(Number(hint))) || 1,
+    pin_number: numericHint ?? sourcePort.pin_number ?? 1,
     x: (pad.x - pcbComponent.center.x) * 1000,
     y: (pad.y - pcbComponent.center.y) * 1000,
   }

--- a/tests/dsn-pcb/source-port-pin-number-export.test.ts
+++ b/tests/dsn-pcb/source-port-pin-number-export.test.ts
@@ -1,0 +1,98 @@
+import { expect, test } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { convertCircuitJsonToDsnJson } from "lib"
+
+test("uses source_port pin_number when exporting DSN pins and nets", () => {
+  const circuitJson: AnyCircuitElement[] = [
+    {
+      type: "pcb_board",
+      width: 10,
+      height: 10,
+      center: { x: 0, y: 0 },
+      num_layers: 2,
+    } as AnyCircuitElement,
+    {
+      type: "source_component",
+      source_component_id: "sc1",
+      name: "U1",
+      ftype: "simple_chip",
+    } as AnyCircuitElement,
+    {
+      type: "pcb_component",
+      pcb_component_id: "pc1",
+      source_component_id: "sc1",
+      center: { x: 0, y: 0 },
+      rotation: 0,
+    } as AnyCircuitElement,
+    {
+      type: "source_port",
+      source_port_id: "sp1",
+      source_component_id: "sc1",
+      name: "IO5",
+      pin_number: 5,
+    } as AnyCircuitElement,
+    {
+      type: "source_port",
+      source_port_id: "sp2",
+      source_component_id: "sc1",
+      name: "IO7",
+      pin_number: 7,
+    } as AnyCircuitElement,
+    {
+      type: "pcb_port",
+      pcb_port_id: "pp1",
+      source_port_id: "sp1",
+      pcb_component_id: "pc1",
+      x: -0.5,
+      y: 0,
+      layers: ["top"],
+    } as AnyCircuitElement,
+    {
+      type: "pcb_port",
+      pcb_port_id: "pp2",
+      source_port_id: "sp2",
+      pcb_component_id: "pc1",
+      x: 0.5,
+      y: 0,
+      layers: ["top"],
+    } as AnyCircuitElement,
+    {
+      type: "pcb_smtpad",
+      pcb_smtpad_id: "pad1",
+      pcb_component_id: "pc1",
+      pcb_port_id: "pp1",
+      shape: "rect",
+      x: -0.5,
+      y: 0,
+      width: 0.5,
+      height: 0.5,
+      layer: "top",
+    } as AnyCircuitElement,
+    {
+      type: "pcb_smtpad",
+      pcb_smtpad_id: "pad2",
+      pcb_component_id: "pc1",
+      pcb_port_id: "pp2",
+      shape: "rect",
+      x: 0.5,
+      y: 0,
+      width: 0.5,
+      height: 0.5,
+      layer: "top",
+    } as AnyCircuitElement,
+    {
+      type: "source_trace",
+      source_trace_id: "st1",
+      connected_source_port_ids: ["sp1", "sp2"],
+    } as AnyCircuitElement,
+  ]
+
+  const dsnJson = convertCircuitJsonToDsnJson(circuitJson)
+  const imagePins = dsnJson.library.images[0].pins.map((pin) => pin.pin_number)
+  const net = dsnJson.network.nets.find(
+    (net) => net.name === "Net-(U1_sc1-Pad5)",
+  )
+
+  expect(imagePins).toEqual([5, 7])
+  expect(net?.pins).toEqual(["U1_sc1-5", "U1_sc1-7"])
+})


### PR DESCRIPTION
Summary
- Use `source_port.pin_number` as the numeric fallback when DSN export has no numeric `port_hints`.
- Preserve those pin numbers in generated library image pins and network pin references.
- Add focused Circuit JSON -> DSN JSON coverage for connected SMT pads that only define `pin_number`.

/claim #54

Verification
- bun test tests/dsn-pcb/source-port-pin-number-export.test.ts
- bunx biome check lib/utils/create-pin-for-image.ts lib/dsn-pcb/circuit-json-to-dsn-json/process-nets.ts tests/dsn-pcb/source-port-pin-number-export.test.ts
- bunx tsc --noEmit
- bun test
- bun run build
- git diff --check

Transparency note: AI-assisted with Codex; I reviewed the diff and verified it locally before submission.