### PR TITLE
Export display value as placement PN

### DIFF
--- a/lib/utils/get-component-value.ts
+++ b/lib/utils/get-component-value.ts
@@ -1,5 +1,8 @@
 export function getComponentValue(sourceComponent: any): string {
   if (!sourceComponent) return ""
+  if (sourceComponent.display_value !== undefined) {
+    return String(sourceComponent.display_value)
+  }
   if ("resistance" in sourceComponent) {
     return sourceComponent.resistance >= 1000
       ? `${sourceComponent.resistance / 1000}k`

--- a/tests/dsn-pcb/display-value-placement-pn.test.ts
+++ b/tests/dsn-pcb/display-value-placement-pn.test.ts
@@ -1,0 +1,61 @@
+import { expect, test } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { convertCircuitJsonToDsnJson } from "lib"
+
+test("exports source component display_value as placement PN", () => {
+  const circuitJson: AnyCircuitElement[] = [
+    {
+      type: "pcb_board",
+      width: 10,
+      height: 10,
+      center: { x: 0, y: 0 },
+      num_layers: 2,
+    } as AnyCircuitElement,
+    {
+      type: "source_component",
+      source_component_id: "sc1",
+      name: "U1",
+      ftype: "simple_chip",
+      display_value: "ATmega328P-AU",
+    } as AnyCircuitElement,
+    {
+      type: "pcb_component",
+      pcb_component_id: "pc1",
+      source_component_id: "sc1",
+      center: { x: 0, y: 0 },
+      rotation: 0,
+    } as AnyCircuitElement,
+    {
+      type: "source_port",
+      source_port_id: "sp1",
+      source_component_id: "sc1",
+      name: "1",
+      port_hints: ["1"],
+    } as AnyCircuitElement,
+    {
+      type: "pcb_port",
+      pcb_port_id: "pp1",
+      source_port_id: "sp1",
+      pcb_component_id: "pc1",
+      x: 0,
+      y: 0,
+      layers: ["top"],
+    } as AnyCircuitElement,
+    {
+      type: "pcb_smtpad",
+      pcb_smtpad_id: "pad1",
+      pcb_component_id: "pc1",
+      pcb_port_id: "pp1",
+      shape: "rect",
+      x: 0,
+      y: 0,
+      width: 0.5,
+      height: 0.5,
+      layer: "top",
+    } as AnyCircuitElement,
+  ]
+
+  const dsnJson = convertCircuitJsonToDsnJson(circuitJson)
+
+  expect(dsnJson.placement.components[0].places[0].PN).toBe("ATmega328P-AU")
+})


### PR DESCRIPTION
Summary
- Prefer `source_component.display_value` when deriving DSN placement PN metadata.
- Keep the existing resistor/capacitor value fallbacks when no explicit display value is present.
- Add focused Circuit JSON -> DSN JSON coverage proving explicit display values reach placement PN.

/claim #54

Verification
- bun test tests/dsn-pcb/display-value-placement-pn.test.ts
- bunx biome check lib/utils/get-component-value.ts tests/dsn-pcb/display-value-placement-pn.test.ts
- bunx tsc --noEmit
- bun test
- bun run build
- git diff --check

Transparency note: AI-assisted with Codex; I reviewed the diff and verified it locally before submission.