### PR TITLE
Omit missing DSN rule widths

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
@@ -20,6 +20,10 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
     return coordinates.join(" ")
   }
 
+  const hasNumericWidth = (rule: { width?: unknown }): rule is {
+    width: number
+  } => typeof rule.width === "number" && Number.isFinite(rule.width)
+
   // Helper function to stringify a path
   const stringifyPath = (path: any, level: number): string => {
     const padding = indent.repeat(level)
@@ -58,7 +62,9 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
   }
   result += `${indent}${indent}(via ${stringifyValue(dsnJson.structure.via)})\n`
   result += `${indent}${indent}(rule\n`
-  result += `${indent}${indent}${indent}(width ${dsnJson.structure.rule.width})\n`
+  if (hasNumericWidth(dsnJson.structure.rule)) {
+    result += `${indent}${indent}${indent}(width ${dsnJson.structure.rule.width})\n`
+  }
   dsnJson.structure.rule.clearances.forEach((clearance) => {
     result += `${indent}${indent}${indent}(clearance ${clearance.value}${clearance.type ? ` (type ${clearance.type})` : ""})\n`
   })
@@ -122,7 +128,9 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
     result += `${indent}${indent}${indent})\n`
     if (cls.rule) {
       result += `${indent}${indent}${indent}(rule\n`
-      result += `${indent}${indent}${indent}${indent}(width ${cls.rule.width})\n`
+      if (hasNumericWidth(cls.rule)) {
+        result += `${indent}${indent}${indent}${indent}(width ${cls.rule.width})\n`
+      }
       cls.rule.clearances.forEach((clearance) => {
         result += `${indent}${indent}${indent}${indent}(clearance ${clearance.value}${clearance.type ? ` (type ${clearance.type})` : ""})\n`
       })

--- a/tests/dsn-pcb/omit-missing-rule-width.test.ts
+++ b/tests/dsn-pcb/omit-missing-rule-width.test.ts
@@ -1,0 +1,65 @@
+import { expect, test } from "bun:test"
+import { type DsnPcb, stringifyDsnJson } from "lib"
+
+test("omits missing rule widths instead of emitting undefined", () => {
+  const dsnJson = {
+    is_dsn_pcb: true,
+    filename: "missing-rule-width.dsn",
+    parser: {
+      string_quote: "",
+      space_in_quoted_tokens: "on",
+      host_cad: "test",
+      host_version: "1",
+    },
+    resolution: { unit: "um", value: 10 },
+    unit: "um",
+    structure: {
+      layers: [],
+      boundary: {
+        path: {
+          layer: "pcb",
+          width: 0,
+          coordinates: [0, 0, 1000, 0, 1000, 1000, 0, 1000, 0, 0],
+        },
+      },
+      via: "Via[0-1]_600:300_um",
+      rule: {
+        clearances: [{ value: 150 }],
+      },
+    },
+    placement: { components: [] },
+    library: { images: [], padstacks: [] },
+    network: {
+      nets: [],
+      classes: [
+        {
+          name: "no_width",
+          description: "",
+          net_names: [],
+          circuit: { use_via: "Via[0-1]_600:300_um" },
+          rule: {
+            clearances: [{ value: 75 }],
+          },
+        },
+        {
+          name: "with_width",
+          description: "",
+          net_names: [],
+          circuit: { use_via: "Via[0-1]_600:300_um" },
+          rule: {
+            width: 42,
+            clearances: [{ value: 25 }],
+          },
+        },
+      ],
+    },
+    wiring: { wires: [] },
+  } as unknown as DsnPcb
+
+  const dsnString = stringifyDsnJson(dsnJson)
+
+  expect(dsnString).not.toContain("(width undefined)")
+  expect(dsnString).toContain("(clearance 150)")
+  expect(dsnString).toContain("(clearance 75)")
+  expect(dsnString).toContain("(width 42)")
+})


### PR DESCRIPTION
Summary
- Omit DSN structure/class rule width records when the parsed rule has no numeric width.
- Keep existing numeric width output unchanged.
- Add focused stringification coverage proving missing widths no longer emit `(width undefined)`.

/claim #54

Verification
- bun test tests/dsn-pcb/omit-missing-rule-width.test.ts
- bunx biome check lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts tests/dsn-pcb/omit-missing-rule-width.test.ts
- bunx tsc --noEmit
- bun test
- bun run build
- git diff --check

Transparency note: AI-assisted with Codex; I reviewed the diff and verified it locally before submission.