### PR TITLE
Export manufacturer part number as placement PN

### DIFF
--- a/lib/utils/get-component-value.ts
+++ b/lib/utils/get-component-value.ts
@@ -13,5 +13,8 @@ export function getComponentValue(sourceComponent: any): string {
       return `${(capacitanceUF).toFixed(3)}uF`
     }
   }
+  if (sourceComponent.manufacturer_part_number !== undefined) {
+    return String(sourceComponent.manufacturer_part_number)
+  }
   return ""
 }

--- a/tests/dsn-pcb/manufacturer-part-placement-pn.test.ts
+++ b/tests/dsn-pcb/manufacturer-part-placement-pn.test.ts
@@ -1,0 +1,62 @@
+import { expect, test } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { convertCircuitJsonToDsnJson } from "lib"
+
+test("uses manufacturer part number as placement PN fallback", () => {
+  const circuitJson: AnyCircuitElement[] = [
+    {
+      type: "pcb_board",
+      pcb_board_id: "board1",
+      center: { x: 0, y: 0 },
+      width: 10,
+      height: 10,
+    },
+    {
+      type: "source_component",
+      source_component_id: "sc1",
+      name: "U1",
+      ftype: "simple_chip",
+      manufacturer_part_number: "RP2040",
+    } as any,
+    {
+      type: "pcb_component",
+      pcb_component_id: "pc1",
+      source_component_id: "sc1",
+      center: { x: 1, y: 2 },
+      rotation: 0,
+      layer: "top",
+    } as any,
+    {
+      type: "source_port",
+      source_port_id: "sp1",
+      source_component_id: "sc1",
+      name: "1",
+      port_hints: ["1"],
+    } as any,
+    {
+      type: "pcb_port",
+      pcb_port_id: "pp1",
+      source_port_id: "sp1",
+      pcb_component_id: "pc1",
+      x: 1,
+      y: 2,
+      layers: ["top"],
+    } as any,
+    {
+      type: "pcb_smtpad",
+      pcb_smtpad_id: "pad1",
+      pcb_component_id: "pc1",
+      pcb_port_id: "pp1",
+      shape: "rect",
+      x: 1,
+      y: 2,
+      width: 0.6,
+      height: 0.4,
+      layer: "top",
+    } as any,
+  ]
+
+  const dsnJson = convertCircuitJsonToDsnJson(circuitJson)
+
+  expect(dsnJson.placement.components[0].places[0].PN).toBe("RP2040")
+})


### PR DESCRIPTION
Summary
- Use `source_component.manufacturer_part_number` as a DSN placement PN fallback.
- Keep existing resistance and capacitance-derived PN behavior unchanged.
- Add focused Circuit JSON -> DSN JSON coverage for a component that only has manufacturer metadata.

/claim #54

Verification
- bun test tests/dsn-pcb/manufacturer-part-placement-pn.test.ts
- bunx biome check lib/utils/get-component-value.ts tests/dsn-pcb/manufacturer-part-placement-pn.test.ts
- bunx tsc --noEmit
- bun test
- bun run build
- git diff --check

Transparency note: AI-assisted with Codex; I reviewed the diff and verified it locally before submission.