### PR TITLE
Format picofarad placement PN values

### DIFF
--- a/lib/utils/get-component-value.ts
+++ b/lib/utils/get-component-value.ts
@@ -9,9 +9,15 @@ export function getComponentValue(sourceComponent: any): string {
     const capacitanceUF = sourceComponent.capacitance * 1e6
     if (capacitanceUF >= 1) {
       return `${capacitanceUF}uF`
+    } else if (capacitanceUF < 0.001) {
+      return `${formatDecimal(sourceComponent.capacitance * 1e12)}pF`
     } else {
       return `${(capacitanceUF).toFixed(3)}uF`
     }
   }
   return ""
+}
+
+function formatDecimal(value: number): string {
+  return Number(value.toFixed(3)).toString()
 }

--- a/tests/dsn-pcb/picofarad-placement-pn.test.ts
+++ b/tests/dsn-pcb/picofarad-placement-pn.test.ts
@@ -1,0 +1,62 @@
+import { expect, test } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { convertCircuitJsonToDsnJson } from "lib"
+
+test("formats picofarad capacitance values without rounding to zero", () => {
+  const circuitJson: AnyCircuitElement[] = [
+    {
+      type: "pcb_board",
+      pcb_board_id: "board1",
+      center: { x: 0, y: 0 },
+      width: 10,
+      height: 10,
+    },
+    {
+      type: "source_component",
+      source_component_id: "sc1",
+      name: "C1",
+      ftype: "capacitor",
+      capacitance: 15e-12,
+    } as any,
+    {
+      type: "pcb_component",
+      pcb_component_id: "pc1",
+      source_component_id: "sc1",
+      center: { x: 1, y: 2 },
+      rotation: 0,
+      layer: "top",
+    } as any,
+    {
+      type: "source_port",
+      source_port_id: "sp1",
+      source_component_id: "sc1",
+      name: "1",
+      port_hints: ["1"],
+    } as any,
+    {
+      type: "pcb_port",
+      pcb_port_id: "pp1",
+      source_port_id: "sp1",
+      pcb_component_id: "pc1",
+      x: 1,
+      y: 2,
+      layers: ["top"],
+    } as any,
+    {
+      type: "pcb_smtpad",
+      pcb_smtpad_id: "pad1",
+      pcb_component_id: "pc1",
+      pcb_port_id: "pp1",
+      shape: "rect",
+      x: 1,
+      y: 2,
+      width: 0.6,
+      height: 0.4,
+      layer: "top",
+    } as any,
+  ]
+
+  const dsnJson = convertCircuitJsonToDsnJson(circuitJson)
+
+  expect(dsnJson.placement.components[0].places[0].PN).toBe("15pF")
+})


### PR DESCRIPTION
Summary
- Format sub-0.001uF capacitance values as pF in DSN placement PN metadata instead of rounding to `0.000uF`.
- Keep existing uF formatting for normal capacitance values unchanged.
- Add focused Circuit JSON -> DSN JSON coverage for a 15pF capacitor.

/claim #54

Verification
- bun test tests/dsn-pcb/picofarad-placement-pn.test.ts
- bunx biome check lib/utils/get-component-value.ts tests/dsn-pcb/picofarad-placement-pn.test.ts
- bunx tsc --noEmit
- bun test
- bun run build
- git diff --check

Transparency note: AI-assisted with Codex; I reviewed the diff and verified it locally before submission.