### PR TITLE
Omit missing DSN class circuit blocks

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
@@ -117,9 +117,11 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
   })
   dsnJson.network.classes.forEach((cls) => {
     result += `${indent}${indent}(class ${stringifyValue(cls.name)} ${stringifyValue(cls.description)}${cls.net_names.map((n) => ` ${stringifyValue(n)}`).join("")}\n`
-    result += `${indent}${indent}${indent}(circuit\n`
-    result += `${indent}${indent}${indent}${indent}(use_via ${stringifyValue(cls.circuit.use_via)})\n`
-    result += `${indent}${indent}${indent})\n`
+    if (cls.circuit?.use_via) {
+      result += `${indent}${indent}${indent}(circuit\n`
+      result += `${indent}${indent}${indent}${indent}(use_via ${stringifyValue(cls.circuit.use_via)})\n`
+      result += `${indent}${indent}${indent})\n`
+    }
     if (cls.rule) {
       result += `${indent}${indent}${indent}(rule\n`
       result += `${indent}${indent}${indent}${indent}(width ${cls.rule.width})\n`

--- a/tests/dsn-pcb/rule-only-class-stringify.test.ts
+++ b/tests/dsn-pcb/rule-only-class-stringify.test.ts
@@ -1,0 +1,53 @@
+import { expect, test } from "bun:test"
+import { type DsnPcb, parseDsnToDsnJson, stringifyDsnJson } from "lib"
+
+test("stringifies rule-only network classes without requiring circuit metadata", () => {
+  const dsn = `(pcb rule-only-class.dsn
+  (parser
+    (string_quote ")
+    (space_in_quoted_tokens on)
+    (host_cad "KiCad's Pcbnew")
+    (host_version "8.0.3")
+  )
+  (resolution um 10)
+  (unit um)
+  (structure
+    (layer F.Cu
+      (type signal)
+      (property
+        (index 0)
+      )
+    )
+    (boundary
+      (path pcb 0 0 0 1000 0 1000 1000 0 1000 0 0)
+    )
+    (via "Via[0-1]_600:300_um")
+    (rule
+      (width 150)
+      (clearance 75)
+    )
+  )
+  (placement)
+  (library)
+  (network
+    (net "N1"
+      (pins U1-1)
+    )
+    (class "rule_only" "" "N1"
+      (rule
+        (width 150)
+        (clearance 75)
+      )
+    )
+  )
+  (wiring)
+)`
+
+  const dsnJson = parseDsnToDsnJson(dsn) as DsnPcb
+  const dsnString = stringifyDsnJson(dsnJson)
+  const reparsedJson = parseDsnToDsnJson(dsnString) as DsnPcb
+
+  expect(dsnString).not.toContain("use_via")
+  expect(reparsedJson.network.classes[0].name).toBe("rule_only")
+  expect(reparsedJson.network.classes[0].rule.width).toBe(150)
+})


### PR DESCRIPTION
Summary
- Avoid assuming every DSN network class has a `circuit.use_via` value while stringifying.
- Preserve existing class circuit output when `use_via` is present.
- Add focused parse -> stringify coverage for a rule-only class without circuit metadata.

/claim #54

Verification
- bun test tests/dsn-pcb/rule-only-class-stringify.test.ts
- bunx biome check lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts tests/dsn-pcb/rule-only-class-stringify.test.ts
- bunx tsc --noEmit
- bun test
- bun run build
- git diff --check

Transparency note: AI-assisted with Codex; I reviewed the diff and verified it locally before submission.