### PR TITLE
Format microfarad placement PN values

### DIFF
--- a/lib/utils/get-component-value.ts
+++ b/lib/utils/get-component-value.ts
@@ -8,10 +8,14 @@ export function getComponentValue(sourceComponent: any): string {
   if ("capacitance" in sourceComponent) {
     const capacitanceUF = sourceComponent.capacitance * 1e6
     if (capacitanceUF >= 1) {
-      return `${capacitanceUF}uF`
+      return `${formatDecimal(capacitanceUF)}uF`
     } else {
       return `${(capacitanceUF).toFixed(3)}uF`
     }
   }
   return ""
+}
+
+function formatDecimal(value: number): string {
+  return Number(value.toFixed(3)).toString()
 }

--- a/tests/dsn-pcb/microfarad-placement-pn.test.ts
+++ b/tests/dsn-pcb/microfarad-placement-pn.test.ts
@@ -1,0 +1,62 @@
+import { expect, test } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { convertCircuitJsonToDsnJson } from "lib"
+
+test("formats microfarad capacitance values as compact decimal strings", () => {
+  const circuitJson: AnyCircuitElement[] = [
+    {
+      type: "pcb_board",
+      pcb_board_id: "board1",
+      center: { x: 0, y: 0 },
+      width: 10,
+      height: 10,
+    },
+    {
+      type: "source_component",
+      source_component_id: "sc1",
+      name: "C1",
+      ftype: "capacitor",
+      capacitance: 0.000009999999999999999,
+    } as any,
+    {
+      type: "pcb_component",
+      pcb_component_id: "pc1",
+      source_component_id: "sc1",
+      center: { x: 1, y: 2 },
+      rotation: 0,
+      layer: "top",
+    } as any,
+    {
+      type: "source_port",
+      source_port_id: "sp1",
+      source_component_id: "sc1",
+      name: "1",
+      port_hints: ["1"],
+    } as any,
+    {
+      type: "pcb_port",
+      pcb_port_id: "pp1",
+      source_port_id: "sp1",
+      pcb_component_id: "pc1",
+      x: 1,
+      y: 2,
+      layers: ["top"],
+    } as any,
+    {
+      type: "pcb_smtpad",
+      pcb_smtpad_id: "pad1",
+      pcb_component_id: "pc1",
+      pcb_port_id: "pp1",
+      shape: "rect",
+      x: 1,
+      y: 2,
+      width: 0.6,
+      height: 0.4,
+      layer: "top",
+    } as any,
+  ]
+
+  const dsnJson = convertCircuitJsonToDsnJson(circuitJson)
+
+  expect(dsnJson.placement.components[0].places[0].PN).toBe("10uF")
+})


### PR DESCRIPTION
Summary
- Normalize >=1uF capacitance placement PN output to compact decimal strings.
- Avoid exporting floating-point artifacts such as `9.999999999999998uF` for 10uF values.
- Add focused Circuit JSON -> DSN JSON coverage for the 10uF fixture-style value.

/claim #54

Verification
- bun test tests/dsn-pcb/microfarad-placement-pn.test.ts
- bunx biome check lib/utils/get-component-value.ts tests/dsn-pcb/microfarad-placement-pn.test.ts
- bunx tsc --noEmit
- bun test
- bun run build
- git diff --check

Transparency note: AI-assisted with Codex; I reviewed the diff and verified it locally before submission.