### PR TITLE
Preserve passive display values in DSN placement PN

### DIFF
--- a/lib/utils/get-component-value.ts
+++ b/lib/utils/get-component-value.ts
@@ -1,11 +1,23 @@
 export function getComponentValue(sourceComponent: any): string {
   if (!sourceComponent) return ""
   if ("resistance" in sourceComponent) {
+    if (
+      typeof sourceComponent.display_resistance === "string" &&
+      sourceComponent.display_resistance.trim() !== ""
+    ) {
+      return sourceComponent.display_resistance
+    }
     return sourceComponent.resistance >= 1000
       ? `${sourceComponent.resistance / 1000}k`
       : `${sourceComponent.resistance}`
   }
   if ("capacitance" in sourceComponent) {
+    if (
+      typeof sourceComponent.display_capacitance === "string" &&
+      sourceComponent.display_capacitance.trim() !== ""
+    ) {
+      return sourceComponent.display_capacitance
+    }
     const capacitanceUF = sourceComponent.capacitance * 1e6
     if (capacitanceUF >= 1) {
       return `${capacitanceUF}uF`

--- a/tests/dsn-pcb/circuit-json-to-dsn-file.test.ts
+++ b/tests/dsn-pcb/circuit-json-to-dsn-file.test.ts
@@ -28,3 +28,36 @@ test("circuit json to dsn file", async () => {
     import.meta.path,
   )
 })
+
+test("uses passive display values for placement PN metadata", () => {
+  const circuitElements = JSON.parse(
+    JSON.stringify(circuitJson),
+  ) as AnyCircuitElement[]
+
+  const resistor = circuitElements.find(
+    (element) =>
+      element.type === "source_component" &&
+      element.source_component_id === "source_component_0",
+  ) as any
+  resistor.display_resistance = "10kΩ"
+
+  const capacitor = circuitElements.find(
+    (element) =>
+      element.type === "source_component" &&
+      element.source_component_id === "source_component_1",
+  ) as any
+  capacitor.display_capacitance = "10nF"
+
+  const dsnFile = convertCircuitJsonToDsnString(circuitElements)
+  const dsnJson = parseDsnToDsnJson(dsnFile) as DsnPcb
+  const places = dsnJson.placement.components.flatMap(
+    (component) => component.places,
+  )
+
+  expect(places.find((place) => place.refdes.startsWith("R1_"))?.PN).toBe(
+    "10kΩ",
+  )
+  expect(places.find((place) => place.refdes.startsWith("C1_"))?.PN).toBe(
+    "10nF",
+  )
+})


### PR DESCRIPTION
Summary
- Prefer explicit `display_resistance` and `display_capacitance` strings when exporting passive component placement PN metadata.
- Keep existing numeric resistance/capacitance fallbacks unchanged when no display string is present.
- Add Circuit JSON -> DSN regression coverage proving resistor and capacitor display strings survive into placement PN values.

Bounty
/claim #54

Validation
- `bun test tests/dsn-pcb/circuit-json-to-dsn-file.test.ts`
- `bun test`
- `bun run format:check`
- `bunx tsc --noEmit`
- `bun run build`
- `git diff --check`

Non-goals
- No changes to generic `display_value`, `symbol_display_value`, supplier/manufacturer PN, or raw capacitance formatting behavior.

Transparency
AI-assisted with Codex; I reviewed the diff and verified it locally before submission.