### PR TITLE
Preserve DSN placement lock types

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
@@ -71,7 +71,11 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
     result += `${indent}${indent}(component ${stringifyValue(component.name)}\n`
     if (component.places) {
       component.places.forEach((place) => {
-        result += `${indent}${indent}${indent}(place ${place.refdes} ${place.x} ${place.y} ${place.side} ${place.rotation}${place.PN ? ` (PN ${stringifyValue(place.PN)})` : ""})\n`
+        const lockType = place.lock_type
+          ? ` (lock_type ${place.lock_type})`
+          : ""
+        const pn = place.PN ? ` (PN ${stringifyValue(place.PN)})` : ""
+        result += `${indent}${indent}${indent}(place ${place.refdes} ${place.x} ${place.y} ${place.side} ${place.rotation}${lockType}${pn})\n`
       })
     }
     result += `${indent}${indent})\n`

--- a/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
@@ -477,7 +477,7 @@ function processPlace(nodes: ASTNode[]): Places {
     }
   }
 
-  // Process optional PN (part number) if present
+  // Process optional placement metadata if present
   for (let i = coordIndex + 4; i < nodes.length; i++) {
     const node = nodes[i]
     if (
@@ -489,7 +489,15 @@ function processPlace(nodes: ASTNode[]): Places {
       node.children[1].type === "Atom"
     ) {
       places.PN = String(node.children[1].value)
-      break
+    } else if (
+      node.type === "List" &&
+      node.children &&
+      node.children[0].type === "Atom" &&
+      node.children[0].value === "lock_type" &&
+      node.children[1] &&
+      node.children[1].type === "Atom"
+    ) {
+      places.lock_type = String(node.children[1].value)
     }
   }
 

--- a/lib/dsn-pcb/types.ts
+++ b/lib/dsn-pcb/types.ts
@@ -92,6 +92,7 @@ export interface ComponentPlacement {
     y: number
     side: "front" | "back"
     rotation: number
+    lock_type?: string
   }>
 }
 
@@ -171,6 +172,7 @@ export interface Places {
   side: string
   rotation: number
   PN: string
+  lock_type?: string
 }
 
 export interface Library {

--- a/tests/dsn-pcb/dsn-placement-lock-type.test.ts
+++ b/tests/dsn-pcb/dsn-placement-lock-type.test.ts
@@ -1,0 +1,57 @@
+import { expect, test } from "bun:test"
+import { type DsnPcb, parseDsnToDsnJson, stringifyDsnJson } from "lib"
+
+test("preserves placement lock_type metadata during DSN JSON round trip", () => {
+  const dsn = `(pcb lock_type_fixture.dsn
+  (parser
+    (string_quote ")
+    (space_in_quoted_tokens on)
+    (host_cad "KiCad's Pcbnew")
+    (host_version "fixture")
+  )
+  (resolution um 10)
+  (unit um)
+  (structure
+    (layer F.Cu
+      (type signal)
+      (property
+        (index 0)
+      )
+    )
+    (boundary
+      (path pcb 0 0 0 1000 0 1000 1000 0 1000)
+    )
+    (via "")
+    (rule
+      (width 100)
+      (clearance 100)
+    )
+  )
+  (placement
+    (component RES_0603
+      (place R1 100 200 front 90 (lock_type position) (PN "10k"))
+    )
+  )
+  (library
+    (image RES_0603)
+  )
+  (network)
+  (wiring)
+)`
+
+  const parsed = parseDsnToDsnJson(dsn) as DsnPcb
+  const place = parsed.placement.components[0].places[0]
+
+  expect(place.lock_type).toBe("position")
+  expect(place.PN).toBe("10k")
+
+  const stringified = stringifyDsnJson(parsed)
+
+  expect(stringified).toContain("(lock_type position)")
+
+  const reparsed = parseDsnToDsnJson(stringified) as DsnPcb
+  const reparsedPlace = reparsed.placement.components[0].places[0]
+
+  expect(reparsedPlace.lock_type).toBe("position")
+  expect(reparsedPlace.PN).toBe("10k")
+})


### PR DESCRIPTION
## Summary
- preserve optional DSN PCB placement `(lock_type ...)` metadata in `processPlace`
- emit preserved placement lock metadata in `stringifyDsnJson`
- add a focused parse -> stringify -> parse regression test for `lock_type` alongside existing PN metadata

/claim #54

## Verification
- `npm exec --yes bun -- test tests/dsn-pcb/dsn-placement-lock-type.test.ts`
- `npm exec --yes bun -- x biome check lib/dsn-pcb/types.ts lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts tests/dsn-pcb/dsn-placement-lock-type.test.ts`
- `npm exec --yes bun -- test`
- `npm exec --yes bun -- x tsc --noEmit`
- `npm exec --yes bun -- run build`
- `git diff --check`

Transparency: AI-assisted with Codex; I reviewed the diff and verified it locally.