### PR TITLE
Preserve non-path image outlines

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
@@ -1,4 +1,4 @@
-import type { DsnPcb } from "../types"
+import type { DsnPcb, Shape } from "../types"
 
 export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
   const indent = "  "
@@ -24,6 +24,26 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
   const stringifyPath = (path: any, level: number): string => {
     const padding = indent.repeat(level)
     return `${padding}(path ${path.layer} ${path.width}  ${stringifyCoordinates(path.coordinates)})`
+  }
+
+  const stringifyShapeContent = (shape: Shape): string => {
+    if (shape.shapeType === "polygon") {
+      return `(polygon ${shape.layer} ${shape.width} ${stringifyCoordinates(shape.coordinates)})`
+    }
+    if (shape.shapeType === "circle") {
+      const coordinates =
+        shape.coordinates && shape.coordinates.length > 0
+          ? ` ${stringifyCoordinates(shape.coordinates)}`
+          : ""
+      return `(circle ${shape.layer} ${shape.diameter}${coordinates})`
+    }
+    if (shape.shapeType === "rect") {
+      return `(rect ${shape.layer} ${stringifyCoordinates(shape.coordinates)})`
+    }
+    if (shape.shapeType === "path") {
+      return `(path ${shape.layer} ${shape.width} ${stringifyCoordinates(shape.coordinates)})`
+    }
+    throw new Error("Unsupported DSN shape type")
   }
 
   // Start with pcb
@@ -83,7 +103,11 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
   dsnJson.library.images.forEach((image) => {
     result += `${indent}${indent}(image ${stringifyValue(image.name)}\n`
     image.outlines.forEach((outline) => {
-      result += `${indent}${indent}${indent}(outline ${stringifyPath(outline.path, 4)})\n`
+      if (outline.path) {
+        result += `${indent}${indent}${indent}(outline ${stringifyPath(outline.path, 4)})\n`
+      } else if (outline.shape) {
+        result += `${indent}${indent}${indent}(outline ${stringifyShapeContent(outline.shape)})\n`
+      }
     })
     image.pins.forEach((pin) => {
       result += `${indent}${indent}${indent}(pin ${pin.padstack_name} ${pin.pin_number} ${pin.x} ${pin.y})\n`

--- a/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
@@ -558,10 +558,16 @@ function processOutline(nodes: ASTNode[]): Outline {
   nodes.forEach((node) => {
     if (
       node.type === "List" &&
-      node.children![0].type === "Atom" &&
-      node.children![0].value === "path"
+      node.children?.[0]?.type === "Atom" &&
+      node.children[0].value === "path"
     ) {
       outline.path = processPath(node.children!)
+    } else if (
+      node.type === "List" &&
+      node.children?.[0]?.type === "Atom" &&
+      typeof node.children[0].value === "string"
+    ) {
+      outline.shape = processShapeContent(node.children!)
     }
   })
   return outline as Outline
@@ -671,24 +677,31 @@ function processShape(nodes: ASTNode[]): Shape {
   const [_, shapeContentNode, ...rest] = nodes
 
   if (shapeContentNode.type === "List") {
-    const [shapeTypeNode, layerNode, ...shapeData] = shapeContentNode.children!
+    return processShapeContent(shapeContentNode.children!)
+  }
 
-    if (
-      shapeTypeNode.type === "Atom" &&
-      typeof shapeTypeNode.value === "string"
-    ) {
-      const shapeType = shapeTypeNode.value
+  console.error("Shape processing error for nodes:", nodes)
+  throw new Error(`Unknown shape type for nodes: ${JSON.stringify(nodes)}`)
+}
 
-      switch (shapeType) {
-        case "polygon":
-          return processPolygonShape(shapeContentNode.children!)
-        case "circle":
-          return processCircleShape(shapeContentNode.children!)
-        case "rect":
-          return processRectShape(shapeContentNode.children!)
-        case "path":
-          return processPathShape(shapeContentNode.children!)
-      }
+function processShapeContent(nodes: ASTNode[]): Shape {
+  const [shapeTypeNode] = nodes
+
+  if (
+    shapeTypeNode.type === "Atom" &&
+    typeof shapeTypeNode.value === "string"
+  ) {
+    const shapeType = shapeTypeNode.value
+
+    switch (shapeType) {
+      case "polygon":
+        return processPolygonShape(nodes)
+      case "circle":
+        return processCircleShape(nodes)
+      case "rect":
+        return processRectShape(nodes)
+      case "path":
+        return processPathShape(nodes)
     }
   }
 
@@ -775,6 +788,13 @@ function processCircleShape(nodes: ASTNode[]): CircleShape {
   ) {
     circle.layer = shapeNodes[1].value
     circle.diameter = shapeNodes[2].value
+    const coordinates = shapeNodes
+      .slice(3)
+      .filter((node) => node.type === "Atom" && typeof node.value === "number")
+      .map((node) => node.value as number)
+    if (coordinates.length > 0) {
+      circle.coordinates = coordinates
+    }
     return circle as CircleShape
   } else {
     // Try to extract coordinates if they exist

--- a/lib/dsn-pcb/types.ts
+++ b/lib/dsn-pcb/types.ts
@@ -185,7 +185,8 @@ export interface Image {
 }
 
 export interface Outline {
-  path: Path
+  path?: Path
+  shape?: Shape
 }
 
 export interface Pin {
@@ -229,6 +230,7 @@ export interface PolygonShape extends BaseShape {
 export interface CircleShape extends BaseShape {
   shapeType: "circle"
   diameter: number
+  coordinates?: number[]
 }
 
 export interface RectShape extends BaseShape {

--- a/tests/dsn-pcb/stringify-dsn-json.test.ts
+++ b/tests/dsn-pcb/stringify-dsn-json.test.ts
@@ -17,3 +17,48 @@ test("stringify dsn json", () => {
   // Test that we can parse the generated string back to the same structure
   // expect(reparsedJson).toEqual(dsnJson)
 })
+
+test("preserves non-path image outlines", () => {
+  const dsnJson = parseDsnToDsnJson(`(pcb "outline-shapes.dsn"
+  (parser
+    (string_quote ")
+    (space_in_quoted_tokens on)
+    (host_cad "KiCad's Pcbnew")
+    (host_version "8.0")
+  )
+  (resolution um 10)
+  (unit um)
+  (structure
+    (layer F.Cu
+      (type signal)
+      (property
+        (index 0)
+      )
+    )
+    (boundary
+      (path F.Cu 0  0 0 1000 0 1000 1000 0 1000 0 0)
+    )
+    (via "Via[0-1]_600:300_um")
+    (rule
+      (width 100)
+    )
+  )
+  (placement)
+  (library
+    (image "U1"
+      (outline (rect F.Cu -100 -50 100 50))
+      (outline (circle F.Cu 200 10 20))
+      (outline (polygon F.Cu 0 0 0 50 0 50 50))
+    )
+  )
+  (network)
+  (wiring)
+)`) as DsnPcb
+
+  const dsnString = stringifyDsnJson(dsnJson)
+  const reparsedJson = parseDsnToDsnJson(dsnString) as DsnPcb
+
+  expect(reparsedJson.library.images[0].outlines).toEqual(
+    dsnJson.library.images[0].outlines,
+  )
+})


### PR DESCRIPTION
/claim #54

## Summary
- parse DSN library image outlines that use direct rect, circle, polygon, or path shape records
- stringify preserved non-path outlines during DSN JSON round-trip
- add regression coverage for rect, circle, and polygon image outlines

## Test
- npx bun test tests\dsn-pcb\stringify-dsn-json.test.ts -t "preserves non-path image outlines"
- npx biome check lib\dsn-pcb\types.ts lib\dsn-pcb\dsn-json-to-circuit-json\parse-dsn-to-dsn-json.ts lib\dsn-pcb\circuit-json-to-dsn-json\stringify-dsn-json.ts tests\dsn-pcb\stringify-dsn-json.test.ts
- npx tsc --noEmit
- npm run build

Note: the existing unfiltered `stringify dsn json` test in this file still fails on the pre-existing parser string_quote/host_cad round-trip mismatch; the new focused regression passes.
