### PR TITLE
Import Bottom padstack shapes as bottom pads

### DIFF
--- a/lib/dsn-pcb/dsn-json-to-circuit-json/dsn-component-converters/convert-padstacks-to-smtpads.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/dsn-component-converters/convert-padstacks-to-smtpads.ts
@@ -5,6 +5,13 @@ import { applyToPoint } from "transformation-matrix"
 
 const debug = Debug("dsn-converter:convertPadstacksToSmtpads")
 
+function dsnShapeLayerToCircuitLayer(layer: string): "top" | "bottom" {
+  const normalizedLayer = layer.toLowerCase()
+  return normalizedLayer.includes("b.") || normalizedLayer === "bottom"
+    ? "bottom"
+    : "top"
+}
+
 export function convertPadstacksToSmtPads(
   pcb: DsnPcb,
   transform: any,
@@ -117,9 +124,7 @@ export function convertPadstacksToSmtPads(
 
         let pcbPad: PcbSmtPad
         if (rectShape || polygonShape || pathShape) {
-          const layer = padstack.shapes[0].layer.includes("B.")
-            ? "bottom"
-            : "top"
+          const layer = dsnShapeLayerToCircuitLayer(padstack.shapes[0].layer)
           debug("determining layer with padstack shapes", {
             shapes: padstack.shapes,
             layer,

--- a/tests/dsn-pcb/bottom-padstack-layer-import.test.ts
+++ b/tests/dsn-pcb/bottom-padstack-layer-import.test.ts
@@ -1,0 +1,97 @@
+import { expect, test } from "bun:test"
+import { type DsnPcb, convertDsnPcbToCircuitJson } from "lib"
+
+test("imports Bottom padstack shapes as bottom SMT pads", () => {
+  const dsnPcb: DsnPcb = {
+    is_dsn_pcb: true,
+    filename: "bottom-padstack.dsn",
+    parser: {
+      string_quote: "",
+      host_version: "",
+      space_in_quoted_tokens: "",
+      host_cad: "",
+    },
+    resolution: {
+      unit: "um",
+      value: 10,
+    },
+    unit: "um",
+    structure: {
+      layers: [
+        { name: "F.Cu", type: "signal", property: { index: 0 } },
+        { name: "B.Cu", type: "signal", property: { index: 1 } },
+      ],
+      boundary: {
+        path: {
+          layer: "pcb",
+          width: 0,
+          coordinates: [-1000, -1000, 1000, -1000, 1000, 1000, -1000, 1000],
+        },
+      },
+      via: "",
+      rule: {
+        width: 0,
+        clearances: [],
+      },
+    },
+    placement: {
+      components: [
+        {
+          name: "BottomPadImage",
+          places: [
+            {
+              refdes: "U1",
+              x: 0,
+              y: 0,
+              side: "back",
+              rotation: 0,
+              PN: "",
+            },
+          ],
+        },
+      ],
+    },
+    library: {
+      images: [
+        {
+          name: "BottomPadImage",
+          outlines: [],
+          pins: [
+            {
+              padstack_name: "BottomRectPad",
+              pin_number: 1,
+              x: 0,
+              y: 0,
+            },
+          ],
+        },
+      ],
+      padstacks: [
+        {
+          name: "BottomRectPad",
+          shapes: [
+            {
+              shapeType: "rect",
+              layer: "Bottom",
+              coordinates: [-500, -250, 500, 250],
+            },
+          ],
+          attach: "off",
+        },
+      ],
+    },
+    network: {
+      nets: [],
+      classes: [],
+    },
+    wiring: {
+      wires: [],
+    },
+  }
+
+  const circuitJson = convertDsnPcbToCircuitJson(dsnPcb)
+  const smtpad = circuitJson.find((element) => element.type === "pcb_smtpad")
+
+  expect(smtpad).toBeDefined()
+  expect(smtpad?.layer).toBe("bottom")
+})


### PR DESCRIPTION
Summary
- Treat DSN padstack shape layer `Bottom` as a bottom copper layer when importing SMT pad geometry.
- Keep existing `B.Cu` behavior and top/default behavior unchanged.
- Add focused DSN PCB -> Circuit JSON coverage for a Bottom rectangular padstack shape.

/claim #54

Verification
- bun test tests/dsn-pcb/bottom-padstack-layer-import.test.ts
- bun test
- bunx tsc --noEmit
- bunx biome check lib/dsn-pcb/dsn-json-to-circuit-json/dsn-component-converters/convert-padstacks-to-smtpads.ts tests/dsn-pcb/bottom-padstack-layer-import.test.ts
- bun run build
- git diff --check

Transparency note: AI-assisted with Codex; I reviewed the diff and verified it locally before submission.