### PR TITLE
Escape quoted DSN string values

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
@@ -4,13 +4,16 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
   const indent = "  "
   let result = ""
 
+  const escapeDsnString = (value: string): string =>
+    value.replace(/\\/g, "\\\\").replace(/"/g, '\\"')
+
   // Helper function to stringify a value with proper formatting
   const stringifyValue = (value: any): string => {
     if (value === null || value === undefined) {
       return '""'
     }
     if (typeof value === "string") {
-      return `"${value}"`
+      return `"${escapeDsnString(value)}"`
     }
     return value.toString()
   }

--- a/tests/dsn-pcb/stringify-dsn-json.test.ts
+++ b/tests/dsn-pcb/stringify-dsn-json.test.ts
@@ -17,3 +17,77 @@ test("stringify dsn json", () => {
   // Test that we can parse the generated string back to the same structure
   // expect(reparsedJson).toEqual(dsnJson)
 })
+
+test("escapes quoted string values when stringifying dsn json", () => {
+  const dsnJson = {
+    is_dsn_pcb: true,
+    filename: "escaped-values.dsn",
+    parser: {
+      string_quote: '"',
+      space_in_quoted_tokens: "on",
+      host_cad: "test",
+      host_version: "1",
+    },
+    resolution: { unit: "um", value: 10 },
+    unit: "um",
+    structure: {
+      layers: [
+        { name: "F.Cu", type: "signal", property: { index: 0 } },
+        { name: "B.Cu", type: "signal", property: { index: 1 } },
+      ],
+      boundary: {
+        path: { layer: "pcb", width: 0, coordinates: [0, 0, 1000, 1000] },
+      },
+      via: "Via[0-1]_600:300_um",
+      rule: { width: 100, clearances: [] },
+    },
+    placement: {
+      components: [
+        {
+          name: 'Package "A"\\B',
+          places: [
+            {
+              refdes: "U1",
+              x: 0,
+              y: 0,
+              side: "front",
+              rotation: 0,
+              PN: 'Part "A"\\B',
+            },
+          ],
+        },
+      ],
+    },
+    library: {
+      images: [{ name: 'Package "A"\\B', outlines: [], pins: [] }],
+      padstacks: [],
+    },
+    network: {
+      nets: [{ name: 'Net "A"\\B', pins: [] }],
+      classes: [
+        {
+          name: 'Class "A"\\B',
+          description: 'Description "A"\\B',
+          net_names: ['Net "A"\\B'],
+          circuit: { use_via: "Via[0-1]_600:300_um" },
+          rule: { width: 100, clearances: [] },
+        },
+      ],
+    },
+    wiring: { wires: [] },
+  } as DsnPcb
+
+  const dsnString = stringifyDsnJson(dsnJson)
+
+  expect(dsnString).toContain('"Net \\"A\\"\\\\B"')
+  expect(dsnString).toContain('"Part \\"A\\"\\\\B"')
+
+  const reparsedJson = parseDsnToDsnJson(dsnString) as DsnPcb
+
+  expect(reparsedJson.placement.components[0].name).toBe('Package "A"\\B')
+  expect(reparsedJson.placement.components[0].places[0].PN).toBe('Part "A"\\B')
+  expect(reparsedJson.network.nets[0].name).toBe('Net "A"\\B')
+  expect(reparsedJson.network.classes[0].name).toBe('Class "A"\\B')
+  expect(reparsedJson.network.classes[0].description).toBe('Description "A"\\B')
+  expect(reparsedJson.network.classes[0].net_names[0]).toBe('Net "A"\\B')
+})


### PR DESCRIPTION
## Summary
- escape embedded double quotes and backslashes when `stringifyDsnJson` emits quoted string values
- add focused parse -> stringify -> parse coverage for names and PN values containing `"` and `\`
- keep the change scoped to existing quoted string serialization

/claim #54

## Verification
- `bun test tests/dsn-pcb/stringify-dsn-json.test.ts`
- `bunx biome check lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts tests/dsn-pcb/stringify-dsn-json.test.ts`
- `bun test`
- `git diff --check`

Not green due existing repo dependency issue:
- `bunx tsc --noEmit` fails with `TS2688: Cannot find type definition file for 'linkify-it'`\n- `bun run build` succeeds ESM output but fails DTS build with the same missing `linkify-it` type definition\n\nTransparency: AI-assisted with Codex; I reviewed the diff and local verification before opening this PR.