### PR TITLE
Preserve rect padstack shapes in DSN stringifier

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
@@ -97,6 +97,8 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
         result += `${indent}${indent}${indent}(shape (polygon ${shape.layer} ${shape.width} ${stringifyCoordinates(shape.coordinates)}))\n`
       } else if (shape.shapeType === "circle") {
         result += `${indent}${indent}${indent}(shape (circle ${shape.layer} ${shape.diameter}))\n`
+      } else if (shape.shapeType === "rect") {
+        result += `${indent}${indent}${indent}(shape (rect ${shape.layer} ${stringifyCoordinates(shape.coordinates)}))\n`
       } else if (shape.shapeType === "path") {
         result += `${indent}${indent}${indent}(shape (path ${shape.layer} ${shape.width} ${stringifyCoordinates(shape.coordinates)}))\n`
       }

--- a/tests/dsn-pcb/stringify-dsn-json.test.ts
+++ b/tests/dsn-pcb/stringify-dsn-json.test.ts
@@ -17,3 +17,70 @@ test("stringify dsn json", () => {
   // Test that we can parse the generated string back to the same structure
   // expect(reparsedJson).toEqual(dsnJson)
 })
+
+test("stringify dsn json preserves rect padstack shapes", () => {
+  const dsnWithRectPadstack = `(pcb rect-padstack.dsn
+  (parser
+    (string_quote ")
+    (space_in_quoted_tokens on)
+    (host_cad "KiCad's Pcbnew")
+    (host_version "9.0.0")
+  )
+  (resolution um 10)
+  (unit um)
+  (structure
+    (layer Top
+      (type signal)
+      (property
+        (index 0)
+      )
+    )
+    (boundary
+      (path pcb 0  0 0  1000 0  1000 1000  0 1000)
+    )
+    (via "Via[0-1]_800:400_um")
+    (rule
+      (width 150)
+      (clearance 150)
+    )
+  )
+  (placement)
+  (library
+    (image "U1"
+      (pin RectPad 1 0 0)
+    )
+    (padstack "RectPad"
+      (shape (rect Top -500 -250 500 250))
+      (attach off)
+    )
+  )
+  (network
+    (net "N1"
+      (pins U1-1)
+    )
+    (class "kicad_default" "" "N1"
+      (circuit
+        (use_via "Via[0-1]_800:400_um")
+      )
+      (rule
+        (width 150)
+        (clearance 150)
+      )
+    )
+  )
+  (wiring)
+)`
+
+  const dsnJson = parseDsnToDsnJson(dsnWithRectPadstack) as DsnPcb
+  const dsnString = stringifyDsnJson(dsnJson)
+  expect(dsnString).toContain("(shape (rect Top -500 -250 500 250))")
+
+  const reparsedJson = parseDsnToDsnJson(dsnString) as DsnPcb
+  expect(reparsedJson.library.padstacks[0].shapes).toEqual([
+    {
+      shapeType: "rect",
+      layer: "Top",
+      coordinates: [-500, -250, 500, 250],
+    },
+  ])
+})


### PR DESCRIPTION
## Summary

Fixes a focused DSN round-trip gap for padstack rectangle shapes.

`parseDsnToDsnJson` already parses `(shape (rect ...))` records, and the Smoothie DSN fixture contains many rect padstack shapes, but `stringifyDsnJson` only emitted polygon, circle, and path shapes. That meant parse -> stringify -> parse silently dropped rect padstack geometry.

This PR adds rect padstack shape stringification and a focused round-trip regression test.

## Verification

- `npm exec --yes bun -- test tests/dsn-pcb/stringify-dsn-json.test.ts`
- `npm exec --yes bun -- x biome check lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts tests/dsn-pcb/stringify-dsn-json.test.ts`
- `npm exec --yes bun -- run build`
- `npm exec --yes bun -- test`
- `git diff --check`

## Claim

/claim #54

AI-assisted with Codex; I reviewed the implementation and verification output before submission.
