### PR TITLE
Link hyphenated DSN wires to source traces

### DIFF
--- a/lib/dsn-pcb/dsn-json-to-circuit-json/dsn-component-converters/convert-wiring-path-to-pcb-traces.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/dsn-component-converters/convert-wiring-path-to-pcb-traces.ts
@@ -1,5 +1,4 @@
 import type {
-  AnyCircuitElement,
   PcbTrace,
   PcbTraceRoutePointWire,
   SourceTrace,
@@ -38,6 +37,7 @@ export const convertWiringPathToPcbTraces = ({
   }
 
   if (points.length >= 2) {
+    const sourceTraceId = netName.split("--")[0]
     const routePoints = points.map((point) => ({
       route_type: "wire" as const,
       x: Number(point.x.toFixed(4)),
@@ -51,14 +51,14 @@ export const convertWiringPathToPcbTraces = ({
     const pcbTrace: PcbTrace = {
       type: "pcb_trace",
       pcb_trace_id: `pcb_trace_${netName}`,
-      source_trace_id: netName.split("-")[0],
+      source_trace_id: sourceTraceId,
       route: routePoints as PcbTraceRoutePointWire[],
       trace_length: getTraceLength(routePoints),
     }
 
     const sourceTrace: SourceTrace = {
       type: "source_trace",
-      source_trace_id: netName.split("--")[0],
+      source_trace_id: sourceTraceId,
       connected_source_net_ids: [],
       connected_source_port_ids: netName.split("--").slice(1),
     }

--- a/tests/dsn-pcb/hyphenated-wire-source-trace-link.test.ts
+++ b/tests/dsn-pcb/hyphenated-wire-source-trace-link.test.ts
@@ -1,0 +1,38 @@
+import { expect, test } from "bun:test"
+import { scale } from "transformation-matrix"
+import { convertWiringPathToPcbTraces } from "../../lib/dsn-pcb/dsn-json-to-circuit-json/dsn-component-converters/convert-wiring-path-to-pcb-traces"
+import type { Wiring } from "../../lib/dsn-pcb/types"
+
+test("hyphenated DSN wire net names keep pcb traces linked to source traces", () => {
+  const wire: Wiring["wires"][number] = {
+    type: "route",
+    net: "Net-(R1-Pad1)",
+    path: {
+      layer: "F.Cu",
+      width: 200,
+      coordinates: [0, 0, 1000, 0],
+    },
+  }
+
+  const circuitElements = convertWiringPathToPcbTraces({
+    wire,
+    transformUmToMm: scale(1 / 1000),
+    netName: "Net-(R1-Pad1)",
+    fromSessionSpace: false,
+  })
+
+  const pcbTrace = circuitElements.find(
+    (element) => element.type === "pcb_trace",
+  )
+  const sourceTrace = circuitElements.find(
+    (element) => element.type === "source_trace",
+  )
+
+  if (!pcbTrace || !sourceTrace) {
+    throw new Error("Expected a pcb_trace and source_trace")
+  }
+
+  expect(pcbTrace.source_trace_id).toBe("Net-(R1-Pad1)")
+  expect(sourceTrace.source_trace_id).toBe("Net-(R1-Pad1)")
+  expect(pcbTrace.source_trace_id).toBe(sourceTrace.source_trace_id)
+})


### PR DESCRIPTION
Summary
- Link pcb_trace.source_trace_id to the same net-derived id used by the emitted source_trace for DSN wiring paths.
- Preserve hyphenated DSN net names such as Net-(R1-Pad1) instead of truncating them at Net.
- Add regression coverage for a hyphenated wire net name.

/claim #54

Verification
- bun test tests/dsn-pcb/hyphenated-wire-source-trace-link.test.ts
- bunx biome check lib/dsn-pcb/dsn-json-to-circuit-json/dsn-component-converters/convert-wiring-path-to-pcb-traces.ts tests/dsn-pcb/hyphenated-wire-source-trace-link.test.ts
- bunx tsc --noEmit
- bun test
- bun run build
- git diff --check

Transparency note: AI-assisted with Codex; I reviewed the diff and verified it locally before submission.