### PR TITLE
Parse session routes metadata

### DIFF
--- a/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
@@ -1073,6 +1073,29 @@ function processSessionNode(ast: ASTNode): DsnSession {
       child.children[0].value === "routes",
   )
   if (routesNode) {
+    const resolutionNode = routesNode.children!.find(
+      (child) =>
+        child.type === "List" &&
+        child.children?.[0].type === "Atom" &&
+        child.children[0].value === "resolution",
+    )
+    if (resolutionNode) {
+      session.routes.resolution = processResolution(resolutionNode.children!)
+    }
+
+    const parserNode = routesNode.children!.find(
+      (child) =>
+        child.type === "List" &&
+        child.children?.[0].type === "Atom" &&
+        child.children[0].value === "parser",
+    )
+    if (parserNode) {
+      session.routes.parser = {
+        ...session.routes.parser,
+        ...processParser(parserNode.children!.slice(1)),
+      }
+    }
+
     // Extract library_out section
     const libraryNode = routesNode.children!.find(
       (child) =>

--- a/tests/dsn-pcb/parse-session-routes-metadata.test.ts
+++ b/tests/dsn-pcb/parse-session-routes-metadata.test.ts
@@ -1,0 +1,31 @@
+import { expect, test } from "bun:test"
+import { type DsnSession, parseDsnToDsnJson } from "lib"
+
+test("parse session routes resolution and parser metadata", () => {
+  const sessionFile = `
+    (session routed-board
+      (base_design routed-board)
+      (placement
+        (resolution um 10)
+      )
+      (was_is)
+      (routes
+        (resolution mil 5)
+        (parser
+          (host_cad "SPECCTRA")
+          (host_version "1.2.3")
+        )
+        (network_out)
+      )
+    )
+  `
+
+  const sessionJson = parseDsnToDsnJson(sessionFile) as DsnSession
+
+  expect(sessionJson.routes.resolution).toEqual({
+    unit: "mil",
+    value: 5,
+  })
+  expect(sessionJson.routes.parser.host_cad).toBe("SPECCTRA")
+  expect(sessionJson.routes.parser.host_version).toBe("1.2.3")
+})


### PR DESCRIPTION
Summary
- Parse the routes-level session `(resolution ...)` block into `session.routes.resolution`.
- Parse the routes-level session `(parser ...)` block into `session.routes.parser` instead of leaving empty parser metadata.
- Add focused regression coverage for non-default session route metadata.

/claim #54

Verification
- bun test tests/dsn-pcb/parse-session-routes-metadata.test.ts
- bunx biome check lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts tests/dsn-pcb/parse-session-routes-metadata.test.ts
- bunx tsc --noEmit
- bun test
- bun run build
- git diff --check

Transparency note: AI-assisted with Codex; I reviewed the diff and verified it locally before submission.