### PR TITLE
Preserve padstack circle offsets

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
@@ -96,7 +96,11 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
       if (shape.shapeType === "polygon") {
         result += `${indent}${indent}${indent}(shape (polygon ${shape.layer} ${shape.width} ${stringifyCoordinates(shape.coordinates)}))\n`
       } else if (shape.shapeType === "circle") {
-        result += `${indent}${indent}${indent}(shape (circle ${shape.layer} ${shape.diameter}))\n`
+        const circleOffset =
+          shape.x !== undefined && shape.y !== undefined
+            ? ` ${shape.x} ${shape.y}`
+            : ""
+        result += `${indent}${indent}${indent}(shape (circle ${shape.layer} ${shape.diameter}${circleOffset}))\n`
       } else if (shape.shapeType === "path") {
         result += `${indent}${indent}${indent}(shape (path ${shape.layer} ${shape.width} ${stringifyCoordinates(shape.coordinates)}))\n`
       }

--- a/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
@@ -775,6 +775,15 @@ function processCircleShape(nodes: ASTNode[]): CircleShape {
   ) {
     circle.layer = shapeNodes[1].value
     circle.diameter = shapeNodes[2].value
+    if (
+      shapeNodes[3]?.type === "Atom" &&
+      typeof shapeNodes[3].value === "number" &&
+      shapeNodes[4]?.type === "Atom" &&
+      typeof shapeNodes[4].value === "number"
+    ) {
+      circle.x = shapeNodes[3].value
+      circle.y = shapeNodes[4].value
+    }
     return circle as CircleShape
   } else {
     // Try to extract coordinates if they exist

--- a/lib/dsn-pcb/types.ts
+++ b/lib/dsn-pcb/types.ts
@@ -229,6 +229,8 @@ export interface PolygonShape extends BaseShape {
 export interface CircleShape extends BaseShape {
   shapeType: "circle"
   diameter: number
+  x?: number
+  y?: number
 }
 
 export interface RectShape extends BaseShape {

--- a/tests/dsn-pcb/padstack-circle-offset-roundtrip.test.ts
+++ b/tests/dsn-pcb/padstack-circle-offset-roundtrip.test.ts
@@ -1,0 +1,78 @@
+import { expect, test } from "bun:test"
+import { type DsnPcb, parseDsnToDsnJson, stringifyDsnJson } from "lib"
+
+test("padstack circle shape offsets survive DSN JSON stringify round trip", () => {
+  const dsnJson: DsnPcb = {
+    is_dsn_pcb: true,
+    filename: "offset-circle.dsn",
+    parser: {
+      string_quote: '"',
+      host_version: "",
+      space_in_quoted_tokens: "on",
+      host_cad: "test",
+    },
+    resolution: {
+      unit: "um",
+      value: 10,
+    },
+    unit: "um",
+    structure: {
+      layers: [
+        { name: "F.Cu", type: "signal", property: { index: 0 } },
+        { name: "B.Cu", type: "signal", property: { index: 1 } },
+      ],
+      boundary: {
+        path: {
+          layer: "pcb",
+          width: 0,
+          coordinates: [0, 0, 1000, 0, 1000, 1000, 0, 1000, 0, 0],
+        },
+      },
+      via: "Via[0-1]_600:300_um",
+      rule: {
+        clearances: [{ value: 150 }],
+        width: 150,
+      },
+    },
+    placement: {
+      components: [],
+    },
+    library: {
+      images: [],
+      padstacks: [
+        {
+          name: "OffsetCircle",
+          shapes: [
+            {
+              shapeType: "circle",
+              layer: "F.Cu",
+              diameter: 600,
+              x: 25,
+              y: -50,
+            },
+          ],
+          attach: "off",
+        },
+      ],
+    },
+    network: {
+      nets: [],
+      classes: [],
+    },
+    wiring: {
+      wires: [],
+    },
+  }
+
+  const dsnString = stringifyDsnJson(dsnJson)
+  const reparsedJson = parseDsnToDsnJson(dsnString) as DsnPcb
+
+  expect(dsnString).toContain("(shape (circle F.Cu 600 25 -50))")
+  expect(reparsedJson.library.padstacks[0].shapes[0]).toMatchObject({
+    shapeType: "circle",
+    layer: "F.Cu",
+    diameter: 600,
+    x: 25,
+    y: -50,
+  })
+})


### PR DESCRIPTION
Summary
- Preserve optional x/y offsets on parsed DSN padstack circle shapes.
- Emit circle offsets from stringifyDsnJson when they are present, while keeping the previous output for centered circles.
- Add focused parse -> stringify -> parse coverage for offset circle padstack shapes.

/claim #54

Verification
- bun test tests/dsn-pcb/padstack-circle-offset-roundtrip.test.ts
- bunx biome check lib/dsn-pcb/types.ts lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts tests/dsn-pcb/padstack-circle-offset-roundtrip.test.ts
- bunx tsc --noEmit
- bun test
- bun run build
- git diff --check

Transparency note: AI-assisted with Codex; I reviewed the diff and verified it locally before submission.