### PR TITLE
Preserve parser metadata when stringifying

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
@@ -30,10 +30,19 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
   result += `(pcb ${dsnJson.filename ? dsnJson.filename : "./converted_dsn.dsn"}\n`
 
   // Parser section
+  const parserStringQuote =
+    dsnJson.parser.string_quote &&
+    dsnJson.parser.string_quote.length === 1 &&
+    !/\s/.test(dsnJson.parser.string_quote)
+      ? dsnJson.parser.string_quote
+      : '"'
+  const parserSpaceInQuotedTokens =
+    dsnJson.parser.space_in_quoted_tokens || "on"
+  const parserHostCad = dsnJson.parser.host_cad || "KiCad's Pcbnew"
   result += `${indent}(parser\n`
-  result += `${indent}${indent}(string_quote ")\n`
-  result += `${indent}${indent}(space_in_quoted_tokens on)\n`
-  result += `${indent}${indent}(host_cad "KiCad's Pcbnew")\n`
+  result += `${indent}${indent}(string_quote ${parserStringQuote})\n`
+  result += `${indent}${indent}(space_in_quoted_tokens ${parserSpaceInQuotedTokens})\n`
+  result += `${indent}${indent}(host_cad ${stringifyValue(parserHostCad)})\n`
   result += `${indent}${indent}(host_version "${dsnJson.parser.host_version}")\n`
   result += `${indent})\n`
 

--- a/tests/dsn-pcb/stringify-parser-metadata.test.ts
+++ b/tests/dsn-pcb/stringify-parser-metadata.test.ts
@@ -1,0 +1,50 @@
+import { expect, test } from "bun:test"
+import { type DsnPcb, parseDsnToDsnJson, stringifyDsnJson } from "lib"
+
+test("stringify DSN JSON preserves parser metadata fields", () => {
+  const dsnFile = `
+    (pcb parser-metadata.dsn
+      (parser
+        (string_quote ')
+        (space_in_quoted_tokens off)
+        (host_cad "Allegro PCB Designer")
+        (host_version "17.4")
+      )
+      (resolution um 10)
+      (unit um)
+      (structure
+        (layer F.Cu
+          (type signal)
+          (property
+            (index 0)
+          )
+        )
+        (layer B.Cu
+          (type signal)
+          (property
+            (index 1)
+          )
+        )
+        (boundary
+          (path pcb 0 0 0 1000 0 1000 1000 0 1000 0 0)
+        )
+        (via "Via[0-1]_600:300_um")
+        (rule
+          (width 150)
+          (clearance 150)
+        )
+      )
+      (placement)
+      (library)
+      (network)
+      (wiring)
+    )
+  `
+
+  const dsnJson = parseDsnToDsnJson(dsnFile) as DsnPcb
+  const reparsedJson = parseDsnToDsnJson(stringifyDsnJson(dsnJson)) as DsnPcb
+
+  expect(reparsedJson.parser.string_quote).toBe("'")
+  expect(reparsedJson.parser.space_in_quoted_tokens).toBe("off")
+  expect(reparsedJson.parser.host_cad).toBe("Allegro PCB Designer")
+})


### PR DESCRIPTION
Summary
- Emit parsed parser `string_quote`, `space_in_quoted_tokens`, and `host_cad` metadata from stringifyDsnJson instead of hard-coding defaults.
- Keep the legacy string_quote fallback when an already-parsed value is not a single sane token.
- Add focused parse -> stringify -> parse coverage for non-default parser metadata.

/claim #54

Verification
- bun test tests/dsn-pcb/stringify-parser-metadata.test.ts tests/dsn-pcb/stringify-dsn-json.test.ts
- bunx biome check lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts tests/dsn-pcb/stringify-parser-metadata.test.ts
- bunx tsc --noEmit
- bun test
- bun run build
- git diff --check

Transparency note: AI-assisted with Codex; I reviewed the diff and verified it locally before submission.