### PR TITLE
Preserve library default vias

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
@@ -104,6 +104,9 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
     result += `${indent}${indent}${indent}(attach ${padstack.attach})\n`
     result += `${indent}${indent})\n`
   })
+  if (dsnJson.library.default_via) {
+    result += `${indent}${indent}default ${stringifyValue(dsnJson.library.default_via)}\n`
+  }
   result += `${indent})\n`
 
   // Network section

--- a/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
@@ -507,7 +507,7 @@ export function processLibrary(nodes: ASTNode[]): Library {
     padstacks: [],
   }
 
-  nodes.forEach((node) => {
+  nodes.forEach((node, index) => {
     if (node.type === "List") {
       const [keyNode, ...rest] = node.children!
       if (keyNode.type === "Atom" && typeof keyNode.value === "string") {
@@ -520,6 +520,14 @@ export function processLibrary(nodes: ASTNode[]): Library {
             library.padstacks!.push(processPadstack(node.children!))
             break
         }
+      }
+    } else if (node.type === "Atom" && node.value === "default") {
+      const defaultViaNode = nodes[index + 1]
+      if (
+        defaultViaNode?.type === "Atom" &&
+        typeof defaultViaNode.value === "string"
+      ) {
+        library.default_via = defaultViaNode.value
       }
     }
   })

--- a/lib/dsn-pcb/types.ts
+++ b/lib/dsn-pcb/types.ts
@@ -45,6 +45,7 @@ export interface DsnPcb {
   library: {
     images: Image[]
     padstacks: Padstack[]
+    default_via?: string
   }
   network: {
     nets: Array<{
@@ -176,6 +177,7 @@ export interface Places {
 export interface Library {
   images: Image[]
   padstacks: Padstack[]
+  default_via?: string
 }
 
 export interface Image {

--- a/tests/dsn-pcb/library-default-via-roundtrip.test.ts
+++ b/tests/dsn-pcb/library-default-via-roundtrip.test.ts
@@ -1,0 +1,53 @@
+import { expect, test } from "bun:test"
+import { type DsnPcb, parseDsnToDsnJson, stringifyDsnJson } from "lib"
+
+test("library default via metadata survives DSN JSON stringify round trip", () => {
+  const dsnFile = `
+    (pcb library-default.dsn
+      (parser
+        (string_quote ")
+        (space_in_quoted_tokens on)
+        (host_cad "KiCad's Pcbnew")
+        (host_version "")
+      )
+      (resolution um 10)
+      (unit um)
+      (structure
+        (layer F.Cu
+          (type signal)
+          (property
+            (index 0)
+          )
+        )
+        (layer B.Cu
+          (type signal)
+          (property
+            (index 1)
+          )
+        )
+        (boundary
+          (path pcb 0 0 0 1000 0 1000 1000 0 1000 0 0)
+        )
+        (via "Via[0-1]_600:300_um")
+        (rule
+          (width 150)
+          (clearance 150)
+        )
+      )
+      (placement)
+      (library
+        default "Via[0-1]_600:300_um"
+      )
+      (network)
+      (wiring)
+    )
+  `
+
+  const dsnJson = parseDsnToDsnJson(dsnFile) as DsnPcb
+  const dsnString = stringifyDsnJson(dsnJson)
+  const reparsedJson = parseDsnToDsnJson(dsnString) as DsnPcb
+
+  expect(dsnJson.library.default_via).toBe("Via[0-1]_600:300_um")
+  expect(dsnString).toContain('default "Via[0-1]_600:300_um"')
+  expect(reparsedJson.library.default_via).toBe("Via[0-1]_600:300_um")
+})


### PR DESCRIPTION
Summary
- Parse bare DSN library default via metadata such as `default "Via[0-1]_600:300_um"`.
- Emit the library default via entry from stringifyDsnJson when present.
- Add focused parse -> stringify -> parse coverage without changing via_rule, structure via, or routed via behavior.

/claim #54

Verification
- bun test tests/dsn-pcb/library-default-via-roundtrip.test.ts
- bunx biome check lib/dsn-pcb/types.ts lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts tests/dsn-pcb/library-default-via-roundtrip.test.ts
- bunx tsc --noEmit
- bun test
- bun run build
- git diff --check

Transparency note: AI-assisted with Codex; I reviewed the diff and verified it locally before submission.