### PR TITLE
Preserve session parser quote metadata

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-session.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-session.ts
@@ -31,6 +31,12 @@ export const stringifyDsnSession = (session: DsnSession): string => {
 
   // Parser subsection
   result += `${indent}${indent}(parser\n`
+  if (session.routes.parser.string_quote) {
+    result += `${indent}${indent}${indent}(string_quote ${session.routes.parser.string_quote})\n`
+  }
+  if (session.routes.parser.space_in_quoted_tokens) {
+    result += `${indent}${indent}${indent}(space_in_quoted_tokens ${session.routes.parser.space_in_quoted_tokens})\n`
+  }
   result += `${indent}${indent}${indent}(host_cad ${JSON.stringify(session.routes.parser.host_cad)})\n`
   result += `${indent}${indent}${indent}(host_version ${JSON.stringify(session.routes.parser.host_version)})\n`
   result += `${indent}${indent})\n`

--- a/tests/dsn-pcb/stringify-dsn-session.test.ts
+++ b/tests/dsn-pcb/stringify-dsn-session.test.ts
@@ -25,3 +25,37 @@ test("stringify session file", () => {
   expect(reparsedNet.name).toBe(originalNet.name)
   expect(reparsedNet.wires).toHaveLength(originalNet.wires.length)
 })
+
+test("stringify session parser quote metadata", () => {
+  const sessionJson: DsnSession = {
+    is_dsn_session: true,
+    filename: "session.ses",
+    placement: {
+      resolution: { unit: "um", value: 10 },
+      components: [],
+    },
+    routes: {
+      resolution: { unit: "um", value: 10 },
+      parser: {
+        string_quote: "'",
+        space_in_quoted_tokens: "off",
+        host_cad: "Custom CAD",
+        host_version: "1.2.3",
+      },
+      library_out: {
+        images: [],
+        padstacks: [],
+      },
+      network_out: {
+        nets: [],
+      },
+    },
+  }
+
+  const stringified = stringifyDsnSession(sessionJson)
+
+  expect(stringified).toContain("(string_quote ')")
+  expect(stringified).toContain("(space_in_quoted_tokens off)")
+  expect(stringified).toContain('(host_cad "Custom CAD")')
+  expect(stringified).toContain('(host_version "1.2.3")')
+})


### PR DESCRIPTION
Summary
- Emit existing session routes parser `string_quote` and `space_in_quoted_tokens` metadata when stringifying DSN session JSON.
- Add focused session stringifier coverage proving parser quote metadata is retained alongside host metadata.
- Keep this scoped away from DSN PCB parser metadata, session routes parsing, and generic string escaping.

/claim #54

Verification
- bun test tests/dsn-pcb/stringify-dsn-session.test.ts
- bunx biome check lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-session.ts tests/dsn-pcb/stringify-dsn-session.test.ts
- bunx tsc --noEmit
- bun test
- bun run build
- git diff --check

Transparency note: AI-assisted with Codex; I reviewed the diff and verified it locally before submission.