### PR TITLE
Preserve quoted DSN backslashes

### DIFF
--- a/lib/common/parse-sexpr.ts
+++ b/lib/common/parse-sexpr.ts
@@ -31,9 +31,11 @@ export function tokenizeDsn(input: string): Token[] {
       i++ // Skip the opening quote
       while (i < length && input[i] !== '"') {
         if (input[i] === "\\") {
-          // Handle escape sequences
-          i++
-          if (i < length) {
+          const nextChar = input[i + 1]
+          if (nextChar === '"' || nextChar === "\\") {
+            value += nextChar
+            i += 2
+          } else {
             value += input[i]
             i++
           }

--- a/tests/dsn-pcb/parse-sexpr.test.ts
+++ b/tests/dsn-pcb/parse-sexpr.test.ts
@@ -1,0 +1,25 @@
+import { expect, test } from "bun:test"
+import { tokenizeDsn } from "lib/common/parse-sexpr"
+
+test("quoted DSN strings preserve literal Windows backslashes", () => {
+  const filename = String.raw`F:\Spiwocoal\Documentos\board.dsn`
+  const tokens = tokenizeDsn(
+    String.raw`(pcb "F:\Spiwocoal\Documentos\board.dsn")`,
+  )
+
+  expect(tokens).toEqual([
+    { type: "LParen" },
+    { type: "Symbol", value: "pcb" },
+    { type: "String", value: filename },
+    { type: "RParen" },
+  ])
+})
+
+test("quoted DSN strings still unescape quotes and escaped backslashes", () => {
+  const tokens = tokenizeDsn(String.raw`(value "has \"quote\" and C:\\tmp")`)
+
+  expect(tokens[2]).toEqual({
+    type: "String",
+    value: String.raw`has "quote" and C:\tmp`,
+  })
+})


### PR DESCRIPTION
/claim #54

## Summary
- Preserve literal backslashes in quoted DSN strings unless the backslash escapes a quote or another backslash.
- Add tokenizer regression coverage for Windows-style DSN filenames plus existing escaped quote/backslash behavior.

## Verification
- `bun test tests/dsn-pcb/parse-sexpr.test.ts`
- `bunx biome check lib/common/parse-sexpr.ts tests/dsn-pcb/parse-sexpr.test.ts`
- `git diff --check`
- `bun test`