### PR TITLE
Import circular padstack shape layers

### DIFF
--- a/lib/dsn-pcb/dsn-json-to-circuit-json/dsn-component-converters/convert-padstacks-to-smtpads.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/dsn-component-converters/convert-padstacks-to-smtpads.ts
@@ -5,6 +5,12 @@ import { applyToPoint } from "transformation-matrix"
 
 const debug = Debug("dsn-converter:convertPadstacksToSmtpads")
 
+function getLayerForCircleShape(shapeLayer: string, placementSide: string) {
+  if (shapeLayer.includes("B.") || shapeLayer === "Bottom") return "bottom"
+  if (shapeLayer.includes("F.") || shapeLayer === "Top") return "top"
+  return placementSide === "front" ? "top" : "bottom"
+}
+
 export function convertPadstacksToSmtPads(
   pcb: DsnPcb,
   transform: any,
@@ -147,7 +153,7 @@ export function convertPadstacksToSmtPads(
             x: circuitX,
             y: circuitY,
             radius: circleShape!.diameter / 2 / 1000,
-            layer: side === "front" ? "top" : "bottom",
+            layer: getLayerForCircleShape(circleShape!.layer, side),
             port_hints: [pin.pin_number.toString()],
           }
         }

--- a/tests/dsn-pcb/circular-padstack-layer-import.test.ts
+++ b/tests/dsn-pcb/circular-padstack-layer-import.test.ts
@@ -1,0 +1,97 @@
+import { expect, test } from "bun:test"
+import { type DsnPcb, convertDsnPcbToCircuitJson } from "lib"
+
+test("imports layer-specific circular padstack shapes on their DSN layer", () => {
+  const dsnPcb: DsnPcb = {
+    is_dsn_pcb: true,
+    filename: "circle-layer.dsn",
+    parser: {
+      string_quote: "",
+      space_in_quoted_tokens: "",
+      host_cad: "",
+      host_version: "",
+    },
+    resolution: { unit: "um", value: 10 },
+    unit: "um",
+    structure: {
+      layers: [
+        { name: "F.Cu", type: "signal", property: { index: 0 } },
+        { name: "B.Cu", type: "signal", property: { index: 1 } },
+      ],
+      boundary: {
+        path: {
+          layer: "pcb",
+          width: 0,
+          coordinates: [-1000, -1000, 1000, -1000, 1000, 1000, -1000, 1000],
+        },
+      },
+      via: "Via[0-1]_600:300_um",
+      rule: {
+        width: 150,
+        clearances: [{ value: 150 }],
+      },
+    },
+    placement: {
+      components: [
+        {
+          name: "LayeredCircle",
+          places: [
+            {
+              refdes: "D1",
+              x: 0,
+              y: 0,
+              side: "front",
+              rotation: 0,
+            },
+          ],
+        },
+      ],
+    },
+    library: {
+      images: [
+        {
+          name: "LayeredCircle",
+          outlines: [],
+          pins: [
+            {
+              padstack_name: "Round[B]Pad_1000_um",
+              pin_number: 1,
+              x: 0,
+              y: 0,
+            },
+          ],
+        },
+      ],
+      padstacks: [
+        {
+          name: "Round[B]Pad_1000_um",
+          shapes: [
+            {
+              shapeType: "circle",
+              layer: "B.Cu",
+              diameter: 1000,
+            },
+          ],
+          attach: "off",
+        },
+      ],
+    },
+    network: {
+      nets: [],
+      classes: [],
+    },
+    wiring: {
+      wires: [],
+    },
+  }
+
+  const circuitJson = convertDsnPcbToCircuitJson(dsnPcb)
+  const smtpad = circuitJson.find((element) => element.type === "pcb_smtpad")
+
+  expect(smtpad).toMatchObject({
+    type: "pcb_smtpad",
+    shape: "circle",
+    layer: "bottom",
+    radius: 0.5,
+  })
+})


### PR DESCRIPTION
Summary
- Use the circular padstack shape layer when importing layer-specific circle pads into Circuit JSON.
- Keep all-layer/session-side fallback behavior for non-copper circle layers.
- Add focused DSN -> Circuit JSON coverage proving a `B.Cu` circular shape imports as a bottom circular SMT pad even when the placement side is front.

/claim #54

Verification
- bun test tests/dsn-pcb/circular-padstack-layer-import.test.ts
- bunx biome check lib/dsn-pcb/dsn-json-to-circuit-json/dsn-component-converters/convert-padstacks-to-smtpads.ts tests/dsn-pcb/circular-padstack-layer-import.test.ts
- bunx tsc --noEmit
- bun test
- bun run build
- git diff --check

Transparency note: AI-assisted with Codex; I reviewed the diff and verified it locally before submission.