### PR TITLE
Preserve bare minus pin labels

### DIFF
--- a/lib/common/parse-sexpr.ts
+++ b/lib/common/parse-sexpr.ts
@@ -44,7 +44,12 @@ export function tokenizeDsn(input: string): Token[] {
       }
       i++ // Skip the closing quote
       tokens.push({ type: "String", value })
-    } else if (char === "-" || /\d/.test(char)) {
+    } else if (
+      /\d/.test(char) ||
+      (char === "-" &&
+        (/\d/.test(input[i + 1] ?? "") ||
+          (input[i + 1] === "." && /\d/.test(input[i + 2] ?? ""))))
+    ) {
       // Parse number (integer or float)
       let numStr = ""
       if (char === "-") {

--- a/tests/dsn-pcb/dsn-minus-pin-label-roundtrip.test.ts
+++ b/tests/dsn-pcb/dsn-minus-pin-label-roundtrip.test.ts
@@ -1,0 +1,59 @@
+import { expect, test } from "bun:test"
+import { type DsnPcb, parseDsnToDsnJson, stringifyDsnJson } from "lib"
+
+const minusPinDsn = `(pcb minus-pin.dsn
+  (parser
+    (string_quote ")
+    (space_in_quoted_tokens on)
+    (host_cad "KiCad's Pcbnew")
+    (host_version "test")
+  )
+  (resolution um 10)
+  (unit um)
+  (structure
+    (layer F.Cu
+      (type signal)
+      (property
+        (index 0)
+      )
+    )
+    (boundary
+      (path pcb 0 0 0 1000 0 1000 1000 0 1000 0 0)
+    )
+    (via "Via[0-1]_600:300_um")
+    (rule
+      (width 100)
+      (clearance 100)
+    )
+  )
+  (placement)
+  (library
+    (image "PolarizedFootprint"
+      (pin Rect[T]Pad_3000x1400_um - -2400 0)
+      (pin Rect[T]Pad_3000x1400_um + 2400 0)
+    )
+    (padstack Rect[T]Pad_3000x1400_um
+      (shape (rect F.Cu -1500 -700 1500 700))
+      (attach off)
+    )
+  )
+  (network)
+  (wiring)
+)`
+
+test("preserves bare minus DSN pin labels without confusing negative coordinates", () => {
+  const dsnJson = parseDsnToDsnJson(minusPinDsn) as DsnPcb
+  const [minusPin, plusPin] = dsnJson.library.images[0].pins
+
+  expect(minusPin).toEqual({
+    padstack_name: "Rect[T]Pad_3000x1400_um",
+    pin_number: "-",
+    x: -2400,
+    y: 0,
+  })
+  expect(plusPin.pin_number).toBe("+")
+  expect(plusPin.x).toBe(2400)
+
+  const reparsedJson = parseDsnToDsnJson(stringifyDsnJson(dsnJson)) as DsnPcb
+  expect(reparsedJson.library.images[0].pins[0]).toEqual(minusPin)
+})


### PR DESCRIPTION
## Summary
- Parse `-` as a number only when it is followed by numeric content.
- Preserve bare `-` as a DSN symbol so Smoothie-style pins like `(pin ... - -2400 0)` keep the `-` pin label.
- Add focused parse/stringify round-trip coverage confirming the `-` label remains distinct from the negative coordinate.

/claim #54

## Verification
- bun test tests/dsn-pcb/dsn-minus-pin-label-roundtrip.test.ts
- bunx biome check lib/common/parse-sexpr.ts tests/dsn-pcb/dsn-minus-pin-label-roundtrip.test.ts
- bunx tsc --noEmit
- bun test
- bun run build
- git diff --check

Transparency note: AI-assisted with Codex; I reviewed the diff and verified it locally before submission.