### PR TITLE
Improve layer mapping for DSN conversion (Fixes Smoothieboard traces)

### DIFF
--- a/lib/dsn-pcb/dsn-json-to-circuit-json/convert-dsn-pcb-to-circuit-json.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/convert-dsn-pcb-to-circuit-json.ts
@@ -28,7 +28,7 @@ export function convertDsnPcbToCircuitJson(
     height: 10,
     thickness: 1.4,
     material: "fr4",
-    num_layers: 4,
+    num_layers: dsnPcb.structure?.layer?.length ?? 2,
   }
   if (dsnPcb.structure.boundary.path) {
     const boundaryPath = pairs(dsnPcb.structure.boundary.path.coordinates)

--- a/lib/dsn-pcb/dsn-json-to-circuit-json/dsn-component-converters/convert-padstacks-to-smtpads.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/dsn-component-converters/convert-padstacks-to-smtpads.ts
@@ -3,6 +3,8 @@ import Debug from "debug"
 import type { DsnPcb } from "lib/dsn-pcb/types"
 import { applyToPoint } from "transformation-matrix"
 
+import { getLayerFromDsnLayer } from "../../../utils/get-layer-from-dsn-layer"
+
 const debug = Debug("dsn-converter:convertPadstacksToSmtpads")
 
 export function convertPadstacksToSmtPads(
@@ -117,9 +119,7 @@ export function convertPadstacksToSmtPads(
 
         let pcbPad: PcbSmtPad
         if (rectShape || polygonShape || pathShape) {
-          const layer = padstack.shapes[0].layer.includes("B.")
-            ? "bottom"
-            : "top"
+          const layer = getLayerFromDsnLayer(padstack.shapes[0].layer)
           debug("determining layer with padstack shapes", {
             shapes: padstack.shapes,
             layer,

--- a/lib/dsn-pcb/dsn-json-to-circuit-json/dsn-component-converters/convert-wiring-path-to-pcb-traces.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/dsn-component-converters/convert-wiring-path-to-pcb-traces.ts
@@ -9,6 +9,8 @@ import { type Matrix, applyToPoint } from "transformation-matrix"
 import { getTraceLength } from "../../../utils/get-trace-length"
 import type { Wiring } from "../../types"
 
+import { getLayerFromDsnLayer } from "../../../utils/get-layer-from-dsn-layer"
+
 const debug = Debug("dsn-converter:convertWiringPathToPcbTraces")
 
 export const convertWiringPathToPcbTraces = ({
@@ -23,6 +25,7 @@ export const convertWiringPathToPcbTraces = ({
   fromSessionSpace?: boolean
 }): Array<PcbTrace | SourceTrace> => {
   const coordinates = wire.path!.coordinates
+  const dsnLayer = wire.path!.layer
   // Convert coordinates to circuit space using the transformation matrix
   const points: Array<{ x: number; y: number }> = []
   for (let i = 0; i < coordinates.length; i += 2) {
@@ -45,7 +48,7 @@ export const convertWiringPathToPcbTraces = ({
       width: fromSessionSpace
         ? wire.path!.width / 10000 // session space to circuit space
         : wire.path!.width / 1000, // dsn space to circuit space
-      layer: wire.path!.layer.includes("F.") ? "top" : "bottom",
+      layer: getLayerFromDsnLayer(dsnLayer),
     }))
 
     const pcbTrace: PcbTrace = {

--- a/lib/utils/get-layer-from-dsn-layer.ts
+++ b/lib/utils/get-layer-from-dsn-layer.ts
@@ -1,0 +1,18 @@
+import type { PcbRenderLayer } from "circuit-json"
+
+export const getLayerFromDsnLayer = (dsnLayer: string): PcbRenderLayer => {
+  const layer = dsnLayer.toLowerCase()
+  if (layer.includes("top") || layer.includes("f.cu")) {
+    return "top"
+  }
+  if (layer.includes("bottom") || layer.includes("b.cu")) {
+    return "bottom"
+  }
+  
+  const innerMatch = layer.match(/(?:in|route|inner)(\d+)/)
+  if (innerMatch) {
+    return `inner${innerMatch[1]}` as PcbRenderLayer
+  }
+
+  return "top"
+}


### PR DESCRIPTION
This PR improves the layer mapping logic in the DSN converter. Previously, it only handled "top" and "bottom" layers using a simple string check. This caused traces on internal layers (like Route2, Route15 in Smoothieboard) to be incorrectly mapped or missed.

Changes:
- Added `getLayerFromDsnLayer` utility to handle various layer naming conventions (Top, Bottom, RouteX, InX, F.Cu, B.Cu).
- Updated `convert-wiring-path-to-pcb-traces` and `convert-padstacks-to-smtpads` to use the new mapping.
- Made `num_layers` dynamic based on the DSN structure.

This should significantly improve the conversion accuracy for multi-layer boards like the Smoothieboard.

/claim #54