### PR TITLE
Preserve wiring via padstack names

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
@@ -26,6 +26,17 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
     return `${padding}(path ${path.layer} ${path.width}  ${stringifyCoordinates(path.coordinates)})`
   }
 
+  const stringifyVia = (wire: any): string => {
+    const viaName = wire.via_name ?? dsnJson.structure?.via
+    const [x, y] = wire.path?.coordinates ?? []
+
+    if (viaName && typeof x === "number" && typeof y === "number") {
+      return `(via ${stringifyValue(viaName)} ${x} ${y} (net ${stringifyValue(wire.net)}))`
+    }
+
+    return `(via ${stringifyPath(wire.path, 3)}(net ${stringifyValue(wire.net)}))`
+  }
+
   // Start with pcb
   result += `(pcb ${dsnJson.filename ? dsnJson.filename : "./converted_dsn.dsn"}\n`
 
@@ -136,7 +147,7 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
   result += `${indent}(wiring\n`
   ;(dsnJson.wiring?.wires ?? []).forEach((wire) => {
     if (wire.type === "via") {
-      result += `${indent}${indent}(via ${stringifyPath(wire.path, 3)}(net ${stringifyValue(wire.net)}))\n`
+      result += `${indent}${indent}${stringifyVia(wire)}\n`
     } else {
       result += `${indent}${indent}(wire ${stringifyPath(wire.path, 3)}(net ${stringifyValue(wire.net)})(type ${wire.type}))\n`
     }

--- a/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
@@ -939,6 +939,10 @@ function processVia(nodes: ASTNode[]): Wire | null {
   }
 
   const wire: Partial<Wire> = {
+    via_name:
+      nodes[1]?.type === "Atom" && typeof nodes[1].value === "string"
+        ? nodes[1].value
+        : undefined,
     path: {
       layer: "all", // vias connect all layers
       width: 0, // width is defined by the padstack

--- a/lib/dsn-pcb/types.ts
+++ b/lib/dsn-pcb/types.ts
@@ -69,6 +69,7 @@ export interface DsnPcb {
   }
   wiring: {
     wires: Array<{
+      via_name?: string
       path: {
         layer: string
         width: number
@@ -269,6 +270,7 @@ export interface Wiring {
 }
 
 export interface Wire {
+  via_name?: string
   polyline_path?: {
     layer: string
     width: number

--- a/tests/dsn-pcb/dsn-wiring-via-padstack-name.test.ts
+++ b/tests/dsn-pcb/dsn-wiring-via-padstack-name.test.ts
@@ -1,0 +1,56 @@
+import { expect, test } from "bun:test"
+import { type DsnPcb, parseDsnToDsnJson, stringifyDsnJson } from "lib"
+
+test("preserves wiring via padstack names during DSN JSON round trip", () => {
+  const dsn = `(pcb board.dsn
+  (parser
+    (string_quote ")
+    (space_in_quoted_tokens on)
+    (host_cad "KiCad's Pcbnew")
+    (host_version "9.0")
+  )
+  (resolution um 10)
+  (unit um)
+  (structure
+    (layer F.Cu
+      (type signal)
+      (property
+        (index 0)
+      )
+    )
+    (boundary
+      (path pcb 0 0 0 1000 0 1000 1000 0 1000 0 0)
+    )
+    (via "Via[0-1]_600:300_um")
+    (rule
+      (width 200)
+    )
+  )
+  (placement)
+  (library)
+  (network
+    (net "N1"
+      (pins U1-1)
+    )
+  )
+  (wiring
+    (via "Via[0-1]_600:300_um" 100 200
+      (net "N1")
+    )
+  )
+)
+`
+
+  const parsed = parseDsnToDsnJson(dsn) as DsnPcb
+  expect(parsed.wiring.wires[0].type).toBe("via")
+  expect(parsed.wiring.wires[0].via_name).toBe("Via[0-1]_600:300_um")
+
+  const stringified = stringifyDsnJson(parsed)
+  expect(stringified).toContain(
+    '(via "Via[0-1]_600:300_um" 100 200 (net "N1"))',
+  )
+
+  const reparsed = parseDsnToDsnJson(stringified) as DsnPcb
+  expect(reparsed.wiring.wires[0].via_name).toBe("Via[0-1]_600:300_um")
+  expect(reparsed.wiring.wires[0].path?.coordinates).toEqual([100, 200])
+})


### PR DESCRIPTION
/claim #54

## Summary
- Preserve the padstack name from DSN wiring via records as `via_name`.
- Stringify via wires back as canonical `(via "<padstack>" x y (net ...))`, falling back to the board default via when needed.
- Add focused parse -> stringify -> parse coverage for wiring via padstack names.

## Verification
- `bun test tests/dsn-pcb/dsn-wiring-via-padstack-name.test.ts`
- `bun test`
- `bun x tsc --noEmit`
- `bun x biome check lib/dsn-pcb/types.ts lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts tests/dsn-pcb/dsn-wiring-via-padstack-name.test.ts`
- `bun run build`
- `git diff --check`

Transparency: AI-assisted with Codex; I reviewed the diff and kept the change scoped to DSN wiring via padstack-name round trips.