### PR TITLE
Preserve wire clearance classes

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
@@ -26,6 +26,12 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
     return `${padding}(path ${path.layer} ${path.width}  ${stringifyCoordinates(path.coordinates)})`
   }
 
+  const stringifyWireMetadata = (wire: any): string => {
+    return wire.clearance_class
+      ? `(clearance_class ${stringifyValue(wire.clearance_class)})`
+      : ""
+  }
+
   // Start with pcb
   result += `(pcb ${dsnJson.filename ? dsnJson.filename : "./converted_dsn.dsn"}\n`
 
@@ -138,7 +144,7 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
     if (wire.type === "via") {
       result += `${indent}${indent}(via ${stringifyPath(wire.path, 3)}(net ${stringifyValue(wire.net)}))\n`
     } else {
-      result += `${indent}${indent}(wire ${stringifyPath(wire.path, 3)}(net ${stringifyValue(wire.net)})(type ${wire.type}))\n`
+      result += `${indent}${indent}(wire ${stringifyPath(wire.path, 3)}(net ${stringifyValue(wire.net)})(type ${wire.type})${stringifyWireMetadata(wire)})\n`
     }
   })
   result += `${indent})\n`

--- a/lib/dsn-pcb/types.ts
+++ b/lib/dsn-pcb/types.ts
@@ -78,6 +78,7 @@ export interface DsnPcb {
         coordinates: number[]
       }
       net: string
+      clearance_class?: string
       type: string
     }>
   }

--- a/tests/dsn-pcb/dsn-wire-clearance-class.test.ts
+++ b/tests/dsn-pcb/dsn-wire-clearance-class.test.ts
@@ -1,0 +1,55 @@
+import { expect, test } from "bun:test"
+import { type DsnPcb, parseDsnToDsnJson, stringifyDsnJson } from "lib"
+
+test("preserves wire clearance classes during DSN JSON round trip", () => {
+  const dsn = `(pcb board.dsn
+  (parser
+    (string_quote ")
+    (space_in_quoted_tokens on)
+    (host_cad "KiCad's Pcbnew")
+    (host_version "9.0")
+  )
+  (resolution um 10)
+  (unit um)
+  (structure
+    (layer F.Cu
+      (type signal)
+      (property
+        (index 0)
+      )
+    )
+    (boundary
+      (path pcb 0 0 0 1000 0 1000 1000 0 1000 0 0)
+    )
+    (via "Via[0-1]_600:300_um")
+    (rule
+      (width 200)
+    )
+  )
+  (placement)
+  (library)
+  (network
+    (net "N1"
+      (pins U1-1)
+    )
+  )
+  (wiring
+    (wire
+      (path F.Cu 200 0 0 1000 0)
+      (net "N1")
+      (type route)
+      (clearance_class "tight pair")
+    )
+  )
+)
+`
+
+  const parsed = parseDsnToDsnJson(dsn) as DsnPcb
+  expect(parsed.wiring.wires[0].clearance_class).toBe("tight pair")
+
+  const stringified = stringifyDsnJson(parsed)
+  expect(stringified).toContain('(clearance_class "tight pair")')
+
+  const reparsed = parseDsnToDsnJson(stringified) as DsnPcb
+  expect(reparsed.wiring.wires[0].clearance_class).toBe("tight pair")
+})


### PR DESCRIPTION
/claim #54

## Summary
- Preserve already-parsed DSN wire `clearance_class` metadata when stringifying DSN JSON.
- Keep this scoped to wiring metadata only; no rule clearance, placement, or Circuit JSON conversion behavior changes.
- Add focused parse -> stringify -> parse coverage for wire clearance classes.

## Verification
- `bun test tests/dsn-pcb/dsn-wire-clearance-class.test.ts`
- `bun test`
- `bun x tsc --noEmit`
- `bun x biome check lib/dsn-pcb/types.ts lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts tests/dsn-pcb/dsn-wire-clearance-class.test.ts`
- `bun run build`
- `git diff --check`

Transparency: AI-assisted with Codex; I reviewed the diff and kept the change scoped to DSN wire clearance-class round trips.