### PR TITLE
guard optional dsn layer property

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
@@ -46,9 +46,11 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
   dsnJson.structure.layers.forEach((layer) => {
     result += `${indent}${indent}(layer ${layer.name}\n`
     result += `${indent}${indent}${indent}(type ${layer.type})\n`
-    result += `${indent}${indent}${indent}(property\n`
-    result += `${indent}${indent}${indent}${indent}(index ${layer.property.index})\n`
-    result += `${indent}${indent}${indent})\n`
+    if (typeof layer.property?.index === "number") {
+      result += `${indent}${indent}${indent}(property\n`
+      result += `${indent}${indent}${indent}${indent}(index ${layer.property.index})\n`
+      result += `${indent}${indent}${indent})\n`
+    }
     result += `${indent}${indent})\n`
   })
   if (dsnJson.structure.boundary) {

--- a/tests/dsn-pcb/stringify-dsn-json.test.ts
+++ b/tests/dsn-pcb/stringify-dsn-json.test.ts
@@ -17,3 +17,39 @@ test("stringify dsn json", () => {
   // Test that we can parse the generated string back to the same structure
   // expect(reparsedJson).toEqual(dsnJson)
 })
+
+test("stringify dsn json with a layer missing property index", () => {
+  const input = `(pcb "missing-layer-property.dsn"
+    (parser
+      (string_quote ")
+      (space_in_quoted_tokens on)
+      (host_cad "KiCad's Pcbnew")
+      (host_version "9.0")
+    )
+    (resolution um 10)
+    (unit um)
+    (structure
+      (layer F.Cu
+        (type signal)
+      )
+      (boundary
+        (path F.Cu 0 0 0 1000 0 1000 1000 0 1000 0 0)
+      )
+      (via "Via[0-1]_600:300_um")
+      (rule
+        (width 150)
+      )
+    )
+    (placement)
+    (library)
+    (network)
+    (wiring)
+  )`
+
+  const dsnJson = parseDsnToDsnJson(input) as DsnPcb
+  const dsnString = stringifyDsnJson(dsnJson)
+  const reparsedJson = parseDsnToDsnJson(dsnString) as DsnPcb
+
+  expect(dsnString).not.toContain("(index undefined)")
+  expect(reparsedJson.structure.layers[0].property).toBeUndefined()
+})


### PR DESCRIPTION
/claim #54

this fixes a dsn pcb round-trip crash when a layer has `(type signal)` but no `(property (index ...))`. the parser accepts that layer and leaves `property` absent, but the stringifier was reading `layer.property.index` every time.

now the property block is emitted only when the parsed layer has a numeric index. i added a focused parse -> stringify -> parse regression for a layer without the property block, and it also checks the output does not contain `(index undefined)`.

checks run:
`npx --yes bun@1.2.17 test tests/dsn-pcb/stringify-dsn-json.test.ts`
`npx --yes bun@1.2.17 x biome check lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts tests/dsn-pcb/stringify-dsn-json.test.ts`
`npx --yes bun@1.2.17 x tsc --noEmit`
`git diff --check`
`npx --yes bun@1.2.17 test`
`npx --yes bun@1.2.17 run build`