### PR TITLE
Preserve DSN class-level clearance and via rules

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
@@ -117,6 +117,12 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
   })
   dsnJson.network.classes.forEach((cls) => {
     result += `${indent}${indent}(class ${stringifyValue(cls.name)} ${stringifyValue(cls.description)}${cls.net_names.map((n) => ` ${stringifyValue(n)}`).join("")}\n`
+    if (cls.clearance_class) {
+      result += `${indent}${indent}${indent}(clearance_class ${stringifyValue(cls.clearance_class)})\n`
+    }
+    if (cls.via_rule) {
+      result += `${indent}${indent}${indent}(via_rule ${stringifyValue(cls.via_rule)})\n`
+    }
     result += `${indent}${indent}${indent}(circuit\n`
     result += `${indent}${indent}${indent}${indent}(use_via ${stringifyValue(cls.circuit.use_via)})\n`
     result += `${indent}${indent}${indent})\n`

--- a/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
@@ -876,6 +876,14 @@ function processClass(nodes: ASTNode[]): Class {
         const key = keyNode.value
         if (key === "circuit") {
           classObj.circuit = processCircuit(node.children!.slice(1))
+        } else if (key === "clearance_class") {
+          if (rest[0]?.type === "Atom" && typeof rest[0].value === "string") {
+            classObj.clearance_class = rest[0].value
+          }
+        } else if (key === "via_rule") {
+          if (rest[0]?.type === "Atom" && typeof rest[0].value === "string") {
+            classObj.via_rule = rest[0].value
+          }
         } else if (key === "rule") {
           classObj.rule = processRule(node.children!.slice(1))
         }

--- a/lib/dsn-pcb/types.ts
+++ b/lib/dsn-pcb/types.ts
@@ -55,6 +55,8 @@ export interface DsnPcb {
       name: string
       description: string
       net_names: string[]
+      clearance_class?: string
+      via_rule?: string
       circuit: {
         use_via: string
       }
@@ -256,6 +258,8 @@ export interface Class {
   name: string
   description: string
   net_names: string[]
+  clearance_class?: string
+  via_rule?: string
   circuit: Circuit
   rule: Rule
 }

--- a/tests/dsn-pcb/stringify-dsn-json.test.ts
+++ b/tests/dsn-pcb/stringify-dsn-json.test.ts
@@ -17,3 +17,63 @@ test("stringify dsn json", () => {
   // Test that we can parse the generated string back to the same structure
   // expect(reparsedJson).toEqual(dsnJson)
 })
+
+test("preserves class-level clearance class and via rule metadata", () => {
+  const dsnString = `(pcb "class-metadata.dsn"
+  (parser
+    (string_quote ")
+    (space_in_quoted_tokens on)
+    (host_cad "KiCad's Pcbnew")
+    (host_version "9.0")
+  )
+  (resolution um 10)
+  (unit um)
+  (structure
+    (layer F.Cu
+      (type signal)
+      (property
+        (index 0)
+      )
+    )
+    (boundary
+      (path F.Cu 0 0 0 1000 0 1000 1000 0 1000)
+    )
+    (via "Via[0-1]_600:300_um")
+    (rule
+      (width 200)
+      (clearance 100)
+    )
+  )
+  (placement)
+  (library)
+  (network
+    (net "N1"
+      (pins U1-1)
+    )
+    (class default "" "N1"
+      (clearance_class default)
+      (via_rule default)
+      (circuit
+        (use_via "Via[0-1]_600:300_um")
+      )
+      (rule
+        (width 200)
+        (clearance 100)
+      )
+    )
+  )
+  (wiring)
+)`
+
+  const dsnJson = parseDsnToDsnJson(dsnString) as DsnPcb
+  expect(dsnJson.network.classes[0].clearance_class).toBe("default")
+  expect(dsnJson.network.classes[0].via_rule).toBe("default")
+
+  const stringified = stringifyDsnJson(dsnJson)
+  expect(stringified).toContain('(clearance_class "default")')
+  expect(stringified).toContain('(via_rule "default")')
+
+  const reparsedJson = parseDsnToDsnJson(stringified) as DsnPcb
+  expect(reparsedJson.network.classes[0].clearance_class).toBe("default")
+  expect(reparsedJson.network.classes[0].via_rule).toBe("default")
+})


### PR DESCRIPTION
Fixes one class metadata round-trip gap for #54.

- preserves class-level `(clearance_class ...)` records
- preserves class-level `(via_rule ...)` records
- adds a parse -> stringify -> parse regression test

/claim #54