### PR TITLE
Preserve DSN image keepouts

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/process-components-and-pads.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/process-components-and-pads.ts
@@ -89,6 +89,7 @@ export function processComponentsAndPads(
     const image: Image = {
       name: footprintName,
       outlines: [],
+      keepouts: [],
       pins: componentGroup.pcb_smtpads
         .map((pad) => {
           const pcbComponent = circuitElements.find(

--- a/lib/dsn-pcb/circuit-json-to-dsn-json/process-plated-holes.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/process-plated-holes.ts
@@ -94,7 +94,7 @@ export function processPlatedHoles(
   function ensureImage(name: string): Image {
     let image = pcb.library.images.find((img) => img.name === name)
     if (!image) {
-      image = { name, outlines: [], pins: [] }
+      image = { name, outlines: [], keepouts: [], pins: [] }
       pcb.library.images.push(image)
     }
     return image

--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
@@ -85,6 +85,22 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
     image.outlines.forEach((outline) => {
       result += `${indent}${indent}${indent}(outline ${stringifyPath(outline.path, 4)})\n`
     })
+    ;(image.keepouts ?? []).forEach((keepout) => {
+      const { shape } = keepout
+      if (shape.shapeType === "circle") {
+        const offset =
+          shape.x !== undefined && shape.y !== undefined
+            ? ` ${shape.x} ${shape.y}`
+            : ""
+        result += `${indent}${indent}${indent}(keepout ${stringifyValue(keepout.name)} (circle ${shape.layer} ${shape.diameter}${offset}))\n`
+      } else if (shape.shapeType === "polygon") {
+        result += `${indent}${indent}${indent}(keepout ${stringifyValue(keepout.name)} (polygon ${shape.layer} ${shape.width} ${stringifyCoordinates(shape.coordinates)}))\n`
+      } else if (shape.shapeType === "path") {
+        result += `${indent}${indent}${indent}(keepout ${stringifyValue(keepout.name)} (path ${shape.layer} ${shape.width} ${stringifyCoordinates(shape.coordinates)}))\n`
+      } else if (shape.shapeType === "rect") {
+        result += `${indent}${indent}${indent}(keepout ${stringifyValue(keepout.name)} (rect ${shape.layer} ${stringifyCoordinates(shape.coordinates)}))\n`
+      }
+    })
     image.pins.forEach((pin) => {
       result += `${indent}${indent}${indent}(pin ${pin.padstack_name} ${pin.pin_number} ${pin.x} ${pin.y})\n`
     })

--- a/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
@@ -18,6 +18,7 @@ import type {
   DsnPcb,
   DsnSession,
   Image,
+  Keepout,
   Layer,
   Library,
   Net,
@@ -533,6 +534,7 @@ function processImage(nodes: ASTNode[]): Image {
     image.name = nodes[1].value
   }
   image.outlines = []
+  image.keepouts = []
   image.pins = []
 
   nodes.slice(2).forEach((node) => {
@@ -542,6 +544,9 @@ function processImage(nodes: ASTNode[]): Image {
         const key = keyNode.value
         if (key === "outline") {
           image.outlines!.push(processOutline(node.children!))
+        } else if (key === "keepout") {
+          const keepout = processKeepout(node.children!)
+          if (keepout) image.keepouts!.push(keepout)
         } else if (key === "pin") {
           const pin = processPin(node.children!)
           if (pin) image.pins!.push(pin)
@@ -551,6 +556,45 @@ function processImage(nodes: ASTNode[]): Image {
   })
 
   return image as Image
+}
+
+function processKeepout(nodes: ASTNode[]): Keepout | null {
+  const nameNode = nodes[1]
+  const shapeNode = nodes[2]
+
+  if (
+    nameNode?.type !== "Atom" ||
+    typeof nameNode.value !== "string" ||
+    shapeNode?.type !== "List"
+  ) {
+    debug("Unsupported keepout format:", nodes)
+    return null
+  }
+
+  return {
+    name: nameNode.value,
+    shape: processKeepoutShape(shapeNode.children!),
+  }
+}
+
+function processKeepoutShape(nodes: ASTNode[]): Shape {
+  const shapeTypeNode = nodes[0]
+  if (shapeTypeNode?.type !== "Atom" || typeof shapeTypeNode.value !== "string") {
+    throw new Error(`Unknown keepout shape type for nodes: ${JSON.stringify(nodes)}`)
+  }
+
+  switch (shapeTypeNode.value) {
+    case "circle":
+      return processCircleShape(nodes)
+    case "path":
+      return processPathShape(nodes)
+    case "polygon":
+      return processPolygonShape(nodes)
+    case "rect":
+      return processRectShape(nodes)
+    default:
+      throw new Error(`Unknown keepout shape type: ${shapeTypeNode.value}`)
+  }
 }
 
 function processOutline(nodes: ASTNode[]): Outline {
@@ -775,6 +819,15 @@ function processCircleShape(nodes: ASTNode[]): CircleShape {
   ) {
     circle.layer = shapeNodes[1].value
     circle.diameter = shapeNodes[2].value
+    if (
+      shapeNodes[3]?.type === "Atom" &&
+      typeof shapeNodes[3].value === "number" &&
+      shapeNodes[4]?.type === "Atom" &&
+      typeof shapeNodes[4].value === "number"
+    ) {
+      circle.x = shapeNodes[3].value
+      circle.y = shapeNodes[4].value
+    }
     return circle as CircleShape
   } else {
     // Try to extract coordinates if they exist

--- a/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
@@ -579,8 +579,13 @@ function processKeepout(nodes: ASTNode[]): Keepout | null {
 
 function processKeepoutShape(nodes: ASTNode[]): Shape {
   const shapeTypeNode = nodes[0]
-  if (shapeTypeNode?.type !== "Atom" || typeof shapeTypeNode.value !== "string") {
-    throw new Error(`Unknown keepout shape type for nodes: ${JSON.stringify(nodes)}`)
+  if (
+    shapeTypeNode?.type !== "Atom" ||
+    typeof shapeTypeNode.value !== "string"
+  ) {
+    throw new Error(
+      `Unknown keepout shape type for nodes: ${JSON.stringify(nodes)}`,
+    )
   }
 
   switch (shapeTypeNode.value) {

--- a/lib/dsn-pcb/types.ts
+++ b/lib/dsn-pcb/types.ts
@@ -181,11 +181,17 @@ export interface Library {
 export interface Image {
   name: string
   outlines: Outline[]
+  keepouts: Keepout[]
   pins: Pin[]
 }
 
 export interface Outline {
   path: Path
+}
+
+export interface Keepout {
+  name: string
+  shape: Shape
 }
 
 export interface Pin {
@@ -229,6 +235,8 @@ export interface PolygonShape extends BaseShape {
 export interface CircleShape extends BaseShape {
   shapeType: "circle"
   diameter: number
+  x?: number
+  y?: number
 }
 
 export interface RectShape extends BaseShape {

--- a/tests/dsn-pcb/stringify-dsn-json.test.ts
+++ b/tests/dsn-pcb/stringify-dsn-json.test.ts
@@ -1,6 +1,10 @@
 import { expect, test } from "bun:test"
 import { type DsnPcb, parseDsnToDsnJson, stringifyDsnJson } from "lib"
 // @ts-ignore
+import smoothieDsnFile from "../assets/repro/smoothieboard-repro.dsn" with {
+  type: "text",
+}
+// @ts-ignore
 import testDsnFile from "../assets/testkicadproject/testkicadproject.dsn" with {
   type: "text",
 }
@@ -16,4 +20,49 @@ test("stringify dsn json", () => {
 
   // Test that we can parse the generated string back to the same structure
   // expect(reparsedJson).toEqual(dsnJson)
+})
+
+test("preserves image keepout circles through DSN stringify roundtrip", () => {
+  const dsnJson = parseDsnToDsnJson(smoothieDsnFile) as DsnPcb
+  const keepouts = dsnJson.library.images.flatMap(
+    (image) => image.keepouts ?? [],
+  )
+
+  expect(keepouts.length).toBeGreaterThan(0)
+  expect(keepouts[0].name).toBe("")
+  expect(keepouts[0].shape).toMatchObject({
+    shapeType: "circle",
+    layer: "Top",
+    diameter: 3600,
+  })
+
+  const offsetKeepout = keepouts.find(
+    (keepout) =>
+      keepout.shape.shapeType === "circle" &&
+      keepout.shape.layer === "Top" &&
+      keepout.shape.diameter === 1600 &&
+      keepout.shape.x === 0 &&
+      keepout.shape.y === -4500,
+  )
+  expect(offsetKeepout).toBeDefined()
+
+  const dsnString = stringifyDsnJson(dsnJson)
+  expect(dsnString).toContain('(keepout "" (circle Top 3600))')
+  expect(dsnString).toContain('(keepout "" (circle Top 1600 0 -4500))')
+
+  const reparsedJson = parseDsnToDsnJson(dsnString) as DsnPcb
+  const reparsedKeepouts = reparsedJson.library.images.flatMap(
+    (image) => image.keepouts ?? [],
+  )
+  expect(reparsedKeepouts.length).toBe(keepouts.length)
+  expect(
+    reparsedKeepouts.some(
+      (keepout) =>
+        keepout.shape.shapeType === "circle" &&
+        keepout.shape.layer === "Top" &&
+        keepout.shape.diameter === 1600 &&
+        keepout.shape.x === 0 &&
+        keepout.shape.y === -4500,
+    ),
+  ).toBe(true)
 })


### PR DESCRIPTION
﻿/claim #54

## Summary
- parse image-level DSN `keepout` records into `Image.keepouts`
- stringify image keepouts back out, including circle x/y offsets used by Smoothie exports
- add regression coverage against the real Smoothie repro fixture so keepouts survive parse -> stringify -> parse

## Scope
This is intentionally limited to library image keepouts. It does not change padstack geometry conversion or circuit-json conversion behavior, so it should stay separate from the other active #54 slices.

## Demo video
- Short proof video: https://github.com/Iineman2/dsn-converter/releases/download/dsn-converter-maintenance-demos-216-373/dsn-pr373-keepout-demo.mp4
- Summarizes the DSN image keepout round-trip and Smoothie repro regression.

## Verification
- `npx --yes bun test tests\dsn-pcb\stringify-dsn-json.test.ts --test-name-pattern "preserves image keepout"`
- `.\node_modules\.bin\tsc.exe --noEmit`
- `npx biome check lib\dsn-pcb\types.ts lib\dsn-pcb\dsn-json-to-circuit-json\parse-dsn-to-dsn-json.ts lib\dsn-pcb\circuit-json-to-dsn-json\stringify-dsn-json.ts lib\dsn-pcb\circuit-json-to-dsn-json\process-components-and-pads.ts lib\dsn-pcb\circuit-json-to-dsn-json\process-plated-holes.ts tests\dsn-pcb\stringify-dsn-json.test.ts`
- `npx --yes bun run build`

Note: running the whole `tests\dsn-pcb\stringify-dsn-json.test.ts` file on this Windows checkout still exposes the existing CRLF-sensitive parser fixture assertion in the older generic stringify test; the new keepout regression itself passes.

