### PR TITLE
Use source component names as DSN PN fallback

### DIFF
--- a/lib/utils/get-component-value.ts
+++ b/lib/utils/get-component-value.ts
@@ -13,5 +13,8 @@ export function getComponentValue(sourceComponent: any): string {
       return `${(capacitanceUF).toFixed(3)}uF`
     }
   }
+  if (typeof sourceComponent.name === "string" && sourceComponent.name.trim()) {
+    return sourceComponent.name
+  }
   return ""
 }

--- a/tests/dsn-pcb/source-component-name-pn-fallback.test.ts
+++ b/tests/dsn-pcb/source-component-name-pn-fallback.test.ts
@@ -1,0 +1,60 @@
+import { expect, test } from "bun:test"
+import { convertCircuitJsonToDsnJson } from "lib/dsn-pcb/circuit-json-to-dsn-json/convert-circuit-json-to-dsn-json"
+
+test("uses source component name as placement PN fallback", () => {
+  const circuitJson: any[] = [
+    {
+      type: "pcb_board",
+      pcb_board_id: "board1",
+      center: { x: 0, y: 0 },
+      width: 10,
+      height: 10,
+    },
+    {
+      type: "source_component",
+      source_component_id: "source_component_0",
+      ftype: "simple_chip",
+      name: "LED",
+    },
+    {
+      type: "pcb_component",
+      pcb_component_id: "pcb_component_0",
+      source_component_id: "source_component_0",
+      center: { x: 0, y: 0 },
+      width: 1.6,
+      height: 0.8,
+      rotation: 0,
+      layer: "top",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_0",
+      source_component_id: "source_component_0",
+      port_hints: ["1"],
+    },
+    {
+      type: "pcb_port",
+      pcb_port_id: "pcb_port_0",
+      source_port_id: "source_port_0",
+      pcb_component_id: "pcb_component_0",
+    },
+    {
+      type: "pcb_smtpad",
+      pcb_smtpad_id: "pcb_smtpad_0",
+      pcb_component_id: "pcb_component_0",
+      pcb_port_id: "pcb_port_0",
+      shape: "rect",
+      x: 0,
+      y: 0,
+      width: 0.6,
+      height: 0.4,
+      layer: "top",
+    },
+  ]
+
+  const dsnJson = convertCircuitJsonToDsnJson(circuitJson)
+
+  expect(dsnJson.placement.components).toHaveLength(1)
+  expect(dsnJson.placement.components[0].places).toHaveLength(1)
+  expect(dsnJson.placement.components[0].places[0].PN).toBe("LED")
+})


### PR DESCRIPTION
## Summary
- use `source_component.name` as the final DSN placement `PN` fallback when no resistor or capacitor value is present
- add focused export coverage for a non-passive source component that otherwise produced a blank `PN`

## Bounty
Part of #54
/claim #54

## Validation
- `npx --yes bun test tests/dsn-pcb/source-component-name-pn-fallback.test.ts`
- `.\node_modules\.bin\biome.exe check lib/utils/get-component-value.ts tests/dsn-pcb/source-component-name-pn-fallback.test.ts`
- `npx --yes bun run build`
- `npx --yes bun test` currently has 3 unrelated failures on this Windows checkout: two debug-file path `ENOENT` failures from absolute Windows paths, plus the existing DSN string quote round-trip failure.