### PR TITLE
Preserve quoted PCB filenames when stringifying DSN

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
@@ -15,6 +15,10 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
     return value.toString()
   }
 
+  const stringifyRootFilename = (filename?: string): string => {
+    return JSON.stringify(filename || "./converted_dsn.dsn")
+  }
+
   // Helper function to stringify an array of coordinates
   const stringifyCoordinates = (coordinates: number[]): string => {
     return coordinates.join(" ")
@@ -27,7 +31,7 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
   }
 
   // Start with pcb
-  result += `(pcb ${dsnJson.filename ? dsnJson.filename : "./converted_dsn.dsn"}\n`
+  result += `(pcb ${stringifyRootFilename(dsnJson.filename)}\n`
 
   // Parser section
   result += `${indent}(parser\n`

--- a/tests/dsn-pcb/stringify-dsn-json.test.ts
+++ b/tests/dsn-pcb/stringify-dsn-json.test.ts
@@ -17,3 +17,41 @@ test("stringify dsn json", () => {
   // Test that we can parse the generated string back to the same structure
   // expect(reparsedJson).toEqual(dsnJson)
 })
+
+test("stringify preserves quoted root pcb filenames with spaces", () => {
+  const dsnJson = parseDsnToDsnJson(`(pcb "smoothie board.dsn"
+    (parser
+      (string_quote ")
+      (space_in_quoted_tokens on)
+      (host_cad "KiCad's Pcbnew")
+      (host_version "9.0")
+    )
+    (resolution um 10)
+    (unit um)
+    (structure
+      (layer F.Cu
+        (type signal)
+        (property
+          (index 0)
+        )
+      )
+      (via "Via[0-1]_600:300_um")
+      (rule
+        (width 150)
+        (clearance 200)
+      )
+    )
+    (placement)
+    (library)
+    (network)
+    (wiring)
+  )`) as DsnPcb
+
+  expect(dsnJson.filename).toBe("smoothie board.dsn")
+
+  const dsnString = stringifyDsnJson(dsnJson)
+  const reparsedJson = parseDsnToDsnJson(dsnString) as DsnPcb
+
+  expect(dsnString).toContain('(pcb "smoothie board.dsn"')
+  expect(reparsedJson.filename).toBe("smoothie board.dsn")
+})


### PR DESCRIPTION
Fixes a focused DSN PCB round-trip gap from #54.

`parseDsnToDsnJson` accepts quoted root PCB filenames, but `stringifyDsnJson` emitted the top-level `(pcb ...)` filename as a raw token. Filenames with spaces, such as `"smoothie board.dsn"`, reparsed as only `smoothie`, losing the original design filename.

This PR quotes/escapes only the root PCB filename during DSN JSON stringification and adds focused parse -> stringify -> parse coverage.

Verification:
- `npx --yes bun@latest test tests/dsn-pcb/stringify-dsn-json.test.ts`
- `npx --yes bun@latest x biome check lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts tests/dsn-pcb/stringify-dsn-json.test.ts`
- `npx --yes bun@latest x tsc --noEmit`
- `npx --yes bun@latest run build`
- `npx --yes bun@latest test`
- `git diff --check`

/claim #54