### PR TITLE
Preserve DSN structure plane polygons

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
@@ -26,6 +26,22 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
     return `${padding}(path ${path.layer} ${path.width}  ${stringifyCoordinates(path.coordinates)})`
   }
 
+  const stringifyShape = (shape: any): string => {
+    if (shape.shapeType === "polygon") {
+      return `(polygon ${shape.layer} ${shape.width} ${stringifyCoordinates(shape.coordinates)})`
+    }
+    if (shape.shapeType === "circle") {
+      return `(circle ${shape.layer} ${shape.diameter})`
+    }
+    if (shape.shapeType === "rect") {
+      return `(rect ${shape.layer} ${stringifyCoordinates(shape.coordinates)})`
+    }
+    if (shape.shapeType === "path") {
+      return `(path ${shape.layer} ${shape.width} ${stringifyCoordinates(shape.coordinates)})`
+    }
+    throw new Error(`Unknown DSN shape type: ${shape.shapeType}`)
+  }
+
   // Start with pcb
   result += `(pcb ${dsnJson.filename ? dsnJson.filename : "./converted_dsn.dsn"}\n`
 
@@ -56,6 +72,9 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
     result += `${indent}${indent}${indent}${stringifyPath(dsnJson.structure.boundary.path, 0)}\n`
     result += `${indent}${indent})\n`
   }
+  ;(dsnJson.structure.planes ?? []).forEach((plane) => {
+    result += `${indent}${indent}(plane ${stringifyValue(plane.net)} ${stringifyShape(plane.shape)})\n`
+  })
   result += `${indent}${indent}(via ${stringifyValue(dsnJson.structure.via)})\n`
   result += `${indent}${indent}(rule\n`
   result += `${indent}${indent}${indent}(width ${dsnJson.structure.rule.width})\n`
@@ -93,12 +112,8 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
   dsnJson.library.padstacks.forEach((padstack) => {
     result += `${indent}${indent}(padstack ${stringifyValue(padstack.name)}\n`
     padstack.shapes.forEach((shape) => {
-      if (shape.shapeType === "polygon") {
-        result += `${indent}${indent}${indent}(shape (polygon ${shape.layer} ${shape.width} ${stringifyCoordinates(shape.coordinates)}))\n`
-      } else if (shape.shapeType === "circle") {
-        result += `${indent}${indent}${indent}(shape (circle ${shape.layer} ${shape.diameter}))\n`
-      } else if (shape.shapeType === "path") {
-        result += `${indent}${indent}${indent}(shape (path ${shape.layer} ${shape.width} ${stringifyCoordinates(shape.coordinates)}))\n`
+      if (["polygon", "circle", "path"].includes(shape.shapeType)) {
+        result += `${indent}${indent}${indent}(shape ${stringifyShape(shape)})\n`
       }
     })
     result += `${indent}${indent}${indent}(attach ${padstack.attach})\n`

--- a/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
@@ -27,6 +27,7 @@ import type {
   Parser as ParserType,
   Path,
   PathShape,
+  Plane,
   Pin,
   Placement,
   Places,
@@ -211,6 +212,7 @@ export function processResolution(nodes: ASTNode[]): Resolution {
 export function processStructure(nodes: ASTNode[]): Structure {
   const structure: Partial<Structure> = {
     layers: [],
+    planes: [],
   }
 
   nodes.forEach((node) => {
@@ -225,6 +227,11 @@ export function processStructure(nodes: ASTNode[]): Structure {
           case "boundary":
             structure.boundary = processBoundary(node.children!.slice(1))
             break
+          case "plane": {
+            const plane = processPlane(node.children!)
+            if (plane) structure.planes!.push(plane)
+            break
+          }
           case "via":
             if (
               node.children![1].type === "Atom" &&
@@ -304,6 +311,27 @@ function processBoundary(nodes: ASTNode[]): Boundary {
     boundary.path = { layer: "", width: 0, coordinates: [] }
   }
   return boundary as Boundary
+}
+
+function processPlane(nodes: ASTNode[]): Plane | null {
+  const netNode = nodes[1]
+  const shapeNode = nodes.find(
+    (node) =>
+      node.type === "List" &&
+      node.children?.[0]?.type === "Atom" &&
+      ["polygon", "circle", "rect", "path"].includes(
+        String(node.children[0].value),
+      ),
+  )
+
+  if (!netNode || netNode.type !== "Atom" || !shapeNode?.children) {
+    return null
+  }
+
+  return {
+    net: String(netNode.value),
+    shape: processShapeContent(shapeNode.children),
+  }
 }
 
 function processPath(nodes: ASTNode[]): Path {
@@ -668,31 +696,35 @@ function processPadstack(nodes: ASTNode[]): Padstack {
 }
 
 function processShape(nodes: ASTNode[]): Shape {
-  const [_, shapeContentNode, ...rest] = nodes
+  const [_, shapeContentNode] = nodes
 
   if (shapeContentNode.type === "List") {
-    const [shapeTypeNode, layerNode, ...shapeData] = shapeContentNode.children!
-
-    if (
-      shapeTypeNode.type === "Atom" &&
-      typeof shapeTypeNode.value === "string"
-    ) {
-      const shapeType = shapeTypeNode.value
-
-      switch (shapeType) {
-        case "polygon":
-          return processPolygonShape(shapeContentNode.children!)
-        case "circle":
-          return processCircleShape(shapeContentNode.children!)
-        case "rect":
-          return processRectShape(shapeContentNode.children!)
-        case "path":
-          return processPathShape(shapeContentNode.children!)
-      }
-    }
+    return processShapeContent(shapeContentNode.children!)
   }
 
   console.error("Shape processing error for nodes:", nodes)
+  throw new Error(`Unknown shape type for nodes: ${JSON.stringify(nodes)}`)
+}
+
+function processShapeContent(nodes: ASTNode[]): Shape {
+  const [shapeTypeNode] = nodes
+
+  if (
+    shapeTypeNode.type === "Atom" &&
+    typeof shapeTypeNode.value === "string"
+  ) {
+    switch (shapeTypeNode.value) {
+      case "polygon":
+        return processPolygonShape(nodes)
+      case "circle":
+        return processCircleShape(nodes)
+      case "rect":
+        return processRectShape(nodes)
+      case "path":
+        return processPathShape(nodes)
+    }
+  }
+
   throw new Error(`Unknown shape type for nodes: ${JSON.stringify(nodes)}`)
 }
 

--- a/lib/dsn-pcb/types.ts
+++ b/lib/dsn-pcb/types.ts
@@ -30,6 +30,7 @@ export interface DsnPcb {
         coordinates: number[]
       }
     }
+    planes?: Plane[]
     via: string
     rule: {
       clearances: Array<{
@@ -110,6 +111,7 @@ export interface Resolution {
 export interface Structure {
   layers: Layer[]
   boundary: Boundary
+  planes?: Plane[]
   via: string
   rule: Rule
 }
@@ -137,6 +139,11 @@ export interface Boundary {
     width: number
     coordinates: number[]
   }
+}
+
+export interface Plane {
+  net: string
+  shape: Shape
 }
 
 export interface Path {

--- a/tests/dsn-pcb/structure-plane.test.ts
+++ b/tests/dsn-pcb/structure-plane.test.ts
@@ -1,0 +1,59 @@
+import { expect, test } from "bun:test"
+import { type DsnPcb, parseDsnToDsnJson, stringifyDsnJson } from "lib"
+
+const dsnWithPlane = `(pcb "plane-test.dsn"
+  (parser
+    (string_quote ")
+    (space_in_quoted_tokens on)
+    (host_cad "KiCad's Pcbnew")
+    (host_version "(5.1.9)-1")
+  )
+  (resolution um 10)
+  (unit um)
+  (structure
+    (layer Top
+      (type signal)
+      (property
+        (index 0)
+      )
+    )
+    (layer Route2
+      (type power)
+      (property
+        (index 1)
+      )
+    )
+    (boundary
+      (path pcb 0  0 0  10000 0  10000 10000  0 10000  0 0)
+    )
+    (plane AGND (polygon Route2 0  0 0  10000 0  10000 10000  0 10000  0 0))
+    (via "Via[0-1]_800:400_um")
+    (rule
+      (width 250)
+      (clearance 200.1)
+    )
+  )
+  (placement)
+  (library)
+  (network)
+  (wiring)
+)`
+
+test("preserves structure plane polygons", () => {
+  const dsnJson = parseDsnToDsnJson(dsnWithPlane) as DsnPcb
+
+  expect(dsnJson.structure.planes).toEqual([
+    {
+      net: "AGND",
+      shape: {
+        shapeType: "polygon",
+        layer: "Route2",
+        width: 0,
+        coordinates: [0, 0, 10000, 0, 10000, 10000, 0, 10000, 0, 0],
+      },
+    },
+  ])
+
+  const reparsedJson = parseDsnToDsnJson(stringifyDsnJson(dsnJson)) as DsnPcb
+  expect(reparsedJson.structure.planes).toEqual(dsnJson.structure.planes)
+})


### PR DESCRIPTION
/claim #54

## Summary
- Parse board-level DSN structure planes into `dsnJson.structure.planes` instead of dropping them.
- Stringify preserved planes back into the structure section.
- Add a regression test that round-trips a Route2 AGND polygon plane like the Smoothie Board DSN uses.

## Why
The Smoothie Board fixture includes a structure-level `(plane AGND (polygon Route2 ...))` entry. Current parsing ignores that node, so the copper plane disappears before any downstream DSN round-trip or conversion step can preserve it.

## Validation
- `bun test`
- `bun run build`

AI-assisted with Codex; reviewed locally.
