### PR TITLE
Preserve DSN polyline wire stringification

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
@@ -138,7 +138,15 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
     if (wire.type === "via") {
       result += `${indent}${indent}(via ${stringifyPath(wire.path, 3)}(net ${stringifyValue(wire.net)}))\n`
     } else {
-      result += `${indent}${indent}(wire ${stringifyPath(wire.path, 3)}(net ${stringifyValue(wire.net)})(type ${wire.type}))\n`
+      const wirePath = wire.path
+        ? stringifyPath(wire.path, 3)
+        : wire.polyline_path
+          ? `${indent.repeat(3)}(polyline_path ${wire.polyline_path.layer} ${wire.polyline_path.width}  ${stringifyCoordinates(wire.polyline_path.coordinates)})`
+          : null
+      if (!wirePath) {
+        throw new Error("Expected wire to contain path or polyline_path")
+      }
+      result += `${indent}${indent}(wire ${wirePath}(net ${stringifyValue(wire.net)})(type ${wire.type}))\n`
     }
   })
   result += `${indent})\n`

--- a/lib/dsn-pcb/types.ts
+++ b/lib/dsn-pcb/types.ts
@@ -68,18 +68,7 @@ export interface DsnPcb {
     }>
   }
   wiring: {
-    wires: Array<{
-      path: {
-        layer: string
-        width: number
-        /**
-         * TODO UNIT?
-         */
-        coordinates: number[]
-      }
-      net: string
-      type: string
-    }>
+    wires: Wire[]
   }
 }
 

--- a/tests/dsn-pcb/stringify-dsn-json.test.ts
+++ b/tests/dsn-pcb/stringify-dsn-json.test.ts
@@ -17,3 +17,56 @@ test("stringify dsn json", () => {
   // Test that we can parse the generated string back to the same structure
   // expect(reparsedJson).toEqual(dsnJson)
 })
+
+test("preserves wiring polyline_path records when stringifying", () => {
+  const dsn = `(pcb "./polyline-wire.dsn"
+  (parser
+    (string_quote ")
+    (space_in_quoted_tokens on)
+    (host_cad "KiCad's Pcbnew")
+    (host_version "8.0")
+  )
+  (resolution um 10)
+  (unit um)
+  (structure
+    (layer F.Cu
+      (type signal)
+      (property
+        (index 0)
+      )
+    )
+    (via "")
+    (rule
+      (width 150)
+    )
+  )
+  (placement)
+  (library)
+  (network
+    (net N1
+      (pins)
+    )
+  )
+  (wiring
+    (wire
+      (polyline_path F.Cu 200 0 0 1000 0 1000 1000)
+      (net N1)
+      (type protect)
+    )
+  )
+)`
+
+  const dsnJson = parseDsnToDsnJson(dsn) as DsnPcb
+  const dsnString = stringifyDsnJson(dsnJson)
+  const reparsedJson = parseDsnToDsnJson(dsnString) as DsnPcb
+  const [wire] = reparsedJson.wiring.wires
+
+  expect(dsnString).toContain("(polyline_path F.Cu 200  0 0 1000 0 1000 1000)")
+  expect(wire.polyline_path).toEqual({
+    layer: "F.Cu",
+    width: 200,
+    coordinates: [0, 0, 1000, 0, 1000, 1000],
+  })
+  expect(wire.net).toBe("N1")
+  expect(wire.type).toBe("protect")
+})


### PR DESCRIPTION
﻿/claim #54

## Summary
- stringify parsed DSN PCB `polyline_path` wires instead of assuming every non-via wire has a `path`
- align `DsnPcb.wiring.wires` with the parser's existing `Wire` type so path and polyline-path wires are both represented
- add focused parse -> stringify -> parse coverage for a Freerouting-style polyline wire

## Why this helps #54
`processWire` already parses `(polyline_path ...)` records into `wire.polyline_path`, but `stringifyDsnJson` crashed when it tried to stringify `wire.path`. This preserves a valid DSN wiring form through the JSON round trip and avoids losing routed polyline wires.

## Verification
- `npx --yes bun test tests\\dsn-pcb\\stringify-dsn-json.test.ts --test-name-pattern "preserves wiring polyline_path"`
- `.\\node_modules\\.bin\\tsc.exe --noEmit`
- `npx biome check lib\\dsn-pcb\\types.ts lib\\dsn-pcb\\circuit-json-to-dsn-json\\stringify-dsn-json.ts tests\\dsn-pcb\\stringify-dsn-json.test.ts`
- `npx --yes bun run build`

Note: the full `tests\\dsn-pcb\\stringify-dsn-json.test.ts` file still exposes the pre-existing parser/string-quote failure in the older generic test on this checkout; the new polyline regression passes in isolation.
