### PR TITLE
Preserve DSN net property metadata

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
@@ -113,6 +113,11 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
     if (net.pins.length > 0) {
       result += `${indent}${indent}${indent}(pins ${net.pins.join(" ")})\n`
     }
+    if (net.property?.index !== undefined) {
+      result += `${indent}${indent}${indent}(property\n`
+      result += `${indent}${indent}${indent}${indent}(index ${net.property.index})\n`
+      result += `${indent}${indent}${indent})\n`
+    }
     result += `${indent}${indent})\n`
   })
   dsnJson.network.classes.forEach((cls) => {

--- a/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
@@ -837,6 +837,12 @@ function processNet(nodes: ASTNode[]): Net {
           throw new Error("Invalid pin in net")
         }
       })
+    } else if (
+      node.type === "List" &&
+      node.children![0].type === "Atom" &&
+      node.children![0].value === "property"
+    ) {
+      net.property = processProperty(node.children!.slice(1))
     }
   })
   return net as Net

--- a/lib/dsn-pcb/types.ts
+++ b/lib/dsn-pcb/types.ts
@@ -50,6 +50,9 @@ export interface DsnPcb {
     nets: Array<{
       name: string
       pins: string[]
+      property?: {
+        index?: number
+      }
     }>
     classes: Array<{
       name: string
@@ -250,6 +253,9 @@ export interface Network {
 export interface Net {
   name: string
   pins: string[]
+  property?: {
+    index?: number
+  }
 }
 
 export interface Class {

--- a/tests/dsn-pcb/stringify-dsn-json.test.ts
+++ b/tests/dsn-pcb/stringify-dsn-json.test.ts
@@ -17,3 +17,48 @@ test("stringify dsn json", () => {
   // Test that we can parse the generated string back to the same structure
   // expect(reparsedJson).toEqual(dsnJson)
 })
+
+test("preserves net property metadata when stringifying", () => {
+  const dsn = `(pcb net-property.dsn
+  (parser
+    (string_quote ")
+    (space_in_quoted_tokens on)
+    (host_cad "KiCad's Pcbnew")
+    (host_version "8.0")
+  )
+  (resolution um 10)
+  (unit um)
+  (structure
+    (layer F.Cu
+      (type signal)
+      (property
+        (index 0)
+      )
+    )
+    (boundary
+      (path F.Cu 0 0 0 1000 0)
+    )
+    (via "")
+    (rule
+      (width 100)
+    )
+  )
+  (placement)
+  (library)
+  (network
+    (net "GND"
+      (pins U1-1)
+      (property
+        (index 42)
+      )
+    )
+  )
+  (wiring)
+)`
+
+  const dsnJson = parseDsnToDsnJson(dsn) as DsnPcb
+  expect(dsnJson.network.nets[0].property).toEqual({ index: 42 })
+
+  const reparsedJson = parseDsnToDsnJson(stringifyDsnJson(dsnJson)) as DsnPcb
+  expect(reparsedJson.network.nets[0].property).toEqual({ index: 42 })
+})


### PR DESCRIPTION
Fixes a focused DSN network round-trip gap from #54.

/claim #54

## Summary
- parse optional `property` metadata on DSN `net` records
- stringify parsed net property indexes back into DSN output
- add focused parse -> stringify -> parse coverage for net property preservation

## Why this helps #54
`parseDsnToDsnJson` already preserves layer-level properties, but net-level `(property (index ...))` metadata was dropped during DSN JSON round trips. This keeps network metadata intact without touching net-number, pin quoting, class, or via-rule behavior covered by other PRs.

## Verification
- `bun test tests/dsn-pcb/stringify-dsn-json.test.ts --test-name-pattern "preserves net property metadata"`
- `bun test tests/dsn-pcb/stringify-dsn-json.test.ts`
- `bunx tsc --noEmit`
- `bunx biome check lib/dsn-pcb/types.ts lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts tests/dsn-pcb/stringify-dsn-json.test.ts`
- `bun run build`
- `git diff --check`