### PR TITLE
fix: stabilize Smoothie Board DSN component conversion

### DIFF
--- a/lib/common/parse-sexpr.ts
+++ b/lib/common/parse-sexpr.ts
@@ -44,7 +44,10 @@ export function tokenizeDsn(input: string): Token[] {
       }
       i++ // Skip the closing quote
       tokens.push({ type: "String", value })
-    } else if (char === "-" || /\d/.test(char)) {
+    } else if (
+      /\d/.test(char) ||
+      (char === "-" && i + 1 < length && /[\d.]/.test(input[i + 1]))
+    ) {
       // Parse number (integer or float)
       let numStr = ""
       if (char === "-") {

--- a/lib/dsn-pcb/dsn-json-to-circuit-json/dsn-component-converters/convert-dsn-pcb-components-to-source-components-and-ports.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/dsn-component-converters/convert-dsn-pcb-components-to-source-components-and-ports.ts
@@ -1,5 +1,11 @@
-import type { AnySourceComponent, PcbPort, SourcePort } from "circuit-json"
+import type {
+  AnySourceComponent,
+  PcbComponent,
+  PcbPort,
+  SourcePort,
+} from "circuit-json"
 import type { DsnPcb, Image, Pin } from "lib/dsn-pcb/types"
+import { getNumericPinNumber } from "lib/utils/normalize-pin-number"
 import { type Matrix, applyToPoint } from "transformation-matrix"
 
 export const convertDsnPcbComponentsToSourceComponentsAndPorts = ({
@@ -8,8 +14,10 @@ export const convertDsnPcbComponentsToSourceComponentsAndPorts = ({
 }: {
   dsnPcb: DsnPcb
   transformDsnUnitToMm: Matrix
-}): Array<AnySourceComponent | SourcePort | PcbPort> => {
-  const result: Array<AnySourceComponent | SourcePort | PcbPort> = []
+}): Array<AnySourceComponent | PcbComponent | SourcePort | PcbPort> => {
+  const result: Array<
+    AnySourceComponent | PcbComponent | SourcePort | PcbPort
+  > = []
 
   // Map to store image definitions for component lookup
   const imageMap = new Map(dsnPcb.library.images.map((img) => [img.name, img]))
@@ -20,6 +28,7 @@ export const convertDsnPcbComponentsToSourceComponentsAndPorts = ({
 
     // Create source component for each place
     component.places.forEach((place) => {
+      const pcbComponentId = `${component.name}_${place.refdes}`
       const sourceComponent: AnySourceComponent = {
         type: "source_component",
         source_component_id: `sc_${component.name}_${place.refdes}`,
@@ -28,7 +37,36 @@ export const convertDsnPcbComponentsToSourceComponentsAndPorts = ({
         // Default to simple_chip if no specific type can be determined
         ftype: "simple_chip",
       }
-      result.push(sourceComponent)
+
+      const center = applyToPoint(transformDsnUnitToMm, {
+        x: place.x || 0,
+        y: place.y || 0,
+      })
+      const pinCenters =
+        image.pins?.map((pin) =>
+          applyToPoint(transformDsnUnitToMm, {
+            x: (place.x || 0) + pin.x,
+            y: (place.y || 0) + pin.y,
+          }),
+        ) ?? []
+      const xs = pinCenters.map((point) => point.x)
+      const ys = pinCenters.map((point) => point.y)
+      const width = xs.length > 0 ? Math.max(...xs) - Math.min(...xs) : 0
+      const height = ys.length > 0 ? Math.max(...ys) - Math.min(...ys) : 0
+
+      const pcbComponent: PcbComponent = {
+        type: "pcb_component",
+        pcb_component_id: pcbComponentId,
+        source_component_id: sourceComponent.source_component_id,
+        center,
+        layer: place.side === "back" ? "bottom" : "top",
+        rotation: place.rotation,
+        width: Math.max(width, 0.1),
+        height: Math.max(height, 0.1),
+        obstructs_within_bounds: true,
+      }
+
+      result.push(sourceComponent, pcbComponent)
 
       // Create ports for each pin in the image
       if (image.pins) {
@@ -38,7 +76,7 @@ export const convertDsnPcbComponentsToSourceComponentsAndPorts = ({
             source_port_id: `source_port_${component.name}-Pad${pin.pin_number}_${place.refdes}`,
             source_component_id: sourceComponent.source_component_id,
             name: `${place.refdes}-${pin.pin_number}`,
-            pin_number: Number(pin.pin_number),
+            pin_number: getNumericPinNumber(pin.pin_number),
             port_hints: [],
           }
           // Handle case where place coordinates might be null/undefined
@@ -52,7 +90,7 @@ export const convertDsnPcbComponentsToSourceComponentsAndPorts = ({
             pcb_port_id: `pcb_port_${component.name}-Pad${pin.pin_number}_${place.refdes}`,
             type: "pcb_port",
             source_port_id: port.source_port_id,
-            pcb_component_id: component.name,
+            pcb_component_id: pcbComponentId,
             x: pcb_port_center.x,
             y: pcb_port_center.y,
             layers: [place.side === "back" ? "bottom" : "top"],

--- a/lib/dsn-pcb/dsn-json-to-circuit-json/dsn-component-converters/convert-padstacks-to-smtpads.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/dsn-component-converters/convert-padstacks-to-smtpads.ts
@@ -1,6 +1,7 @@
 import type { AnyCircuitElement, PcbSmtPad } from "circuit-json"
 import Debug from "debug"
 import type { DsnPcb } from "lib/dsn-pcb/types"
+import { getPinIdSuffix } from "lib/utils/normalize-pin-number"
 import { applyToPoint } from "transformation-matrix"
 
 const debug = Debug("dsn-converter:convertPadstacksToSmtpads")
@@ -110,6 +111,8 @@ export function convertPadstacksToSmtPads(
 
         // Calculate position in circuit space using the transformation matrix
         // Convert component position and pin offset to circuit coordinates
+        const pcbComponentId = `${componentId}_${place.refdes}`
+        const pinIdSuffix = getPinIdSuffix(pin.pin_number)
         const { x: circuitX, y: circuitY } = applyToPoint(transform, {
           x: (compX || 0) + pin.x,
           y: (compY || 0) + pin.y,
@@ -126,8 +129,8 @@ export function convertPadstacksToSmtPads(
           })
           pcbPad = {
             type: "pcb_smtpad",
-            pcb_smtpad_id: `pcb_smtpad_${componentId}_${place.refdes}_${Number(pin.pin_number) - 1}`,
-            pcb_component_id: `${componentId}_${place.refdes}`,
+            pcb_smtpad_id: `pcb_smtpad_${componentId}_${place.refdes}_${pinIdSuffix}`,
+            pcb_component_id: pcbComponentId,
             pcb_port_id: `pcb_port_${componentId}-Pad${pin.pin_number}_${place.refdes}`,
             shape: "rect",
             x: circuitX,
@@ -140,8 +143,8 @@ export function convertPadstacksToSmtPads(
         } else {
           pcbPad = {
             type: "pcb_smtpad",
-            pcb_smtpad_id: `pcb_smtpad_${componentId}_${place.refdes}_${Number(pin.pin_number) - 1}`,
-            pcb_component_id: `${componentId}_${place.refdes}`,
+            pcb_smtpad_id: `pcb_smtpad_${componentId}_${place.refdes}_${pinIdSuffix}`,
+            pcb_component_id: pcbComponentId,
             pcb_port_id: `pcb_port_${componentId}-Pad${pin.pin_number}_${place.refdes}`,
             shape: "circle",
             x: circuitX,

--- a/lib/utils/normalize-pin-number.ts
+++ b/lib/utils/normalize-pin-number.ts
@@ -1,0 +1,17 @@
+export const getNumericPinNumber = (
+  pinNumber: string | number,
+): number | undefined => {
+  if (typeof pinNumber === "number") {
+    return Number.isNaN(pinNumber) ? undefined : pinNumber
+  }
+
+  const parsed = Number.parseInt(pinNumber, 10)
+  return Number.isNaN(parsed) ? undefined : parsed
+}
+
+export const getPinIdSuffix = (pinNumber: string | number): string => {
+  const numericPinNumber = getNumericPinNumber(pinNumber)
+  return numericPinNumber === undefined
+    ? String(pinNumber)
+    : String(numericPinNumber - 1)
+}

--- a/tests/repros/repro7-smoothie-board.test.ts
+++ b/tests/repros/repro7-smoothie-board.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "bun:test"
+import { su } from "@tscircuit/soup-util"
 import { convertCircuitJsonToPcbSvg } from "circuit-to-svg"
 import { type DsnPcb, convertDsnPcbToCircuitJson, parseDsnToDsnJson } from "lib"
 
@@ -15,4 +16,37 @@ test("smoothieboard repro", async () => {
   expect(convertCircuitJsonToPcbSvg(circuitJson)).toMatchSvgSnapshot(
     import.meta.path,
   )
+})
+
+test("smoothieboard conversion emits pcb components and stable nonnumeric pin ids", () => {
+  const dsnJson = parseDsnToDsnJson(dsnFileWithFreeroutingTrace) as DsnPcb
+
+  const circuitJson = convertDsnPcbToCircuitJson(dsnJson)
+  const soup = su(circuitJson as any)
+
+  const expectedPlacementCount = dsnJson.placement.components.reduce(
+    (sum, component) => sum + component.places.length,
+    0,
+  )
+  const pcbComponentIds = new Set(
+    soup.pcb_component.list().map((component) => component.pcb_component_id),
+  )
+
+  expect(soup.pcb_component.list()).toHaveLength(expectedPlacementCount)
+  expect(
+    soup.source_port.list().filter((port) => Number.isNaN(port.pin_number)),
+  ).toHaveLength(0)
+  expect(
+    soup.pcb_smtpad.list().filter((pad) => pad.pcb_smtpad_id.includes("NaN")),
+  ).toHaveLength(0)
+
+  for (const pad of soup.pcb_smtpad.list()) {
+    if (!pad.pcb_component_id) throw new Error("Expected pad pcb_component_id")
+    expect(pcbComponentIds.has(pad.pcb_component_id)).toBe(true)
+  }
+  for (const port of soup.pcb_port.list()) {
+    if (!port.pcb_component_id)
+      throw new Error("Expected port pcb_component_id")
+    expect(pcbComponentIds.has(port.pcb_component_id)).toBe(true)
+  }
 })


### PR DESCRIPTION
## Summary
- parse symbolic `+`/`-` DSN pin names without turning `-` into `NaN`
- emit `pcb_component` elements for DSN placements and connect generated pads/ports to them
- keep nonnumeric pin names out of numeric `pin_number` while preserving stable pad ids and port hints
- add Smoothie Board coverage for pcb components, non-NaN pins, and pad/port component links

## Verification
- npx bun test tests/repros/repro7-smoothie-board.test.ts
- npx bun test
- npx tsc --noEmit
- npx bun run build

/claim #54