### PR TITLE
Parse leading-plus DSN numeric literals

### DIFF
--- a/lib/common/parse-sexpr.ts
+++ b/lib/common/parse-sexpr.ts
@@ -44,6 +44,17 @@ export function tokenizeDsn(input: string): Token[] {
       }
       i++ // Skip the closing quote
       tokens.push({ type: "String", value })
+    } else if (char === "+") {
+      let sym = ""
+      while (i < length && !/\s|\(|\)/.test(input[i])) {
+        sym += input[i]
+        i++
+      }
+      if (/^\+(?:\d+(?:\.\d*)?|\.\d+)$/.test(sym)) {
+        tokens.push({ type: "Number", value: parseFloat(sym) })
+      } else {
+        tokens.push({ type: "Symbol", value: sym })
+      }
     } else if (char === "-" || /\d/.test(char)) {
       // Parse number (integer or float)
       let numStr = ""

--- a/tests/dsn-pcb/dsn-leading-plus-numbers.test.ts
+++ b/tests/dsn-pcb/dsn-leading-plus-numbers.test.ts
@@ -1,0 +1,56 @@
+import { expect, test } from "bun:test"
+import { type DsnPcb, parseDsnToDsnJson } from "lib"
+
+test("parses delimiter-bounded leading-plus numeric coordinates", () => {
+  const dsnJson = parseDsnToDsnJson(`
+    (pcb plus-number.dsn
+      (resolution um 10)
+      (unit um)
+      (structure
+        (layer F.Cu (type signal) (property (index 0)))
+        (boundary (path pcb 0 +100 +200 +300 +400))
+        (via Via)
+        (rule (width 100) (clearance 100))
+      )
+      (placement)
+      (library)
+      (network
+        (net +5V (pins U1-1))
+      )
+      (wiring
+        (wire (path F.Cu 100 +1.5 -2.5 +3 +4) (net +5V) (type route))
+      )
+    )
+  `) as DsnPcb
+
+  expect(dsnJson.structure.boundary.path.coordinates).toEqual([
+    100, 200, 300, 400,
+  ])
+  expect(dsnJson.wiring.wires[0].path?.coordinates).toEqual([1.5, -2.5, 3, 4])
+})
+
+test("keeps nonnumeric plus-prefixed symbols intact", () => {
+  const dsnJson = parseDsnToDsnJson(`
+    (pcb plus-symbol.dsn
+      (resolution um 10)
+      (unit um)
+      (structure
+        (layer F.Cu (type signal) (property (index 0)))
+        (boundary (path pcb 0 0 0 100 100))
+        (via Via)
+        (rule (width 100) (clearance 100))
+      )
+      (placement)
+      (library)
+      (network
+        (net +5V (pins U1-1))
+      )
+      (wiring
+        (wire (path F.Cu 100 0 0 100 100) (net +5V) (type route))
+      )
+    )
+  `) as DsnPcb
+
+  expect(dsnJson.network.nets[0].name).toBe("+5V")
+  expect(dsnJson.wiring.wires[0].net).toBe("+5V")
+})


### PR DESCRIPTION
## Summary
- parse delimiter-bounded leading-plus DSN numeric tokens such as `+100` and `+1.5` as numbers
- keep nonnumeric plus-prefixed symbols such as `+5V` intact
- add focused parser coverage for boundary/wire coordinates and plus-prefixed net names

/claim #54

## Verification
- `npx --yes bun@latest test tests/dsn-pcb/dsn-leading-plus-numbers.test.ts`
- `npx --yes bun@latest test tests/dsn-pcb`
- `npx --yes bun@latest x biome check lib/common/parse-sexpr.ts tests/dsn-pcb/dsn-leading-plus-numbers.test.ts`
- `npx --yes bun@latest x tsc --noEmit`
- `npx --yes bun@latest run build`
- `git diff --check`

Transparency: AI-assisted with Codex; I reviewed the diff and local verification before submission.