### PR TITLE
Preserve quoted numeric DSN pin labels

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
@@ -20,6 +20,18 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
     return coordinates.join(" ")
   }
 
+  const stringifyPinIdentifier = (value: string | number): string => {
+    if (typeof value === "number") {
+      return value.toString()
+    }
+    return /^(?!0$)0\d+$/.test(value) ||
+      /^[+-]\d+$/.test(value) ||
+      /^\d*\.\d+(?:[eE][+-]?\d+)?$/.test(value) ||
+      /^\d+[eE][+-]?\d+$/.test(value)
+      ? stringifyValue(value)
+      : value
+  }
+
   // Helper function to stringify a path
   const stringifyPath = (path: any, level: number): string => {
     const padding = indent.repeat(level)
@@ -86,7 +98,7 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
       result += `${indent}${indent}${indent}(outline ${stringifyPath(outline.path, 4)})\n`
     })
     image.pins.forEach((pin) => {
-      result += `${indent}${indent}${indent}(pin ${pin.padstack_name} ${pin.pin_number} ${pin.x} ${pin.y})\n`
+      result += `${indent}${indent}${indent}(pin ${pin.padstack_name} ${stringifyPinIdentifier(pin.pin_number)} ${pin.x} ${pin.y})\n`
     })
     result += `${indent}${indent})\n`
   })

--- a/lib/utils/get-pin-number.ts
+++ b/lib/utils/get-pin-number.ts
@@ -3,13 +3,17 @@ import type { ASTNode } from "../common/parse-sexpr"
 
 const debug = Debug("dsn-converter:getPinNum")
 
+const isCanonicalIntegerString = (value: string) =>
+  /^(?:0|[1-9]\d*)$/.test(value)
+
 /**
- * Process pin identifier from AST nodes and convert to appropriate type
- * Handles both extraction from nodes and type conversion in one step
+ * Process pin identifier from AST nodes and preserve string identifiers.
+ * Bare numeric DSN pins are already tokenized as numbers; string values came
+ * from quoted identifiers or symbols and should not be coerced.
  */
 export function getPinNum(nodes: ASTNode[]): number | string | null {
   // Extract pin number from AST nodes
-  let pinNumber
+  let pinNumber: string | number | undefined
 
   if (nodes[2]?.type === "List" && nodes[2].children) {
     // Pin number is in a List structure
@@ -22,11 +26,9 @@ export function getPinNum(nodes: ASTNode[]): number | string | null {
     return null
   }
 
-  // Now process the extracted/direct value
   if (typeof pinNumber === "number") {
     return pinNumber
   }
-  // Try parsing as number first
-  const parsed = parseInt(String(pinNumber), 10)
-  return Number.isNaN(parsed) ? String(pinNumber) : parsed
+  const pinString = String(pinNumber)
+  return isCanonicalIntegerString(pinString) ? Number(pinString) : pinString
 }

--- a/tests/dsn-pcb/quoted-numeric-pin-labels.test.ts
+++ b/tests/dsn-pcb/quoted-numeric-pin-labels.test.ts
@@ -1,0 +1,70 @@
+import { expect, test } from "bun:test"
+import { type DsnPcb, parseDsnToDsnJson, stringifyDsnJson } from "lib"
+
+const dsnWithQuotedNumericPin = `(pcb "quoted-pin.dsn"
+  (parser
+    (string_quote ")
+    (space_in_quoted_tokens on)
+    (host_cad "KiCad's Pcbnew")
+    (host_version "9.0")
+  )
+  (resolution um 10)
+  (unit um)
+  (structure
+    (layer F.Cu
+      (type signal)
+      (property
+        (index 0)
+      )
+    )
+    (boundary
+      (path F.Cu 0 0 0 1000 0 1000 1000 0 1000)
+    )
+    (via "Via[0-1]_600:300_um")
+    (rule
+      (width 100)
+      (clearance 100)
+    )
+  )
+  (placement
+    (component U
+      (place U1 0 0 front 0)
+    )
+  )
+  (library
+    (image U
+      (pin Rect[T]Pad_1000x1000_um "01" 0 0)
+    )
+    (padstack Rect[T]Pad_1000x1000_um
+      (shape (rect F.Cu -500 -500 500 500))
+      (attach off)
+    )
+  )
+  (network
+    (net N1
+      (pins U1-"01")
+    )
+    (class default default N1
+      (circuit
+        (use_via "Via[0-1]_600:300_um")
+      )
+      (rule
+        (width 100)
+        (clearance 100)
+      )
+    )
+  )
+  (wiring)
+)`
+
+test("preserves quoted numeric image pin labels", () => {
+  const parsed = parseDsnToDsnJson(dsnWithQuotedNumericPin) as DsnPcb
+
+  expect(parsed.library.images[0].pins[0].pin_number).toBe("01")
+
+  const stringified = stringifyDsnJson(parsed)
+  expect(stringified).toContain('(pin Rect[T]Pad_1000x1000_um "01" 0 0)')
+
+  const reparsed = parseDsnToDsnJson(stringified) as DsnPcb
+  expect(reparsed.library.images[0].pins[0].pin_number).toBe("01")
+})


### PR DESCRIPTION
## Summary
- keep canonical numeric pins as numbers, while preserving quoted numeric-like pin labels such as \"01\" as strings
- quote non-canonical numeric-looking string pin identifiers when stringifying DSN JSON so parse -> stringify -> parse does not collapse them
- add focused regression coverage for quoted numeric image pin labels

## Bounty
/claim #54

## Verification
- `bun test tests/dsn-pcb/quoted-numeric-pin-labels.test.ts tests/dsn-pcb/stringify-dsn-json.test.ts tests/repros/repro2-motor-driver.test.ts tests/repros/repro-4-arduino-nano.test.ts`
- `bunx biome check lib/utils/get-pin-number.ts lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts tests/dsn-pcb/quoted-numeric-pin-labels.test.ts`
- `bunx tsc --noEmit`
- `bun test`
- `bun run build`
- `git diff --check`

Transparency note: AI-assisted with Codex; I reviewed the diff and full verification locally before submission.