### PR TITLE
Parse numeric DSN net pin atoms

### DIFF
--- a/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
@@ -831,11 +831,14 @@ function processNet(nodes: ASTNode[]): Net {
       node.children![0].value === "pins"
     ) {
       net.pins = node.children!.slice(1).map((pinNode) => {
-        if (pinNode.type === "Atom" && typeof pinNode.value === "string") {
-          return pinNode.value
-        } else {
-          throw new Error("Invalid pin in net")
+        if (
+          pinNode.type === "Atom" &&
+          (typeof pinNode.value === "string" ||
+            typeof pinNode.value === "number")
+        ) {
+          return String(pinNode.value)
         }
+        throw new Error("Invalid pin in net")
       })
     }
   })

--- a/tests/dsn-pcb/stringify-dsn-json.test.ts
+++ b/tests/dsn-pcb/stringify-dsn-json.test.ts
@@ -17,3 +17,41 @@ test("stringify dsn json", () => {
   // Test that we can parse the generated string back to the same structure
   // expect(reparsedJson).toEqual(dsnJson)
 })
+
+test("parses numeric atoms in network pin lists as pin references", () => {
+  const dsnJson = parseDsnToDsnJson(`(pcb numeric-net-pins
+  (parser
+    (string_quote ")
+    (space_in_quoted_tokens on)
+    (host_cad "fixture")
+    (host_version "1")
+  )
+  (resolution um 10)
+  (unit um)
+  (structure
+    (layer F.Cu
+      (type signal)
+      (property
+        (index 0)
+      )
+    )
+    (via "")
+    (rule
+      (width 100)
+    )
+  )
+  (placement)
+  (library)
+  (network
+    (net "N1"
+      (pins 1 U1-2 3)
+    )
+  )
+  (wiring)
+)`) as DsnPcb
+
+  expect(dsnJson.network.nets[0].pins).toEqual(["1", "U1-2", "3"])
+
+  const reparsedJson = parseDsnToDsnJson(stringifyDsnJson(dsnJson)) as DsnPcb
+  expect(reparsedJson.network.nets[0].pins).toEqual(["1", "U1-2", "3"])
+})


### PR DESCRIPTION
## Summary
- accept numeric atom values inside DSN network `(pins ...)` lists and preserve them as string pin references
- keep invalid/list pin entries rejected
- add focused parse -> stringify -> parse regression coverage for mixed numeric/string pin references

## Bounty
/claim #54

## Verification
- `bun test tests/dsn-pcb/stringify-dsn-json.test.ts`
- `bunx biome check lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts tests/dsn-pcb/stringify-dsn-json.test.ts`
- `bunx tsc --noEmit`
- `bun test`
- `bun run build`
- `git diff --check`

Transparency note: AI-assisted with Codex; I reviewed the diff and full verification locally before submission.