### PR TITLE
Skip semicolon comments in DSN tokenizer

### DIFF
--- a/lib/common/parse-sexpr.ts
+++ b/lib/common/parse-sexpr.ts
@@ -22,6 +22,10 @@ export function tokenizeDsn(input: string): Token[] {
     } else if (char === ")") {
       tokens.push({ type: "RParen" })
       i++
+    } else if (char === ";") {
+      while (i < length && input[i] !== "\n") {
+        i++
+      }
     } else if (/\s/.test(char)) {
       // Ignore whitespace
       i++

--- a/tests/dsn-pcb/parse-dsn-json-to-circuit-json.test.ts
+++ b/tests/dsn-pcb/parse-dsn-json-to-circuit-json.test.ts
@@ -15,6 +15,46 @@ test("parse s-expr to json", async () => {
   expect(pcbJson).toBeTruthy()
 })
 
+test("parse s-expr with semicolon comments", () => {
+  const dsn = `(pcb commented.dsn
+    ; exporter metadata can appear between top-level records
+    (parser
+      (string_quote ")
+      (space_in_quoted_tokens on)
+      (host_cad "KiCad")
+      (host_version "8.0")
+    )
+    (resolution um 10) ; inline comment after a record
+    (unit um)
+    (structure
+      (layer F.Cu
+        (type signal)
+        (property
+          (index 0)
+        )
+      )
+      ; comment inside a nested form
+      (boundary
+        (path pcb 0 0 0 1000 0 1000 1000 0 1000 0 0)
+      )
+      (via "Via[0-1]_600:300_um")
+      (rule
+        (width 100)
+      )
+    )
+    (placement)
+    (library)
+    (network)
+    (wiring)
+  )`
+
+  const pcbJson = parseDsnToDsnJson(dsn) as DsnPcb
+
+  expect(pcbJson.filename).toBe("commented.dsn")
+  expect(pcbJson.structure.layers[0].name).toBe("F.Cu")
+  expect(pcbJson.structure.boundary.path.coordinates).toHaveLength(10)
+})
+
 test("parse json to circuit json", async () => {
   const pcb = parseDsnToDsnJson(testDsnFile) as DsnPcb
   const circuitJson = convertDsnJsonToCircuitJson(pcb)


### PR DESCRIPTION
## Summary
- skip semicolon line comments in the shared DSN S-expression tokenizer
- add parser coverage for comments between top-level records, inline after records, and inside nested forms

## Verification
- npx --yes bun test tests/dsn-pcb/parse-dsn-json-to-circuit-json.test.ts
- npx --yes biome check lib/common/parse-sexpr.ts tests/dsn-pcb/parse-dsn-json-to-circuit-json.test.ts

@algora-pbc /claim #54