### PR TITLE
Parse placements without side tokens

### DIFF
--- a/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
@@ -457,24 +457,33 @@ function processPlace(nodes: ASTNode[]): Places {
     throw new Error("Invalid place format: invalid refdes")
   }
 
-  // Process coordinates and rotation
+  // Process coordinates and optional side/rotation
   const coordIndex = 2
-  if (coordIndex + 3 < nodes.length) {
-    if (
-      nodes[coordIndex].type === "Atom" &&
-      typeof nodes[coordIndex].value === "number" &&
-      nodes[coordIndex + 1].type === "Atom" &&
-      typeof nodes[coordIndex + 1].value === "number" &&
-      nodes[coordIndex + 2].type === "Atom" &&
-      typeof nodes[coordIndex + 2].value === "string" &&
-      nodes[coordIndex + 3].type === "Atom" &&
-      typeof nodes[coordIndex + 3].value === "number"
-    ) {
-      places.x = nodes[coordIndex].value as number
-      places.y = nodes[coordIndex + 1].value as number
-      places.side = nodes[coordIndex + 2].value as string
-      places.rotation = nodes[coordIndex + 3].value as number
-    }
+  if (
+    coordIndex + 1 < nodes.length &&
+    nodes[coordIndex].type === "Atom" &&
+    typeof nodes[coordIndex].value === "number" &&
+    nodes[coordIndex + 1].type === "Atom" &&
+    typeof nodes[coordIndex + 1].value === "number"
+  ) {
+    places.x = nodes[coordIndex].value as number
+    places.y = nodes[coordIndex + 1].value as number
+  }
+
+  if (
+    coordIndex + 2 < nodes.length &&
+    nodes[coordIndex + 2].type === "Atom" &&
+    typeof nodes[coordIndex + 2].value === "string"
+  ) {
+    places.side = nodes[coordIndex + 2].value as string
+  }
+
+  if (
+    coordIndex + 3 < nodes.length &&
+    nodes[coordIndex + 3].type === "Atom" &&
+    typeof nodes[coordIndex + 3].value === "number"
+  ) {
+    places.rotation = nodes[coordIndex + 3].value as number
   }
 
   // Process optional PN (part number) if present

--- a/tests/dsn-pcb/parse-dsn-json-to-circuit-json.test.ts
+++ b/tests/dsn-pcb/parse-dsn-json-to-circuit-json.test.ts
@@ -15,6 +15,50 @@ test("parse s-expr to json", async () => {
   expect(pcbJson).toBeTruthy()
 })
 
+test("parse placement with coordinates but no side or rotation", () => {
+  const dsn = `(pcb minimal-place.dsn
+    (parser
+      (string_quote ")
+      (space_in_quoted_tokens on)
+      (host_cad "KiCad")
+      (host_version "8.0")
+    )
+    (resolution um 10)
+    (unit um)
+    (structure
+      (layer F.Cu
+        (type signal)
+        (property
+          (index 0)
+        )
+      )
+      (boundary
+        (path pcb 0 0 0 1000 0 1000 1000 0 1000 0 0)
+      )
+      (via "Via[0-1]_600:300_um")
+      (rule
+        (width 100)
+      )
+    )
+    (placement
+      (component U_LIB
+        (place U1 125 250)
+      )
+    )
+    (library)
+    (network)
+    (wiring)
+  )`
+
+  const pcbJson = parseDsnToDsnJson(dsn) as DsnPcb
+  const place = pcbJson.placement.components[0].places[0]
+
+  expect(place.x).toBe(125)
+  expect(place.y).toBe(250)
+  expect(place.side).toBe("front")
+  expect(place.rotation).toBe(0)
+})
+
 test("parse json to circuit json", async () => {
   const pcb = parseDsnToDsnJson(testDsnFile) as DsnPcb
   const circuitJson = convertDsnJsonToCircuitJson(pcb)


### PR DESCRIPTION
## Summary
- parse placement x/y coordinates independently from optional side and rotation tokens
- keep the existing defaults of `side: "front"` and `rotation: 0` when those fields are omitted
- add focused parser coverage for `(place U1 x y)` records

## Verification
- `npx --yes bun test tests/dsn-pcb/parse-dsn-json-to-circuit-json.test.ts`
- `npx --yes biome check lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts tests/dsn-pcb/parse-dsn-json-to-circuit-json.test.ts`

@algora-pbc /claim #54