### PR TITLE
Parse placement PN without rotation

### DIFF
--- a/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
@@ -457,28 +457,37 @@ function processPlace(nodes: ASTNode[]): Places {
     throw new Error("Invalid place format: invalid refdes")
   }
 
-  // Process coordinates and rotation
+  // Process coordinates and optional side/rotation
   const coordIndex = 2
-  if (coordIndex + 3 < nodes.length) {
-    if (
-      nodes[coordIndex].type === "Atom" &&
-      typeof nodes[coordIndex].value === "number" &&
-      nodes[coordIndex + 1].type === "Atom" &&
-      typeof nodes[coordIndex + 1].value === "number" &&
-      nodes[coordIndex + 2].type === "Atom" &&
-      typeof nodes[coordIndex + 2].value === "string" &&
-      nodes[coordIndex + 3].type === "Atom" &&
-      typeof nodes[coordIndex + 3].value === "number"
-    ) {
-      places.x = nodes[coordIndex].value as number
-      places.y = nodes[coordIndex + 1].value as number
-      places.side = nodes[coordIndex + 2].value as string
-      places.rotation = nodes[coordIndex + 3].value as number
-    }
+  if (
+    coordIndex + 1 < nodes.length &&
+    nodes[coordIndex].type === "Atom" &&
+    typeof nodes[coordIndex].value === "number" &&
+    nodes[coordIndex + 1].type === "Atom" &&
+    typeof nodes[coordIndex + 1].value === "number"
+  ) {
+    places.x = nodes[coordIndex].value as number
+    places.y = nodes[coordIndex + 1].value as number
+  }
+
+  if (
+    coordIndex + 2 < nodes.length &&
+    nodes[coordIndex + 2].type === "Atom" &&
+    typeof nodes[coordIndex + 2].value === "string"
+  ) {
+    places.side = nodes[coordIndex + 2].value as string
+  }
+
+  if (
+    coordIndex + 3 < nodes.length &&
+    nodes[coordIndex + 3].type === "Atom" &&
+    typeof nodes[coordIndex + 3].value === "number"
+  ) {
+    places.rotation = nodes[coordIndex + 3].value as number
   }
 
   // Process optional PN (part number) if present
-  for (let i = coordIndex + 4; i < nodes.length; i++) {
+  for (let i = coordIndex + 2; i < nodes.length; i++) {
     const node = nodes[i]
     if (
       node.type === "List" &&

--- a/tests/dsn-pcb/parse-dsn-json-to-circuit-json.test.ts
+++ b/tests/dsn-pcb/parse-dsn-json-to-circuit-json.test.ts
@@ -23,3 +23,39 @@ test("parse json to circuit json", async () => {
     import.meta.path,
   )
 })
+
+test("parse placement PN when rotation is omitted", () => {
+  const dsn = `(pcb placement-pn-without-rotation.dsn
+  (parser
+    (string_quote ")
+    (space_in_quoted_tokens on)
+    (host_cad "KiCad's Pcbnew")
+    (host_version "8.0")
+  )
+  (resolution um 10)
+  (unit um)
+  (structure
+    (layer F.Cu (type signal) (property (index 0)))
+    (boundary (path pcb 0 0 0 100 0 100 100 0 100 0 0))
+    (via "")
+    (rule (width 100) (clearance 100))
+  )
+  (placement
+    (component R0603
+      (place R1 125 250 front (PN "10k"))
+    )
+  )
+  (library)
+  (network)
+  (wiring)
+)`
+
+  const pcbJson = parseDsnToDsnJson(dsn) as DsnPcb
+  const place = pcbJson.placement.components[0].places[0]
+
+  expect(place.x).toBe(125)
+  expect(place.y).toBe(250)
+  expect(place.side).toBe("front")
+  expect(place.rotation).toBe(0)
+  expect(place.PN).toBe("10k")
+})


### PR DESCRIPTION
## Summary

@algora-pbc /claim #54

Preserves DSN placement `PN` metadata when a placement has a side token but omits the optional rotation value, for example `(place R1 125 250 front (PN "10k"))`.

- parses placement `x`/`y` independently from optional side/rotation tokens
- keeps the existing default `rotation: 0` fallback
- scans optional placement metadata lists even when the rotation slot is absent
- adds focused parser coverage for side + PN without explicit rotation

## Verification

- `npx --yes bun test tests/dsn-pcb/parse-dsn-json-to-circuit-json.test.ts`
- `npx --yes biome check lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts tests/dsn-pcb/parse-dsn-json-to-circuit-json.test.ts`
