### PR TITLE
Parse placement rotation without side

### DIFF
--- a/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
@@ -457,24 +457,35 @@ function processPlace(nodes: ASTNode[]): Places {
     throw new Error("Invalid place format: invalid refdes")
   }
 
-  // Process coordinates and rotation
+  // Process coordinates and optional side/rotation
   const coordIndex = 2
-  if (coordIndex + 3 < nodes.length) {
-    if (
-      nodes[coordIndex].type === "Atom" &&
-      typeof nodes[coordIndex].value === "number" &&
-      nodes[coordIndex + 1].type === "Atom" &&
-      typeof nodes[coordIndex + 1].value === "number" &&
-      nodes[coordIndex + 2].type === "Atom" &&
-      typeof nodes[coordIndex + 2].value === "string" &&
-      nodes[coordIndex + 3].type === "Atom" &&
-      typeof nodes[coordIndex + 3].value === "number"
-    ) {
-      places.x = nodes[coordIndex].value as number
-      places.y = nodes[coordIndex + 1].value as number
-      places.side = nodes[coordIndex + 2].value as string
-      places.rotation = nodes[coordIndex + 3].value as number
-    }
+  if (
+    coordIndex + 1 < nodes.length &&
+    nodes[coordIndex].type === "Atom" &&
+    typeof nodes[coordIndex].value === "number" &&
+    nodes[coordIndex + 1].type === "Atom" &&
+    typeof nodes[coordIndex + 1].value === "number"
+  ) {
+    places.x = nodes[coordIndex].value as number
+    places.y = nodes[coordIndex + 1].value as number
+  }
+
+  let optionalIndex = coordIndex + 2
+  if (
+    optionalIndex < nodes.length &&
+    nodes[optionalIndex].type === "Atom" &&
+    typeof nodes[optionalIndex].value === "string"
+  ) {
+    places.side = nodes[optionalIndex].value as string
+    optionalIndex++
+  }
+
+  if (
+    optionalIndex < nodes.length &&
+    nodes[optionalIndex].type === "Atom" &&
+    typeof nodes[optionalIndex].value === "number"
+  ) {
+    places.rotation = nodes[optionalIndex].value as number
   }
 
   // Process optional PN (part number) if present

--- a/tests/dsn-pcb/parse-dsn-json-to-circuit-json.test.ts
+++ b/tests/dsn-pcb/parse-dsn-json-to-circuit-json.test.ts
@@ -23,3 +23,38 @@ test("parse json to circuit json", async () => {
     import.meta.path,
   )
 })
+
+test("parse placement rotation when side is omitted", () => {
+  const dsn = `(pcb placement-rotation-without-side.dsn
+  (parser
+    (string_quote ")
+    (space_in_quoted_tokens on)
+    (host_cad "KiCad's Pcbnew")
+    (host_version "8.0")
+  )
+  (resolution um 10)
+  (unit um)
+  (structure
+    (layer F.Cu (type signal) (property (index 0)))
+    (boundary (path pcb 0 0 0 100 0 100 100 0 100 0 0))
+    (via "")
+    (rule (width 100) (clearance 100))
+  )
+  (placement
+    (component U_SOIC
+      (place U1 125 250 90)
+    )
+  )
+  (library)
+  (network)
+  (wiring)
+)`
+
+  const pcbJson = parseDsnToDsnJson(dsn) as DsnPcb
+  const place = pcbJson.placement.components[0].places[0]
+
+  expect(place.x).toBe(125)
+  expect(place.y).toBe(250)
+  expect(place.side).toBe("front")
+  expect(place.rotation).toBe(90)
+})


### PR DESCRIPTION
## Summary

@algora-pbc /claim #54

Parses DSN placement rotation when the optional side token is omitted, for example `(place U1 125 250 90)`.

- parses placement coordinates independently from optional side/rotation tokens
- consumes `side` only when a string side token is present
- parses rotation from the next numeric atom and keeps the existing default `side: "front"`
- adds focused parser coverage for rotation-without-side

## Verification

- `npx --yes bun test tests/dsn-pcb/parse-dsn-json-to-circuit-json.test.ts`
- `npx --yes biome check lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts tests/dsn-pcb/parse-dsn-json-to-circuit-json.test.ts`
