### PR TITLE
Preserve numeric DSN net and class references

### DIFF
--- a/lib/dsn-pcb/dsn-json-to-circuit-json/dsn-component-converters/convert-nets-to-source-nets-and-traces.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/dsn-component-converters/convert-nets-to-source-nets-and-traces.ts
@@ -10,7 +10,8 @@ export const convertNetsToSourceNetsAndTraces = ({
 
   let source_trace_id = dsnPcb.wiring.wires.length
   for (const net of nets) {
-    const { name, pins = [] } = net
+    const { pins = [] } = net
+    const name = String(net.name)
 
     if (!name || name.startsWith("unconnected-")) continue
 

--- a/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
@@ -817,10 +817,13 @@ export function processNetwork(nodes: ASTNode[]): Network {
 
 function processNet(nodes: ASTNode[]): Net {
   const net: Partial<Net> = {}
-  if (nodes[1].type === "Atom" && typeof nodes[1].value === "string") {
+  if (
+    nodes[1].type === "Atom" &&
+    (typeof nodes[1].value === "string" || typeof nodes[1].value === "number")
+  ) {
     net.name = nodes[1].value
   } else {
-    net.name = nodes[1].value?.toString()
+    net.name = String(nodes[1].value)
     debug("net name was not a string", net.name)
   }
 

--- a/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
@@ -860,10 +860,9 @@ function processClass(nodes: ASTNode[]): Class {
   while (
     i < nodes.length &&
     nodes[i].type === "Atom" &&
-    typeof nodes[i].value === "string" &&
-    nodes[i].value !== undefined
+    (typeof nodes[i].value === "string" || typeof nodes[i].value === "number")
   ) {
-    classObj.net_names.push(nodes[i].value as string)
+    classObj.net_names.push(nodes[i].value as string | number)
     i++
   }
 

--- a/lib/dsn-pcb/types.ts
+++ b/lib/dsn-pcb/types.ts
@@ -48,7 +48,7 @@ export interface DsnPcb {
   }
   network: {
     nets: Array<{
-      name: string
+      name: string | number
       pins: string[]
     }>
     classes: Array<{
@@ -248,7 +248,7 @@ export interface Network {
 }
 
 export interface Net {
-  name: string
+  name: string | number
   pins: string[]
 }
 

--- a/lib/dsn-pcb/types.ts
+++ b/lib/dsn-pcb/types.ts
@@ -54,7 +54,7 @@ export interface DsnPcb {
     classes: Array<{
       name: string
       description: string
-      net_names: string[]
+      net_names: Array<string | number>
       circuit: {
         use_via: string
       }
@@ -255,7 +255,7 @@ export interface Net {
 export interface Class {
   name: string
   description: string
-  net_names: string[]
+  net_names: Array<string | number>
   circuit: Circuit
   rule: Rule
 }

--- a/tests/dsn-pcb/stringify-dsn-json.test.ts
+++ b/tests/dsn-pcb/stringify-dsn-json.test.ts
@@ -17,3 +17,60 @@ test("stringify dsn json", () => {
   // Test that we can parse the generated string back to the same structure
   // expect(reparsedJson).toEqual(dsnJson)
 })
+
+test("preserves numeric class net references", () => {
+  const dsnString = `(pcb numeric-class-net-refs.dsn
+  (parser
+    (string_quote ")
+    (space_in_quoted_tokens on)
+    (host_cad "KiCad's Pcbnew")
+    (host_version "8.0")
+  )
+  (resolution um 10)
+  (unit um)
+  (structure
+    (layer F.Cu
+      (type signal)
+      (property
+        (index 0)
+      )
+    )
+    (boundary
+      (path pcb 0 0 0 1000 0 1000 1000 0 1000 0 0)
+    )
+    (via "Via[0-1]_600:300_um")
+    (rule
+      (width 100)
+      (clearance 100)
+    )
+  )
+  (placement)
+  (library)
+  (network
+    (net 1
+      (pins U1-1)
+    )
+    (net 2
+      (pins U2-1)
+    )
+    (class "kicad_default" "" 1 2
+      (circuit
+        (use_via "Via[0-1]_600:300_um")
+      )
+      (rule
+        (width 100)
+        (clearance 100)
+      )
+    )
+  )
+  (wiring)
+)`
+
+  const dsnJson = parseDsnToDsnJson(dsnString) as DsnPcb
+
+  expect(dsnJson.network.classes[0].net_names).toEqual([1, 2])
+
+  const reparsedJson = parseDsnToDsnJson(stringifyDsnJson(dsnJson)) as DsnPcb
+
+  expect(reparsedJson.network.classes[0].net_names).toEqual([1, 2])
+})

--- a/tests/dsn-pcb/stringify-dsn-json.test.ts
+++ b/tests/dsn-pcb/stringify-dsn-json.test.ts
@@ -68,9 +68,11 @@ test("preserves numeric class net references", () => {
 
   const dsnJson = parseDsnToDsnJson(dsnString) as DsnPcb
 
+  expect(dsnJson.network.nets.map((net) => net.name)).toEqual([1, 2])
   expect(dsnJson.network.classes[0].net_names).toEqual([1, 2])
 
   const reparsedJson = parseDsnToDsnJson(stringifyDsnJson(dsnJson)) as DsnPcb
 
+  expect(reparsedJson.network.nets.map((net) => net.name)).toEqual([1, 2])
   expect(reparsedJson.network.classes[0].net_names).toEqual([1, 2])
 })

--- a/tests/dsn-pcb/subcircuits-having-same-component.test.ts
+++ b/tests/dsn-pcb/subcircuits-having-same-component.test.ts
@@ -10,7 +10,7 @@ test("convert circuit json to dsn pcb", async () => {
   expect(dsnJson.network.nets.length).toBe(6)
 
   const net1Count = dsnJson.network.nets.filter((net) =>
-    net.name.startsWith("NET1"),
+    String(net.name).startsWith("NET1"),
   ).length
   expect(net1Count).toBe(2)
 })


### PR DESCRIPTION
## Summary
- preserve numeric DSN network net names as numeric atoms instead of converting them to quoted strings
- preserve numeric atoms in DSN class net-reference lists instead of dropping them
- keep Circuit JSON conversion using string source-net names while retaining numeric DSN JSON round trips
- add focused parse -> stringify -> parse coverage for numeric net names and class net references

## Why
This is a narrow #54 round-trip gap separate from the active optional net-number, pin, tokenizer, placement, and metadata PRs. If a DSN file uses bare numeric net names and references them from a `(class ...)`, current main converts the net names to quoted strings and drops numeric class references because `processClass` only accepts string atoms.

/claim #54

## Verification
- `npx --yes bun@latest test tests/dsn-pcb/stringify-dsn-json.test.ts tests/dsn-pcb/subcircuits-having-same-component.test.ts`
- `npx --yes bun@latest x tsc --noEmit`
- `npx --yes bun@latest x biome check lib/dsn-pcb/types.ts lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts lib/dsn-pcb/dsn-json-to-circuit-json/dsn-component-converters/convert-nets-to-source-nets-and-traces.ts tests/dsn-pcb/stringify-dsn-json.test.ts tests/dsn-pcb/subcircuits-having-same-component.test.ts`
- `npx --yes bun@latest run build`
- `git diff --check`

Transparency: AI-assisted with Codex; I reviewed the diff and verification before submitting.