### PR TITLE
Parse leading-dot DSN numeric literals

### DIFF
--- a/lib/common/parse-sexpr.ts
+++ b/lib/common/parse-sexpr.ts
@@ -7,7 +7,7 @@ interface Token {
   value?: string | number
 }
 
-const dsnNumberAtomRegex = /^-?(?:\d+(?:\.\d*)?|\.\d+)$/
+const dsnNumberAtomRegex = /^-?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?$/
 
 // **Tokenizer Function**
 export function tokenizeDsn(input: string): Token[] {

--- a/lib/common/parse-sexpr.ts
+++ b/lib/common/parse-sexpr.ts
@@ -44,7 +44,11 @@ export function tokenizeDsn(input: string): Token[] {
       }
       i++ // Skip the closing quote
       tokens.push({ type: "String", value })
-    } else if (char === "-" || /\d/.test(char)) {
+    } else if (
+      char === "-" ||
+      (char === "." && /\d/.test(input[i + 1] ?? "")) ||
+      /\d/.test(char)
+    ) {
       // Parse number (integer or float)
       let numStr = ""
       if (char === "-") {

--- a/lib/common/parse-sexpr.ts
+++ b/lib/common/parse-sexpr.ts
@@ -7,6 +7,8 @@ interface Token {
   value?: string | number
 }
 
+const dsnNumberAtomRegex = /^-?(?:\d+(?:\.\d*)?|\.\d+)$/
+
 // **Tokenizer Function**
 export function tokenizeDsn(input: string): Token[] {
   const tokens: Token[] = []
@@ -44,30 +46,18 @@ export function tokenizeDsn(input: string): Token[] {
       }
       i++ // Skip the closing quote
       tokens.push({ type: "String", value })
-    } else if (
-      char === "-" ||
-      (char === "." && /\d/.test(input[i + 1] ?? "")) ||
-      /\d/.test(char)
-    ) {
-      // Parse number (integer or float)
-      let numStr = ""
-      if (char === "-") {
-        numStr += "-"
-        i++
-      }
-      while (i < length && /[\d.]/.test(input[i])) {
-        numStr += input[i]
-        i++
-      }
-      tokens.push({ type: "Number", value: parseFloat(numStr) })
     } else {
-      // Parse symbol
-      let sym = ""
+      let atom = ""
       while (i < length && !/\s|\(|\)/.test(input[i])) {
-        sym += input[i]
+        atom += input[i]
         i++
       }
-      tokens.push({ type: "Symbol", value: sym })
+
+      if (dsnNumberAtomRegex.test(atom)) {
+        tokens.push({ type: "Number", value: parseFloat(atom) })
+      } else {
+        tokens.push({ type: "Symbol", value: atom })
+      }
     }
   }
 

--- a/tests/dsn-pcb/parse-leading-dot-numbers.test.ts
+++ b/tests/dsn-pcb/parse-leading-dot-numbers.test.ts
@@ -26,7 +26,11 @@ test("parses leading-dot decimal DSN path coordinates", () => {
       (width 0.15)
     )
   )
-  (placement)
+  (placement
+    (component C0603
+      (place C1 0 0 front 0 (PN .1uF))
+    )
+  )
   (library)
   (network)
   (wiring
@@ -42,6 +46,7 @@ test("parses leading-dot decimal DSN path coordinates", () => {
   expect(parsed.wiring.wires[0].path?.coordinates).toEqual([
     0.5, 0.75, 1.25, 0.25,
   ])
+  expect(parsed.placement.components[0].places[0].PN).toBe(".1uF")
 
   const reparsed = parseDsnToDsnJson(stringifyDsnJson(parsed)) as DsnPcb
   expect(reparsed.structure.boundary.path.coordinates).toEqual([
@@ -50,4 +55,5 @@ test("parses leading-dot decimal DSN path coordinates", () => {
   expect(reparsed.wiring.wires[0].path?.coordinates).toEqual([
     0.5, 0.75, 1.25, 0.25,
   ])
+  expect(reparsed.placement.components[0].places[0].PN).toBe(".1uF")
 })

--- a/tests/dsn-pcb/parse-leading-dot-numbers.test.ts
+++ b/tests/dsn-pcb/parse-leading-dot-numbers.test.ts
@@ -19,7 +19,7 @@ test("parses leading-dot decimal DSN path coordinates", () => {
       )
     )
     (boundary
-      (path F.Cu 0.15 .5 1.5 2 .25)
+      (path F.Cu 0.15 .5 1.5 2 .25 5.6843418860808015e-11)
     )
     (via "")
     (rule
@@ -41,7 +41,7 @@ test("parses leading-dot decimal DSN path coordinates", () => {
   const parsed = parseDsnToDsnJson(dsn) as DsnPcb
 
   expect(parsed.structure.boundary.path.coordinates).toEqual([
-    0.5, 1.5, 2, 0.25,
+    0.5, 1.5, 2, 0.25, 5.6843418860808015e-11,
   ])
   expect(parsed.wiring.wires[0].path?.coordinates).toEqual([
     0.5, 0.75, 1.25, 0.25,
@@ -50,7 +50,7 @@ test("parses leading-dot decimal DSN path coordinates", () => {
 
   const reparsed = parseDsnToDsnJson(stringifyDsnJson(parsed)) as DsnPcb
   expect(reparsed.structure.boundary.path.coordinates).toEqual([
-    0.5, 1.5, 2, 0.25,
+    0.5, 1.5, 2, 0.25, 5.6843418860808015e-11,
   ])
   expect(reparsed.wiring.wires[0].path?.coordinates).toEqual([
     0.5, 0.75, 1.25, 0.25,

--- a/tests/dsn-pcb/parse-leading-dot-numbers.test.ts
+++ b/tests/dsn-pcb/parse-leading-dot-numbers.test.ts
@@ -1,0 +1,53 @@
+import { expect, test } from "bun:test"
+import { type DsnPcb, parseDsnToDsnJson, stringifyDsnJson } from "lib"
+
+test("parses leading-dot decimal DSN path coordinates", () => {
+  const dsn = `(pcb leading-dot.dsn
+  (parser
+    (string_quote ")
+    (space_in_quoted_tokens on)
+    (host_cad "KiCad")
+    (host_version "8.0")
+  )
+  (resolution um 10)
+  (unit um)
+  (structure
+    (layer F.Cu
+      (type signal)
+      (property
+        (index 0)
+      )
+    )
+    (boundary
+      (path F.Cu 0.15 .5 1.5 2 .25)
+    )
+    (via "")
+    (rule
+      (width 0.15)
+    )
+  )
+  (placement)
+  (library)
+  (network)
+  (wiring
+    (wire (path F.Cu 0.15 .5 .75 1.25 .25)(net "N1")(type route))
+  )
+)`
+
+  const parsed = parseDsnToDsnJson(dsn) as DsnPcb
+
+  expect(parsed.structure.boundary.path.coordinates).toEqual([
+    0.5, 1.5, 2, 0.25,
+  ])
+  expect(parsed.wiring.wires[0].path?.coordinates).toEqual([
+    0.5, 0.75, 1.25, 0.25,
+  ])
+
+  const reparsed = parseDsnToDsnJson(stringifyDsnJson(parsed)) as DsnPcb
+  expect(reparsed.structure.boundary.path.coordinates).toEqual([
+    0.5, 1.5, 2, 0.25,
+  ])
+  expect(reparsed.wiring.wires[0].path?.coordinates).toEqual([
+    0.5, 0.75, 1.25, 0.25,
+  ])
+})


### PR DESCRIPTION
## Summary

- parse DSN numeric atoms that start with a decimal point, such as `.5`
- keep leading-dot path coordinates as numbers instead of symbols so path parsers do not drop them
- add focused parse -> stringify -> parse coverage for boundary and wiring paths

/claim #54

## Tests

- `npx --yes bun test tests/dsn-pcb/parse-leading-dot-numbers.test.ts`
- `npx --yes bun test tests/dsn-pcb`
- `npx biome format lib/common/parse-sexpr.ts tests/dsn-pcb/parse-leading-dot-numbers.test.ts`
- `npx --yes bun run build`
- `git diff --check`