### PR TITLE
Preserve missing DSN wiring net metadata

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
@@ -26,6 +26,9 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
     return `${padding}(path ${path.layer} ${path.width}  ${stringifyCoordinates(path.coordinates)})`
   }
 
+  const stringifyNet = (net: string | null | undefined): string =>
+    net === undefined ? "" : `(net ${stringifyValue(net)})`
+
   // Start with pcb
   result += `(pcb ${dsnJson.filename ? dsnJson.filename : "./converted_dsn.dsn"}\n`
 
@@ -136,9 +139,9 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
   result += `${indent}(wiring\n`
   ;(dsnJson.wiring?.wires ?? []).forEach((wire) => {
     if (wire.type === "via") {
-      result += `${indent}${indent}(via ${stringifyPath(wire.path, 3)}(net ${stringifyValue(wire.net)}))\n`
+      result += `${indent}${indent}(via ${stringifyPath(wire.path, 3)}${stringifyNet(wire.net)})\n`
     } else {
-      result += `${indent}${indent}(wire ${stringifyPath(wire.path, 3)}(net ${stringifyValue(wire.net)})(type ${wire.type}))\n`
+      result += `${indent}${indent}(wire ${stringifyPath(wire.path, 3)}${stringifyNet(wire.net)}(type ${wire.type}))\n`
     }
   })
   result += `${indent})\n`

--- a/tests/dsn-pcb/stringify-dsn-json.test.ts
+++ b/tests/dsn-pcb/stringify-dsn-json.test.ts
@@ -17,3 +17,64 @@ test("stringify dsn json", () => {
   // Test that we can parse the generated string back to the same structure
   // expect(reparsedJson).toEqual(dsnJson)
 })
+
+const createDsnWithWiring = (wiring: string) => `(pcb board.dsn
+  (parser
+    (string_quote quote)
+    (space_in_quoted_tokens on)
+    (host_cad "test")
+    (host_version "1")
+  )
+  (resolution um 10)
+  (unit um)
+  (structure
+    (layer F.Cu
+      (type signal)
+      (property
+        (index 0)
+      )
+    )
+    (boundary
+      (path pcb 0 0 0 100 0 100 100 0 100 0 0)
+    )
+    (via Via_600)
+    (rule
+      (width 100)
+      (clearance 100)
+    )
+  )
+  (placement)
+  (library)
+  (network)
+  (wiring
+    ${wiring}
+  )
+)`
+
+test("stringify dsn json preserves missing wire net metadata", () => {
+  const dsnJson = parseDsnToDsnJson(
+    createDsnWithWiring("(wire (path F.Cu 100 0 0 100 0) (type protect))"),
+  ) as DsnPcb
+
+  expect(dsnJson.wiring.wires[0].net).toBeUndefined()
+
+  const dsnString = stringifyDsnJson(dsnJson)
+  expect(dsnString).not.toContain('(net "")')
+
+  const reparsedJson = parseDsnToDsnJson(dsnString) as DsnPcb
+  expect(reparsedJson.wiring.wires[0].net).toBeUndefined()
+})
+
+test("stringify dsn json preserves missing via net metadata", () => {
+  const dsnJson = parseDsnToDsnJson(
+    createDsnWithWiring("(via Via_600 10 20)"),
+  ) as DsnPcb
+
+  expect(dsnJson.wiring.wires[0].net).toBeUndefined()
+
+  const dsnString = stringifyDsnJson(dsnJson)
+  expect(dsnString).not.toContain('(net "")')
+
+  const reparsedJson = parseDsnToDsnJson(dsnString) as DsnPcb
+  expect(reparsedJson.wiring.wires[0].net).toBeUndefined()
+})


### PR DESCRIPTION
## Summary
- preserve absent DSN wiring `(net ...)` children during DSN JSON stringification
- avoid converting missing wire/via net metadata into `(net "")` on parse -> stringify -> parse
- add focused coverage for netless wire and via records

## Bounty
/claim #54

## Verification
- `bunx biome check lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts tests/dsn-pcb/stringify-dsn-json.test.ts`
- `bun test tests/dsn-pcb/stringify-dsn-json.test.ts` with the repo SVG snapshot preload temporarily disabled; default preload is blocked locally by a missing `sharp` native binary after libvips download timeouts
- `bunx tsc --noEmit`
- `bun run build`
- `git diff --check`

Transparency: AI-assisted with Codex; I reviewed the diff and local verification before submission.