### PR TITLE
Preserve source net labels in DSN output

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/process-nets.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/process-nets.ts
@@ -46,6 +46,28 @@ export function processNets(circuitElements: AnyCircuitElement[], pcb: DsnPcb) {
 
   const netMap = new Map()
   const netTraceWidthMap = new Map<string, number>()
+  const sourceNetNameById = new Map<string, string>()
+  const sourceNetNameCounts = new Map<string, number>()
+
+  for (const element of circuitElements) {
+    if (element.type === "source_net") {
+      sourceNetNameCounts.set(
+        element.name,
+        (sourceNetNameCounts.get(element.name) ?? 0) + 1,
+      )
+    }
+  }
+
+  for (const element of circuitElements) {
+    if (element.type === "source_net") {
+      sourceNetNameById.set(
+        element.source_net_id,
+        sourceNetNameCounts.get(element.name) === 1
+          ? element.name
+          : `${element.name}_${element.source_net_id}`,
+      )
+    }
+  }
 
   for (const element of circuitElements) {
     if (element.type === "source_trace" && element.connected_source_port_ids) {
@@ -116,7 +138,8 @@ export function processNets(circuitElements: AnyCircuitElement[], pcb: DsnPcb) {
             if ("min_trace_thickness" in trace && trace.min_trace_thickness) {
               const traceWidthMicrons = trace.min_trace_thickness * 1000
               netTraceWidthMap.set(
-                `${element.name}_${element.source_net_id}`,
+                sourceNetNameById.get(element.source_net_id) ??
+                  `${element.name}_${element.source_net_id}`,
                 traceWidthMicrons,
               )
               break
@@ -140,7 +163,9 @@ export function processNets(circuitElements: AnyCircuitElement[], pcb: DsnPcb) {
   // Add source nets (GND, VCC, etc.)
   for (const element of circuitElements) {
     if (element.type === "source_net") {
-      const netName = `${element.name}_${element.source_net_id}`
+      const netName =
+        sourceNetNameById.get(element.source_net_id) ??
+        `${element.name}_${element.source_net_id}`
       if (!netMap.has(netName)) {
         netMap.set(netName, new Set())
       }

--- a/tests/dsn-pcb/source-net-labels.test.ts
+++ b/tests/dsn-pcb/source-net-labels.test.ts
@@ -1,0 +1,69 @@
+import { expect, test } from "bun:test"
+import { convertCircuitJsonToDsnJson } from "lib"
+import type { AnyCircuitElement } from "circuit-json"
+
+test("source net names are used as DSN net labels", () => {
+  const circuitJson: AnyCircuitElement[] = [
+    {
+      type: "source_component",
+      source_component_id: "source_component_1",
+      name: "U1",
+      ftype: "simple_chip",
+    } as any,
+    {
+      type: "pcb_component",
+      pcb_component_id: "pcb_component_1",
+      source_component_id: "source_component_1",
+      center: { x: 0, y: 0 },
+      rotation: 0,
+      layer: "top",
+    } as any,
+    {
+      type: "source_port",
+      source_port_id: "source_port_1",
+      source_component_id: "source_component_1",
+      name: "pin1",
+      port_hints: ["1"],
+    } as any,
+    {
+      type: "pcb_port",
+      pcb_port_id: "pcb_port_1",
+      source_port_id: "source_port_1",
+      x: 0,
+      y: 0,
+      layers: ["top"],
+    } as any,
+    {
+      type: "pcb_smtpad",
+      pcb_smtpad_id: "pcb_smtpad_1",
+      pcb_component_id: "pcb_component_1",
+      pcb_port_id: "pcb_port_1",
+      layer: "top",
+      shape: "rect",
+      x: 0,
+      y: 0,
+      width: 1,
+      height: 1,
+    } as any,
+    {
+      type: "source_net",
+      source_net_id: "source_net_0",
+      name: "GND",
+    } as any,
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_1",
+      connected_source_net_ids: ["source_net_0"],
+      connected_source_port_ids: ["source_port_1"],
+    } as any,
+  ]
+
+  const dsnJson = convertCircuitJsonToDsnJson(circuitJson)
+  const netNames = dsnJson.network.nets.map((net) => net.name)
+
+  expect(netNames).toContain("GND")
+  expect(netNames).not.toContain("GND_source_net_0")
+  expect(
+    dsnJson.network.classes.some((cls) => cls.net_names.includes("GND")),
+  ).toBe(true)
+})

--- a/tests/repros/repro2-motor-driver.test.ts
+++ b/tests/repros/repro2-motor-driver.test.ts
@@ -44,7 +44,7 @@ test("circuit json (motor driver breakout) -> dsn file", async () => {
   //expect the first net to have length name "GND" and pins length 11
   let foundGndNet = false
   dsnJson.network.nets.forEach((net) => {
-    if (net.name === "GND_source_net_1") {
+    if (net.name === "GND") {
       expect(net.pins.length).toBe(11)
       foundGndNet = true
     }
@@ -54,7 +54,7 @@ test("circuit json (motor driver breakout) -> dsn file", async () => {
   //expect the second net to have length name "VCC" and pins length 3
   let foundVccNet = false
   dsnJson.network.nets.forEach((net) => {
-    if (net.name === "VCC_source_net_0") {
+    if (net.name === "VCC") {
       expect(net.pins.length).toBe(3)
       foundVccNet = true
     }


### PR DESCRIPTION
## Summary
- Preserve source net labels when converting circuit JSON nets to DSN JSON
- Avoid generated DSN net names like `GND_source_net_1` when the original source net label is known
- Add regression coverage for GND/VCC-style source net names

## Test plan
- `bun test`

Fixes/helps #54.
