### PR TITLE
Preserve class use_layer metadata

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
@@ -118,6 +118,9 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
   dsnJson.network.classes.forEach((cls) => {
     result += `${indent}${indent}(class ${stringifyValue(cls.name)} ${stringifyValue(cls.description)}${cls.net_names.map((n) => ` ${stringifyValue(n)}`).join("")}\n`
     result += `${indent}${indent}${indent}(circuit\n`
+    if (cls.circuit.use_layer?.length) {
+      result += `${indent}${indent}${indent}${indent}(use_layer ${cls.circuit.use_layer.map((layer) => stringifyValue(layer)).join(" ")})\n`
+    }
     result += `${indent}${indent}${indent}${indent}(use_via ${stringifyValue(cls.circuit.use_via)})\n`
     result += `${indent}${indent}${indent})\n`
     if (cls.rule) {

--- a/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
@@ -901,6 +901,18 @@ function processCircuit(nodes: ASTNode[]): Circuit {
       ) {
         circuit.use_via = node.children![1].value
       }
+    } else if (
+      node.type === "List" &&
+      node.children![0].type === "Atom" &&
+      node.children![0].value === "use_layer"
+    ) {
+      circuit.use_layer = node.children!
+        .slice(1)
+        .filter(
+          (layerNode) =>
+            layerNode.type === "Atom" && typeof layerNode.value === "string",
+        )
+        .map((layerNode) => layerNode.value as string)
     }
   })
   return circuit as Circuit

--- a/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
@@ -906,8 +906,8 @@ function processCircuit(nodes: ASTNode[]): Circuit {
       node.children![0].type === "Atom" &&
       node.children![0].value === "use_layer"
     ) {
-      circuit.use_layer = node.children!
-        .slice(1)
+      circuit.use_layer = node
+        .children!.slice(1)
         .filter(
           (layerNode) =>
             layerNode.type === "Atom" && typeof layerNode.value === "string",

--- a/lib/dsn-pcb/types.ts
+++ b/lib/dsn-pcb/types.ts
@@ -57,6 +57,7 @@ export interface DsnPcb {
       net_names: string[]
       circuit: {
         use_via: string
+        use_layer?: string[]
       }
       rule: {
         clearances: Array<{
@@ -262,6 +263,7 @@ export interface Class {
 
 export interface Circuit {
   use_via: string
+  use_layer?: string[]
 }
 
 export interface Wiring {

--- a/tests/dsn-pcb/stringify-dsn-json.test.ts
+++ b/tests/dsn-pcb/stringify-dsn-json.test.ts
@@ -17,3 +17,17 @@ test("stringify dsn json", () => {
   // Test that we can parse the generated string back to the same structure
   // expect(reparsedJson).toEqual(dsnJson)
 })
+
+test("preserves class circuit use_layer metadata when stringifying", () => {
+  const dsnJson = parseDsnToDsnJson(testDsnFile) as DsnPcb
+  dsnJson.network.classes[0].circuit.use_layer = ["F.Cu", "B.Cu"]
+
+  const dsnString = stringifyDsnJson(dsnJson)
+  const reparsedJson = parseDsnToDsnJson(dsnString) as DsnPcb
+
+  expect(dsnString).toContain('(use_layer "F.Cu" "B.Cu")')
+  expect(reparsedJson.network.classes[0].circuit.use_layer).toEqual([
+    "F.Cu",
+    "B.Cu",
+  ])
+})


### PR DESCRIPTION
﻿/claim #54

This preserves DSN class circuit `use_layer` metadata during parse -> stringify -> parse round trips.

Changes:
- adds `use_layer?: string[]` to the parsed circuit metadata shape
- parses `(use_layer ...)` from class circuit blocks
- emits `use_layer` entries when stringifying class circuit metadata
- adds focused coverage for preserving `["F.Cu", "B.Cu"]`

Verification:
- `bun test tests/dsn-pcb/stringify-dsn-json.test.ts -t "preserves class circuit use_layer"`
- `bun run build`
- `bunx biome check --formatter-enabled=false lib/dsn-pcb/types.ts lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts tests/dsn-pcb/stringify-dsn-json.test.ts`

Note: the full existing `tests/dsn-pcb/stringify-dsn-json.test.ts` still has a pre-existing baseline failure in `stringify dsn json` around parser metadata/string_quote round-trip; this PR does not touch that path.
