### PR TITLE
Preserve session polyline path wires

### DIFF
--- a/lib/dsn-pcb/dsn-json-to-circuit-json/convert-dsn-session-to-circuit-json.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/convert-dsn-session-to-circuit-json.ts
@@ -8,6 +8,7 @@ import Debug from "debug"
 import { applyToPoint, scale } from "transformation-matrix"
 import type { DsnPcb, DsnSession } from "../types"
 import { convertDsnPcbToCircuitJson } from "./convert-dsn-pcb-to-circuit-json"
+import { convertPolylinePathToPcbTraces } from "./dsn-component-converters/convert-polyline-path-to-pcb-traces"
 import { convertViaToPcbVia } from "./dsn-component-converters/convert-via-to-pcb-via"
 import { convertWiringPathToPcbTraces } from "./dsn-component-converters/convert-wiring-path-to-pcb-traces"
 
@@ -88,11 +89,27 @@ export function convertDsnSessionToCircuitJson(
 
     // Process wires and vias together in routes
     net.wires?.forEach((wire, wireIdx) => {
+      const netName = `${net.name}_${wireIdx}`
       if ("path" in wire) {
         const traces = convertWiringPathToPcbTraces({
           wire,
           transformUmToMm,
-          netName: `${net.name}_${wireIdx}`,
+          netName,
+        })
+
+        // Update trace IDs to maintain proper linkage
+        traces.forEach((trace) => {
+          trace.source_trace_id = sourceTrace
+            ? sourceTrace.source_trace_id
+            : `source_trace_${net.name}`
+        })
+
+        sessionElements.push(...traces)
+      } else if ("polyline_path" in wire) {
+        const traces = convertPolylinePathToPcbTraces({
+          wire,
+          transformUmToMm,
+          netName,
         })
 
         // Update trace IDs to maintain proper linkage

--- a/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
@@ -1127,11 +1127,14 @@ function processSessionNode(ast: ASTNode): DsnSession {
 
         const net = {
           name: netName,
-          wires: wireNodes.map((wireNode) => ({
-            path: processPath(wireNode.children!.slice(1)),
-            net: netName,
-            type: "route",
-          })),
+          wires: wireNodes.map((wireNode) => {
+            const wire = processWire(wireNode.children!)
+            return {
+              ...wire,
+              net: wire.net ?? netName,
+              type: wire.type ?? "route",
+            }
+          }),
           vias: viaNodes.map((viaNode) => ({
             x: viaNode.children![2].value as number,
             y: viaNode.children![3].value as number,

--- a/tests/dsn-pcb/parse-session-file.test.ts
+++ b/tests/dsn-pcb/parse-session-file.test.ts
@@ -1,5 +1,10 @@
 import { expect, test } from "bun:test"
-import { type DsnSession, parseDsnToDsnJson } from "lib"
+import {
+  type DsnPcb,
+  type DsnSession,
+  convertDsnSessionToCircuitJson,
+  parseDsnToDsnJson,
+} from "lib"
 // @ts-ignore
 import sessionFile from "../assets/freerouting-sessions/session1.ses" with {
   type: "text",
@@ -59,4 +64,81 @@ test("parse session file", () => {
   expect(firstPadstack?.shapes[0].shapeType).toBe("circle")
   expect(firstPadstack?.shapes[0].layer).toBe("F.Cu")
   expect((firstPadstack?.shapes[0] as any).diameter).toBe(6000)
+})
+
+test("parse and convert session polyline_path wires", () => {
+  const sessionFileWithPolylinePath = `(session test
+  (placement
+    (resolution um 10)
+  )
+  (routes
+    (resolution um 10)
+    (parser
+      (host_cad "")
+      (host_version "")
+    )
+    (network_out
+      (net N1
+        (wire
+          (polyline_path F.Cu 2000
+            0 0 10000 0
+            10000 -10000 10000 10000
+            10000 10000 20000 10000
+          )
+        )
+      )
+    )
+  )
+)`
+
+  const sessionJson = parseDsnToDsnJson(
+    sessionFileWithPolylinePath,
+  ) as DsnSession
+
+  expect(sessionJson.routes.network_out.nets[0].wires[0].polyline_path).toEqual(
+    {
+      layer: "F.Cu",
+      width: 2000,
+      coordinates: [
+        0, 0, 10000, 0, 10000, -10000, 10000, 10000, 10000, 10000, 20000, 10000,
+      ],
+    },
+  )
+
+  const dsnPcb: DsnPcb = {
+    is_dsn_pcb: true,
+    filename: "test.dsn",
+    parser: {
+      string_quote: "",
+      host_version: "",
+      space_in_quoted_tokens: "",
+      host_cad: "",
+    },
+    resolution: { unit: "um", value: 10 },
+    unit: "um",
+    structure: {
+      layers: [],
+      boundary: { path: { layer: "pcb", width: 0, coordinates: [] } },
+      via: "",
+      rule: { width: 0, clearances: [] },
+    },
+    placement: { components: [] },
+    library: { images: [], padstacks: [] },
+    network: { nets: [], classes: [] },
+    wiring: { wires: [] },
+  }
+
+  const circuitJson = convertDsnSessionToCircuitJson(dsnPcb, sessionJson)
+  const sessionTrace = circuitJson.find(
+    (element) => element.type === "pcb_trace",
+  )
+
+  expect(sessionTrace).toMatchObject({
+    type: "pcb_trace",
+    pcb_trace_id: "pcb_trace_N1_0",
+    route: [
+      { route_type: "wire", x: 1, y: 0, width: 0.2, layer: "top" },
+      { route_type: "wire", x: 1, y: 1, width: 0.2, layer: "top" },
+    ],
+  })
 })


### PR DESCRIPTION
Summary
- Parse `polyline_path` wires inside session `network_out` nets by reusing the existing DSN wire parser.
- Convert parsed session polyline wires through the existing polyline trace converter, preserving the same source-trace linkage behavior as path wires.
- Add focused coverage for parse -> session conversion of `polyline_path` wires.

This is intentionally session-specific and separate from the existing PCB wiring polyline stringifier / single-segment converter PRs.

/claim #54

Verification
- `bun test tests/dsn-pcb/parse-session-file.test.ts`
- `bunx biome check lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts lib/dsn-pcb/dsn-json-to-circuit-json/convert-dsn-session-to-circuit-json.ts tests/dsn-pcb/parse-session-file.test.ts`
- `bunx tsc --noEmit`
- `bun run build`
- `bun test`
- `git diff --check`

Transparency note: AI-assisted with Codex; I reviewed the diff and verified it locally before submission.