### PR TITLE
Preserve DSN place boundary shapes

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
@@ -26,6 +26,22 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
     return `${padding}(path ${path.layer} ${path.width}  ${stringifyCoordinates(path.coordinates)})`
   }
 
+  const stringifyShape = (shape: any): string => {
+    if (shape.shapeType === "polygon") {
+      return `(polygon ${shape.layer} ${shape.width} ${stringifyCoordinates(shape.coordinates)})`
+    }
+    if (shape.shapeType === "circle") {
+      return `(circle ${shape.layer} ${shape.diameter})`
+    }
+    if (shape.shapeType === "rect") {
+      return `(rect ${shape.layer} ${stringifyCoordinates(shape.coordinates)})`
+    }
+    if (shape.shapeType === "path") {
+      return `(path ${shape.layer} ${shape.width} ${stringifyCoordinates(shape.coordinates)})`
+    }
+    throw new Error(`Unknown shape type: ${shape.shapeType}`)
+  }
+
   // Start with pcb
   result += `(pcb ${dsnJson.filename ? dsnJson.filename : "./converted_dsn.dsn"}\n`
 
@@ -56,6 +72,9 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
     result += `${indent}${indent}${indent}${stringifyPath(dsnJson.structure.boundary.path, 0)}\n`
     result += `${indent}${indent})\n`
   }
+  ;(dsnJson.structure.place_boundaries ?? []).forEach((shape) => {
+    result += `${indent}${indent}(place_boundary ${stringifyShape(shape)})\n`
+  })
   result += `${indent}${indent}(via ${stringifyValue(dsnJson.structure.via)})\n`
   result += `${indent}${indent}(rule\n`
   result += `${indent}${indent}${indent}(width ${dsnJson.structure.rule.width})\n`
@@ -94,11 +113,11 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
     result += `${indent}${indent}(padstack ${stringifyValue(padstack.name)}\n`
     padstack.shapes.forEach((shape) => {
       if (shape.shapeType === "polygon") {
-        result += `${indent}${indent}${indent}(shape (polygon ${shape.layer} ${shape.width} ${stringifyCoordinates(shape.coordinates)}))\n`
+        result += `${indent}${indent}${indent}(shape ${stringifyShape(shape)})\n`
       } else if (shape.shapeType === "circle") {
-        result += `${indent}${indent}${indent}(shape (circle ${shape.layer} ${shape.diameter}))\n`
+        result += `${indent}${indent}${indent}(shape ${stringifyShape(shape)})\n`
       } else if (shape.shapeType === "path") {
-        result += `${indent}${indent}${indent}(shape (path ${shape.layer} ${shape.width} ${stringifyCoordinates(shape.coordinates)}))\n`
+        result += `${indent}${indent}${indent}(shape ${stringifyShape(shape)})\n`
       }
     })
     result += `${indent}${indent}${indent}(attach ${padstack.attach})\n`

--- a/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
@@ -225,6 +225,14 @@ export function processStructure(nodes: ASTNode[]): Structure {
           case "boundary":
             structure.boundary = processBoundary(node.children!.slice(1))
             break
+          case "place_boundary":
+            structure.place_boundaries ??= []
+            if (node.children![1]) {
+              structure.place_boundaries.push(
+                processShapeContent(node.children![1]),
+              )
+            }
+            break
           case "via":
             if (
               node.children![1].type === "Atom" &&
@@ -668,8 +676,15 @@ function processPadstack(nodes: ASTNode[]): Padstack {
 }
 
 function processShape(nodes: ASTNode[]): Shape {
-  const [_, shapeContentNode, ...rest] = nodes
+  const shapeContentNode =
+    nodes[0]?.type === "Atom" && nodes[0].value === "shape"
+      ? nodes[1]
+      : nodes[0]
 
+  return processShapeContent(shapeContentNode)
+}
+
+function processShapeContent(shapeContentNode: ASTNode): Shape {
   if (shapeContentNode.type === "List") {
     const [shapeTypeNode, layerNode, ...shapeData] = shapeContentNode.children!
 
@@ -692,8 +707,10 @@ function processShape(nodes: ASTNode[]): Shape {
     }
   }
 
-  console.error("Shape processing error for nodes:", nodes)
-  throw new Error(`Unknown shape type for nodes: ${JSON.stringify(nodes)}`)
+  console.error("Shape processing error for node:", shapeContentNode)
+  throw new Error(
+    `Unknown shape type for node: ${JSON.stringify(shapeContentNode)}`,
+  )
 }
 
 function processRectShape(nodes: ASTNode[]): RectShape {

--- a/lib/dsn-pcb/types.ts
+++ b/lib/dsn-pcb/types.ts
@@ -30,6 +30,7 @@ export interface DsnPcb {
         coordinates: number[]
       }
     }
+    place_boundaries?: Shape[]
     via: string
     rule: {
       clearances: Array<{
@@ -110,6 +111,7 @@ export interface Resolution {
 export interface Structure {
   layers: Layer[]
   boundary: Boundary
+  place_boundaries?: Shape[]
   via: string
   rule: Rule
 }

--- a/tests/dsn-pcb/stringify-dsn-json.test.ts
+++ b/tests/dsn-pcb/stringify-dsn-json.test.ts
@@ -17,3 +17,52 @@ test("stringify dsn json", () => {
   // Test that we can parse the generated string back to the same structure
   // expect(reparsedJson).toEqual(dsnJson)
 })
+
+test("preserves structure place_boundary shapes", () => {
+  const dsnJson = parseDsnToDsnJson(`(pcb sample.dsn
+  (parser
+    (host_version "test")
+  )
+  (resolution um 10)
+  (unit um)
+  (structure
+    (layer F.Cu
+      (type signal)
+      (property
+        (index 0)
+      )
+    )
+    (boundary
+      (path pcb 0 0 0 1000 0 1000 1000 0 1000 0 0)
+    )
+    (place_boundary (rect signal -500 -400 500 400))
+    (via "Via[0-0]_600:300_um")
+    (rule
+      (width 100)
+      (clearance 100)
+    )
+  )
+  (placement)
+  (library)
+  (network)
+  (wiring)
+)`) as DsnPcb
+
+  expect(dsnJson.structure.place_boundaries).toEqual([
+    {
+      shapeType: "rect",
+      layer: "signal",
+      coordinates: [-500, -400, 500, 400],
+    },
+  ])
+
+  const dsnString = stringifyDsnJson(dsnJson)
+  expect(dsnString).toContain(
+    "(place_boundary (rect signal -500 -400 500 400))",
+  )
+
+  const reparsedJson = parseDsnToDsnJson(dsnString) as DsnPcb
+  expect(reparsedJson.structure.place_boundaries).toEqual(
+    dsnJson.structure.place_boundaries,
+  )
+})


### PR DESCRIPTION
﻿## Summary
- Parse `structure` `(place_boundary ...)` shape records into DSN JSON.
- Stringify parsed place-boundary shapes so they survive DSN parse -> stringify -> parse round trips.
- Add focused coverage for a SPECCTRA-style rectangular place boundary.

/claim #54

## Verification
- `npm run build`
- `npx bun test tests/dsn-pcb/stringify-dsn-json.test.ts -t "preserves structure place_boundary shapes"`

Note: the full `stringify-dsn-json.test.ts` file still has an existing Windows line-ending-sensitive failure in the pre-existing `stringify dsn json` test around parser string_quote metadata; the new focused place_boundary test passes.
