### PR TITLE
Preserve split placement PN atoms

### DIFF
--- a/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
@@ -485,10 +485,9 @@ function processPlace(nodes: ASTNode[]): Places {
       node.children &&
       node.children[0].type === "Atom" &&
       node.children[0].value === "PN" &&
-      node.children[1] &&
-      node.children[1].type === "Atom"
+      node.children.length > 1
     ) {
-      places.PN = String(node.children[1].value)
+      places.PN = stringifyPlaceMetadataAtoms(node.children.slice(1))
       break
     }
   }
@@ -499,6 +498,13 @@ function processPlace(nodes: ASTNode[]): Places {
   places.rotation = places.rotation || 0
 
   return places as Places
+}
+
+function stringifyPlaceMetadataAtoms(nodes: ASTNode[]): string {
+  return nodes
+    .filter((node) => node.type === "Atom" && node.value !== undefined)
+    .map((node) => String(node.value))
+    .join("")
 }
 
 export function processLibrary(nodes: ASTNode[]): Library {

--- a/tests/repros/repro7-smoothie-board.test.ts
+++ b/tests/repros/repro7-smoothie-board.test.ts
@@ -16,3 +16,18 @@ test("smoothieboard repro", async () => {
     import.meta.path,
   )
 })
+
+test("smoothieboard placement PNs keep numeric prefixes and suffixes", () => {
+  const dsnJson = parseDsnToDsnJson(dsnFileWithFreeroutingTrace) as DsnPcb
+  const placesByRefdes = new Map(
+    dsnJson.placement.components.flatMap((component) =>
+      component.places.map((place) => [place.refdes, place]),
+    ),
+  )
+
+  expect(placesByRefdes.get("Q2")?.PN).toBe("12MHz")
+  expect(placesByRefdes.get("C2")?.PN).toBe("12pF")
+  expect(placesByRefdes.get("R31")?.PN).toBe("0.05R")
+  expect(placesByRefdes.get("R92")?.PN).toBe("5k6")
+  expect(placesByRefdes.get("U$5")?.PN).toBe("5MMCONN")
+})


### PR DESCRIPTION
## Summary
- preserve full placement PN metadata when unquoted values are tokenized as number+symbol atoms
- keep Smoothie Board import display values such as `12MHz`, `12pF`, `0.05R`, `5k6`, and `5MMCONN` intact
- add focused Smoothie Board repro coverage for numeric-prefix PN values

## Verification
- `npx --yes bun@latest test tests/repros/repro7-smoothie-board.test.ts`
- `npx biome check lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts tests/repros/repro7-smoothie-board.test.ts`
- `npx tsc --noEmit`
- `npx --yes bun@latest run build`
- `git diff --check`

/claim #54

AI-assisted with Codex; I reviewed the diff and verification before submission.