### PR TITLE
Preserve omitted padstack attach clauses

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
@@ -101,7 +101,9 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
         result += `${indent}${indent}${indent}(shape (path ${shape.layer} ${shape.width} ${stringifyCoordinates(shape.coordinates)}))\n`
       }
     })
-    result += `${indent}${indent}${indent}(attach ${padstack.attach})\n`
+    if (padstack.attach !== undefined) {
+      result += `${indent}${indent}${indent}(attach ${padstack.attach})\n`
+    }
     result += `${indent}${indent})\n`
   })
   result += `${indent})\n`

--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-session.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-session.ts
@@ -47,7 +47,9 @@ export const stringifyDsnSession = (session: DsnSession): string => {
           result += `${indent}${indent}${indent}${indent})\n`
         }
       })
-      result += `${indent}${indent}${indent}${indent}(attach ${padstack.attach})\n`
+      if (padstack.attach !== undefined) {
+        result += `${indent}${indent}${indent}${indent}(attach ${padstack.attach})\n`
+      }
       result += `${indent}${indent}${indent})\n`
     })
     result += `${indent}${indent})\n`

--- a/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
@@ -646,7 +646,6 @@ function processPadstack(nodes: ASTNode[]): Padstack {
     padstack.name = nodes[1].value
   }
   padstack.shapes = []
-  padstack.attach = "off" // default value
 
   nodes.slice(2).forEach((node) => {
     if (node.type === "List") {

--- a/lib/dsn-pcb/types.ts
+++ b/lib/dsn-pcb/types.ts
@@ -198,7 +198,7 @@ export interface Pin {
 export interface Padstack {
   name: string
   shapes: Shape[]
-  attach: string
+  attach?: string
   hole?: {
     shape: "circle" | "square" | "oval"
     width?: number

--- a/tests/dsn-pcb/stringify-dsn-json.test.ts
+++ b/tests/dsn-pcb/stringify-dsn-json.test.ts
@@ -1,5 +1,11 @@
 import { expect, test } from "bun:test"
-import { type DsnPcb, parseDsnToDsnJson, stringifyDsnJson } from "lib"
+import {
+  type DsnPcb,
+  type DsnSession,
+  parseDsnToDsnJson,
+  stringifyDsnJson,
+  stringifyDsnSession,
+} from "lib"
 // @ts-ignore
 import testDsnFile from "../assets/testkicadproject/testkicadproject.dsn" with {
   type: "text",
@@ -16,4 +22,101 @@ test("stringify dsn json", () => {
 
   // Test that we can parse the generated string back to the same structure
   // expect(reparsedJson).toEqual(dsnJson)
+})
+
+test("preserves omitted padstack attach in pcb round trips", () => {
+  const dsnFile = `(pcb attach-test.dsn
+  (parser
+    (string_quote ")
+    (space_in_quoted_tokens on)
+    (host_cad "KiCad's Pcbnew")
+    (host_version "test")
+  )
+  (resolution um 10)
+  (unit um)
+  (structure
+    (layer F.Cu
+      (type signal)
+      (property
+        (index 0)
+      )
+    )
+    (boundary
+      (path F.Cu 0 0 0 1000 1000)
+    )
+    (via Via)
+    (rule
+      (width 100)
+    )
+  )
+  (placement)
+  (library
+    (padstack NoAttach
+      (shape (circle F.Cu 100))
+    )
+    (padstack ExplicitAttach
+      (shape (circle F.Cu 100))
+      (attach off)
+    )
+  )
+  (network)
+  (wiring)
+)`
+
+  const dsnJson = parseDsnToDsnJson(dsnFile) as DsnPcb
+  expect(dsnJson.library.padstacks[0].attach).toBeUndefined()
+  expect(dsnJson.library.padstacks[1].attach).toBe("off")
+
+  const dsnString = stringifyDsnJson(dsnJson)
+  expect(dsnString.match(/\(attach/g)).toHaveLength(1)
+
+  const reparsedJson = parseDsnToDsnJson(dsnString) as DsnPcb
+  expect(reparsedJson.library.padstacks[0].attach).toBeUndefined()
+  expect(reparsedJson.library.padstacks[1].attach).toBe("off")
+})
+
+test("preserves omitted padstack attach in session round trips", () => {
+  const session: DsnSession = {
+    is_dsn_session: true,
+    filename: "attach-test",
+    placement: {
+      resolution: { unit: "um", value: 10 },
+      components: [],
+    },
+    routes: {
+      resolution: { unit: "um", value: 10 },
+      parser: {
+        string_quote: "",
+        host_cad: "Freerouting",
+        host_version: "test",
+        space_in_quoted_tokens: "",
+      },
+      library_out: {
+        images: [],
+        padstacks: [
+          {
+            name: "NoAttach",
+            shapes: [{ shapeType: "circle", layer: "F.Cu", diameter: 100 }],
+          },
+          {
+            name: "ExplicitAttach",
+            shapes: [{ shapeType: "circle", layer: "F.Cu", diameter: 100 }],
+            attach: "off",
+          },
+        ],
+      },
+      network_out: {
+        nets: [],
+      },
+    },
+  }
+
+  const sessionString = stringifyDsnSession(session)
+  expect(sessionString.match(/\(attach/g)).toHaveLength(1)
+
+  const reparsedSession = parseDsnToDsnJson(sessionString) as DsnSession
+  expect(
+    reparsedSession.routes.library_out?.padstacks[0].attach,
+  ).toBeUndefined()
+  expect(reparsedSession.routes.library_out?.padstacks[1].attach).toBe("off")
 })


### PR DESCRIPTION
## Summary
- preserve whether parsed padstacks omitted `(attach ...)` instead of defaulting them to `attach: "off"`
- omit `(attach ...)` during PCB and session stringification when the source padstack omitted it
- add focused PCB and session round-trip coverage

## Tests
- `npx --yes bun@latest test tests/dsn-pcb/stringify-dsn-json.test.ts`
- `npx --yes bun@latest run build`

/claim #54

Transparency: AI-assisted with Codex; I reviewed the diff and verified it locally.