### PR TITLE
Preserve placement mirror descriptors

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
@@ -71,7 +71,7 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
     result += `${indent}${indent}(component ${stringifyValue(component.name)}\n`
     if (component.places) {
       component.places.forEach((place) => {
-        result += `${indent}${indent}${indent}(place ${place.refdes} ${place.x} ${place.y} ${place.side} ${place.rotation}${place.PN ? ` (PN ${stringifyValue(place.PN)})` : ""})\n`
+        result += `${indent}${indent}${indent}(place ${place.refdes} ${place.x} ${place.y} ${place.side} ${place.rotation}${place.mirror ? ` (mirror ${place.mirror})` : ""}${place.PN ? ` (PN ${stringifyValue(place.PN)})` : ""})\n`
       })
     }
     result += `${indent}${indent})\n`

--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-session.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-session.ts
@@ -16,7 +16,7 @@ export const stringifyDsnSession = (session: DsnSession): string => {
   session.placement.components.forEach((component) => {
     result += `${indent}${indent}(component ${component.name}\n`
     component.places.forEach((place) => {
-      result += `${indent}${indent}${indent}(place ${place.refdes} ${place.x} ${place.y} ${place.side} ${place.rotation})\n`
+      result += `${indent}${indent}${indent}(place ${place.refdes} ${place.x} ${place.y} ${place.side} ${place.rotation}${place.mirror ? ` (mirror ${place.mirror})` : ""})\n`
     })
     result += `${indent}${indent})\n`
   })

--- a/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
@@ -477,8 +477,8 @@ function processPlace(nodes: ASTNode[]): Places {
     }
   }
 
-  // Process optional PN (part number) if present
-  for (let i = coordIndex + 4; i < nodes.length; i++) {
+  // Process optional placement descriptors if present
+  for (let i = 2; i < nodes.length; i++) {
     const node = nodes[i]
     if (
       node.type === "List" &&
@@ -489,7 +489,16 @@ function processPlace(nodes: ASTNode[]): Places {
       node.children[1].type === "Atom"
     ) {
       places.PN = String(node.children[1].value)
-      break
+    }
+    if (
+      node.type === "List" &&
+      node.children &&
+      node.children[0].type === "Atom" &&
+      node.children[0].value === "mirror" &&
+      node.children[1] &&
+      node.children[1].type === "Atom"
+    ) {
+      places.mirror = String(node.children[1].value)
     }
   }
 

--- a/lib/dsn-pcb/types.ts
+++ b/lib/dsn-pcb/types.ts
@@ -88,6 +88,7 @@ export interface ComponentPlacement {
   places: Array<{
     refdes: string
     PN?: string
+    mirror?: string
     x: number
     y: number
     side: "front" | "back"
@@ -170,6 +171,7 @@ export interface Places {
   y: number
   side: string
   rotation: number
+  mirror?: string
   PN: string
 }
 

--- a/tests/dsn-pcb/stringify-dsn-json.test.ts
+++ b/tests/dsn-pcb/stringify-dsn-json.test.ts
@@ -17,3 +17,74 @@ test("stringify dsn json", () => {
   // Test that we can parse the generated string back to the same structure
   // expect(reparsedJson).toEqual(dsnJson)
 })
+
+test("preserves placement mirror descriptors when stringifying dsn json", () => {
+  const dsn = `(pcb mirror_fixture
+  (parser
+    (string_quote ")
+    (space_in_quoted_tokens on)
+    (host_cad "fixture")
+    (host_version "1")
+  )
+  (resolution um 10)
+  (unit um)
+  (structure
+    (layer F.Cu
+      (type signal)
+      (property
+        (index 0)
+      )
+    )
+    (boundary
+      (path pcb 0 0 0 1000 0 1000 1000 0 1000 0 0)
+    )
+    (via "Via[0-1]_600:300_um")
+    (rule
+      (width 100)
+      (clearance 100)
+    )
+  )
+  (placement
+    (component "Device"
+      (place U1 100 200 front 90 (mirror X) (PN "controller"))
+      (place U2 300 400 back 180 (mirror XY))
+    )
+  )
+  (library
+    (image "Device"
+      (pin RoundPad 1 0 0)
+    )
+    (padstack RoundPad
+      (shape (circle F.Cu 100))
+      (attach off)
+    )
+  )
+  (network
+    (net "N1"
+      (pins U1-1 U2-1)
+    )
+    (class "default" "" "N1"
+      (circuit
+        (use_via "Via[0-1]_600:300_um")
+      )
+      (rule
+        (width 100)
+        (clearance 100)
+      )
+    )
+  )
+  (wiring)
+)`
+
+  const dsnJson = parseDsnToDsnJson(dsn) as DsnPcb
+  expect(dsnJson.placement.components[0].places[0].mirror).toBe("X")
+  expect(dsnJson.placement.components[0].places[1].mirror).toBe("XY")
+
+  const dsnString = stringifyDsnJson(dsnJson)
+  expect(dsnString).toContain("(mirror X)")
+  expect(dsnString).toContain("(mirror XY)")
+
+  const reparsedJson = parseDsnToDsnJson(dsnString) as DsnPcb
+  expect(reparsedJson.placement.components[0].places[0].mirror).toBe("X")
+  expect(reparsedJson.placement.components[0].places[1].mirror).toBe("XY")
+})


### PR DESCRIPTION
Fixes part of #54
/claim #54

## Summary
- preserve optional SPECCTRA placement `(mirror ...)` descriptors in parsed DSN placement data
- emit mirror descriptors from PCB and session DSN stringifiers
- add focused parse -> stringify -> parse coverage for `(mirror X)` and `(mirror XY)`

## Verification
- `bun test tests/dsn-pcb/stringify-dsn-json.test.ts` (focused run with the repository test preload temporarily disabled locally because the preload imports SVG/image tooling; output: 2 pass / 0 fail)
- `node_modules/@biomejs/biome/bin/biome check lib/dsn-pcb/types.ts lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-session.ts tests/dsn-pcb/stringify-dsn-json.test.ts`
- `node node_modules/typescript/bin/tsc --noEmit`
- `node node_modules/tsup/dist/cli-default.js ./lib/index.ts --format esm --dts --sourcemap`
- `git diff --check`

AI-assisted with Codex; I reviewed the diff and kept the scope to placement mirror metadata.