### PR TITLE
Handle parserless DSN PCB stringification

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
@@ -30,12 +30,14 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
   result += `(pcb ${dsnJson.filename ? dsnJson.filename : "./converted_dsn.dsn"}\n`
 
   // Parser section
-  result += `${indent}(parser\n`
-  result += `${indent}${indent}(string_quote ")\n`
-  result += `${indent}${indent}(space_in_quoted_tokens on)\n`
-  result += `${indent}${indent}(host_cad "KiCad's Pcbnew")\n`
-  result += `${indent}${indent}(host_version "${dsnJson.parser.host_version}")\n`
-  result += `${indent})\n`
+  if (dsnJson.parser) {
+    result += `${indent}(parser\n`
+    result += `${indent}${indent}(string_quote ")\n`
+    result += `${indent}${indent}(space_in_quoted_tokens on)\n`
+    result += `${indent}${indent}(host_cad "KiCad's Pcbnew")\n`
+    result += `${indent}${indent}(host_version "${dsnJson.parser.host_version}")\n`
+    result += `${indent})\n`
+  }
 
   // Resolution and unit
   result += `${indent}(resolution ${dsnJson.resolution.unit} ${dsnJson.resolution.value})\n`

--- a/tests/dsn-pcb/stringify-dsn-json.test.ts
+++ b/tests/dsn-pcb/stringify-dsn-json.test.ts
@@ -17,3 +17,20 @@ test("stringify dsn json", () => {
   // Test that we can parse the generated string back to the same structure
   // expect(reparsedJson).toEqual(dsnJson)
 })
+
+test("stringify parsed pcb without parser section", () => {
+  const dsnWithoutParser = testDsnFile.replace(
+    /\n {2}\(parser[\s\S]*?\n {2}\)\n(?= {2}\(resolution)/,
+    "\n",
+  )
+  const dsnJson = parseDsnToDsnJson(dsnWithoutParser) as DsnPcb
+  const dsnString = stringifyDsnJson(dsnJson)
+  const reparsedJson = parseDsnToDsnJson(dsnString) as DsnPcb
+
+  expect(dsnString).not.toContain("\n  (parser")
+  expect("parser" in reparsedJson).toBe(false)
+
+  for (const key of Object.keys(reparsedJson) as Array<keyof DsnPcb>) {
+    expect(reparsedJson[key]).toEqual(dsnJson[key] as any)
+  }
+})


### PR DESCRIPTION
## Summary
- avoid crashing when a parsed DSN PCB omits the optional top-level `(parser ...)` block
- omit the parser block on stringify when it was absent from the parsed input
- add focused parse -> stringify -> parse coverage for the parserless case

## Verification
- `npx --yes bun@latest test tests/dsn-pcb/stringify-dsn-json.test.ts`
- `npx --yes bun@latest x biome check lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts tests/dsn-pcb/stringify-dsn-json.test.ts`
- `git diff --check`

/claim #54


Fixes #54
