### PR TITLE
fix: make wiring via ids unique

### DIFF
--- a/lib/dsn-pcb/dsn-json-to-circuit-json/dsn-component-converters/convert-wiring-via-to-pcb-vias.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/dsn-component-converters/convert-wiring-via-to-pcb-vias.ts
@@ -22,12 +22,16 @@ export const convertWiringViaToPcbVias = ({
   const [x, y] = wire.path.coordinates
   const circuitPoint = applyToPoint(transformUmToMm, { x, y })
 
+  const xMm = Number(circuitPoint.x.toFixed(4))
+  const yMm = Number(circuitPoint.y.toFixed(4))
+
   const via: PcbVia = {
     type: "pcb_via",
     layers: ["top", "bottom"],
-    pcb_via_id: `pcb_via_${netName}`,
-    x: Number(circuitPoint.x.toFixed(4)),
-    y: Number(circuitPoint.y.toFixed(4)),
+    pcb_via_id: `pcb_via_${netName}_${xMm}_${yMm}`,
+    pcb_trace_id: `pcb_trace_${netName}`,
+    x: xMm,
+    y: yMm,
     // TODO look up via size
     outer_diameter: 0.6, // Standard via diameter in mm
     hole_diameter: 0.3, // Standard drill diameter in mm

--- a/tests/repros/repro7-smoothie-board.test.ts
+++ b/tests/repros/repro7-smoothie-board.test.ts
@@ -11,6 +11,18 @@ test("smoothieboard repro", async () => {
   const dsnJson = parseDsnToDsnJson(dsnFileWithFreeroutingTrace) as DsnPcb
 
   const circuitJson = convertDsnPcbToCircuitJson(dsnJson)
+  const smoothieVias = circuitJson.filter(
+    (element) => element.type === "pcb_via",
+  )
+
+  expect(smoothieVias).toHaveLength(42)
+  expect(new Set(smoothieVias.map((via) => via.pcb_via_id)).size).toBe(
+    smoothieVias.length,
+  )
+  expect(new Set(smoothieVias.map((via) => via.pcb_trace_id)).size).toBe(1)
+  expect(
+    smoothieVias.every((via) => via.pcb_trace_id === "pcb_trace_AGND"),
+  ).toBe(true)
 
   expect(convertCircuitJsonToPcbSvg(circuitJson)).toMatchSvgSnapshot(
     import.meta.path,


### PR DESCRIPTION
## Summary

Fixes an incremental Smoothieboard DSN conversion issue from #54: wiring vias that share the same net were all emitted with the same `pcb_via_id`.

For the Smoothieboard repro, the 42 AGND vias now retain distinct Circuit JSON identities by including their converted coordinates in the via ID. The converter also attaches the via to the net trace with `pcb_trace_id`, matching the existing session via conversion helper behavior.

/claim #54

## Changes

- Generate wiring via IDs as `pcb_via_${netName}_${xMm}_${yMm}` instead of only `pcb_via_${netName}`.
- Add `pcb_trace_id: pcb_trace_${netName}` for wiring vias.
- Extend the Smoothieboard repro test to assert:
  - 42 vias are generated
  - every via ID is unique
  - vias are linked to the AGND trace

## Verification

- `bun test tests/repros/repro7-smoothie-board.test.ts --preload ./tests/fixtures/preload.ts`
- `bun test --preload ./tests/fixtures/preload.ts` — 47 pass, 1 skip, 0 fail
- `bun run build`

Note: `bun run format:check` currently reports pre-existing formatting issues under generated `debug-files/*` JSON files after the test run; the changed source/test files were formatted directly with Biome.
