### PR TITLE
Preserve DSN session network vias

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-session.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-session.ts
@@ -66,6 +66,9 @@ export const stringifyDsnSession = (session: DsnSession): string => {
         result += `${indent}${indent}${indent}${indent})\n`
       }
     })
+    net.vias?.forEach((via) => {
+      result += `${indent}${indent}${indent}${indent}(via ${JSON.stringify(via.padstack_name ?? "")} ${via.x} ${via.y})\n`
+    })
     result += `${indent}${indent}${indent})\n`
   })
   result += `${indent}${indent})\n`

--- a/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
@@ -1133,6 +1133,10 @@ function processSessionNode(ast: ASTNode): DsnSession {
             type: "route",
           })),
           vias: viaNodes.map((viaNode) => ({
+            padstack_name:
+              viaNode.children![1].type === "Atom"
+                ? String(viaNode.children![1].value)
+                : undefined,
             x: viaNode.children![2].value as number,
             y: viaNode.children![3].value as number,
           })),

--- a/lib/dsn-pcb/types.ts
+++ b/lib/dsn-pcb/types.ts
@@ -285,6 +285,7 @@ export interface Wire {
 }
 
 export interface Via {
+  padstack_name?: string
   x: number
   y: number
 }

--- a/tests/dsn-pcb/stringify-dsn-session.test.ts
+++ b/tests/dsn-pcb/stringify-dsn-session.test.ts
@@ -25,3 +25,50 @@ test("stringify session file", () => {
   expect(reparsedNet.name).toBe(originalNet.name)
   expect(reparsedNet.wires).toHaveLength(originalNet.wires.length)
 })
+
+test("stringify session preserves network vias", () => {
+  const sessionWithVia = `(session routed
+  (base_design routed)
+  (placement
+    (resolution um 10)
+  )
+  (routes
+    (resolution um 10)
+    (parser
+      (host_cad "KiCad's Pcbnew")
+      (host_version "8.0")
+    )
+    (library_out
+      (padstack "Via[0-1]_600:300_um"
+        (shape
+          (circle F.Cu 600 0 0)
+        )
+        (shape
+          (circle B.Cu 600 0 0)
+        )
+        (attach off)
+      )
+    )
+    (network_out
+      (net "N1"
+        (wire
+          (path F.Cu 200
+            0 0
+            1250 -2500
+          )
+        )
+        (via "Via[0-1]_600:300_um" 1250 -2500)
+      )
+    )
+  )
+)`
+
+  const parsed = parseDsnToDsnJson(sessionWithVia) as DsnSession
+  const stringified = stringifyDsnSession(parsed)
+  const reparsed = parseDsnToDsnJson(stringified) as DsnSession
+
+  expect(stringified).toContain('(via "Via[0-1]_600:300_um" 1250 -2500)')
+  expect(reparsed.routes.network_out.nets[0].vias).toEqual(
+    parsed.routes.network_out.nets[0].vias,
+  )
+})


### PR DESCRIPTION
/claim #54

## Summary

This PR fixes a focused DSN session round-trip gap: `parseDsnToDsnJson` already reads `network_out` via records from session files, but `stringifyDsnSession` dropped those vias when writing the session back out.

Changes:

- Preserve the session via padstack name while parsing `network_out` vias.
- Emit session `network_out` vias in `stringifyDsnSession`.
- Add focused round-trip coverage proving parsed session vias survive parse -> stringify -> parse.

## Verification

- `npx --yes bun install`
- `npx --yes bun test tests/dsn-pcb/stringify-dsn-session.test.ts`
- `npx --yes bun test tests/dsn-pcb/stringify-dsn-session.test.ts tests/dsn-pcb/parse-session-file.test.ts tests/dsn-pcb/convert-session-to-circuit-json.test.ts`
- `npx --yes bun run build`
- `npx biome format lib/dsn-pcb/types.ts lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-session.ts tests/dsn-pcb/stringify-dsn-session.test.ts`
- `git diff --check`

## Scope

This stays limited to DSN session via round-tripping. It does not change PCB DSN stringification or Circuit JSON conversion behavior.
