### PR TITLE
Preserve DSN structure grid descriptors

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
@@ -57,6 +57,9 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
     result += `${indent}${indent})\n`
   }
   result += `${indent}${indent}(via ${stringifyValue(dsnJson.structure.via)})\n`
+  dsnJson.structure.grids?.forEach((grid) => {
+    result += `${indent}${indent}(grid ${grid.kind} ${grid.value})\n`
+  })
   result += `${indent}${indent}(rule\n`
   result += `${indent}${indent}${indent}(width ${dsnJson.structure.rule.width})\n`
   dsnJson.structure.rule.clearances.forEach((clearance) => {

--- a/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
@@ -17,6 +17,7 @@ import type {
   DsnJson,
   DsnPcb,
   DsnSession,
+  Grid,
   Image,
   Layer,
   Library,
@@ -211,6 +212,7 @@ export function processResolution(nodes: ASTNode[]): Resolution {
 export function processStructure(nodes: ASTNode[]): Structure {
   const structure: Partial<Structure> = {
     layers: [],
+    grids: [],
   }
 
   nodes.forEach((node) => {
@@ -224,6 +226,9 @@ export function processStructure(nodes: ASTNode[]): Structure {
             break
           case "boundary":
             structure.boundary = processBoundary(node.children!.slice(1))
+            break
+          case "grid":
+            structure.grids!.push(processGrid(node.children!))
             break
           case "via":
             if (
@@ -242,6 +247,22 @@ export function processStructure(nodes: ASTNode[]): Structure {
   })
 
   return structure as Structure
+}
+
+function processGrid(nodes: ASTNode[]): Grid {
+  if (
+    nodes[1]?.type === "Atom" &&
+    typeof nodes[1].value === "string" &&
+    nodes[2]?.type === "Atom" &&
+    typeof nodes[2].value === "number"
+  ) {
+    return {
+      kind: nodes[1].value,
+      value: nodes[2].value,
+    }
+  }
+
+  throw new Error("Invalid grid format")
 }
 
 function processLayer(nodes: ASTNode[]): Layer {

--- a/lib/dsn-pcb/types.ts
+++ b/lib/dsn-pcb/types.ts
@@ -23,6 +23,7 @@ export interface DsnPcb {
         index: number
       }
     }>
+    grids?: Grid[]
     boundary: {
       path: {
         layer: string
@@ -109,9 +110,15 @@ export interface Resolution {
 
 export interface Structure {
   layers: Layer[]
+  grids?: Grid[]
   boundary: Boundary
   via: string
   rule: Rule
+}
+
+export interface Grid {
+  kind: string
+  value: number
 }
 
 export interface Layer {

--- a/tests/dsn-pcb/dsn-structure-grid.test.ts
+++ b/tests/dsn-pcb/dsn-structure-grid.test.ts
@@ -1,0 +1,50 @@
+import { expect, test } from "bun:test"
+import { type DsnPcb, parseDsnToDsnJson, stringifyDsnJson } from "lib"
+
+test("preserves structure grid descriptors", () => {
+  const dsn = `(pcb grid-test
+  (parser
+    (string_quote quote)
+    (space_in_quoted_tokens on)
+    (host_cad "test")
+    (host_version "1")
+  )
+  (resolution um 10)
+  (unit um)
+  (structure
+    (layer F.Cu
+      (type signal)
+      (property
+        (index 0)
+      )
+    )
+    (boundary
+      (path pcb 0 0 0 1000 0 1000 1000 0 1000 0 0)
+    )
+    (via Via[0-1])
+    (grid via 1)
+    (grid wire 5)
+    (rule
+      (width 100)
+      (clearance 100)
+    )
+  )
+  (placement)
+  (library)
+  (network)
+  (wiring)
+)`
+
+  const dsnJson = parseDsnToDsnJson(dsn) as DsnPcb
+  expect(dsnJson.structure.grids).toEqual([
+    { kind: "via", value: 1 },
+    { kind: "wire", value: 5 },
+  ])
+
+  const stringified = stringifyDsnJson(dsnJson)
+  expect(stringified).toContain("(grid via 1)")
+  expect(stringified).toContain("(grid wire 5)")
+
+  const reparsed = parseDsnToDsnJson(stringified) as DsnPcb
+  expect(reparsed.structure.grids).toEqual(dsnJson.structure.grids)
+})


### PR DESCRIPTION
## Summary
- Preserve DSN structure `(grid ...)` descriptors in the parsed DSN JSON model.
- Emit preserved structure grids from `stringifyDsnJson`.
- Add focused parse -> stringify -> parse coverage for `(grid via ...)` and `(grid wire ...)`.

## Scope
This is limited to DSN PCB structure metadata round-tripping. It does not change Circuit JSON conversion, routing, placement, session, or geometry behavior.

## Bounty
/claim #54

## Verification
- `npx --yes bun test tests/dsn-pcb/dsn-structure-grid.test.ts`
- `npx --yes bun test tests/dsn-pcb/stringify-dsn-json.test.ts tests/dsn-pcb/dsn-structure-grid.test.ts`
- `npx --yes bun test`
- `npx --yes bun x biome check lib/dsn-pcb/types.ts lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts tests/dsn-pcb/dsn-structure-grid.test.ts`
- `npx --yes bun x tsc --noEmit`
- `npx --yes bun run build`
- `git diff --check`

Transparency note: AI-assisted with Codex; I reviewed the diff and local verification before submitting.