### PR TITLE
Preserve DSN structure keepouts

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
@@ -26,6 +26,22 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
     return `${padding}(path ${path.layer} ${path.width}  ${stringifyCoordinates(path.coordinates)})`
   }
 
+  const stringifyBareShape = (shape: any): string => {
+    if (shape.shapeType === "polygon") {
+      return `(polygon ${shape.layer} ${shape.width} ${stringifyCoordinates(shape.coordinates)})`
+    }
+    if (shape.shapeType === "circle") {
+      return `(circle ${shape.layer} ${shape.diameter})`
+    }
+    if (shape.shapeType === "path") {
+      return `(path ${shape.layer} ${shape.width} ${stringifyCoordinates(shape.coordinates)})`
+    }
+    if (shape.shapeType === "rect") {
+      return `(rect ${shape.layer} ${stringifyCoordinates(shape.coordinates)})`
+    }
+    throw new Error(`Unsupported shape type: ${shape.shapeType}`)
+  }
+
   // Start with pcb
   result += `(pcb ${dsnJson.filename ? dsnJson.filename : "./converted_dsn.dsn"}\n`
 
@@ -57,6 +73,9 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
     result += `${indent}${indent})\n`
   }
   result += `${indent}${indent}(via ${stringifyValue(dsnJson.structure.via)})\n`
+  dsnJson.structure.keepouts?.forEach((keepout) => {
+    result += `${indent}${indent}(${keepout.kind} ${stringifyBareShape(keepout.shape)})\n`
+  })
   result += `${indent}${indent}(rule\n`
   result += `${indent}${indent}${indent}(width ${dsnJson.structure.rule.width})\n`
   dsnJson.structure.rule.clearances.forEach((clearance) => {

--- a/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
@@ -36,6 +36,7 @@ import type {
   Rule,
   Shape,
   Structure,
+  StructureKeepout,
   Wire,
   Wiring,
 } from "../types"
@@ -211,6 +212,7 @@ export function processResolution(nodes: ASTNode[]): Resolution {
 export function processStructure(nodes: ASTNode[]): Structure {
   const structure: Partial<Structure> = {
     layers: [],
+    keepouts: [],
   }
 
   nodes.forEach((node) => {
@@ -224,6 +226,14 @@ export function processStructure(nodes: ASTNode[]): Structure {
             break
           case "boundary":
             structure.boundary = processBoundary(node.children!.slice(1))
+            break
+          case "keepout":
+          case "via_keepout":
+          case "wire_keepout":
+          case "place_keepout":
+            structure.keepouts!.push(
+              processStructureKeepout(key, node.children!),
+            )
             break
           case "via":
             if (
@@ -242,6 +252,44 @@ export function processStructure(nodes: ASTNode[]): Structure {
   })
 
   return structure as Structure
+}
+
+function processStructureKeepout(
+  kind: string,
+  nodes: ASTNode[],
+): StructureKeepout {
+  const shapeNode = nodes.slice(1).find((node) => node.type === "List")
+  if (!shapeNode?.children) {
+    throw new Error("Invalid structure keepout format")
+  }
+
+  return {
+    kind,
+    shape: processBareShape(shapeNode.children),
+  }
+}
+
+function processBareShape(nodes: ASTNode[]): Shape {
+  const shapeTypeNode = nodes[0]
+  if (
+    shapeTypeNode.type !== "Atom" ||
+    typeof shapeTypeNode.value !== "string"
+  ) {
+    throw new Error("Invalid shape format")
+  }
+
+  switch (shapeTypeNode.value) {
+    case "polygon":
+      return processPolygonShape(nodes)
+    case "circle":
+      return processCircleShape(nodes)
+    case "rect":
+      return processRectShape(nodes)
+    case "path":
+      return processPathShape(nodes)
+  }
+
+  throw new Error(`Unknown shape type: ${shapeTypeNode.value}`)
 }
 
 function processLayer(nodes: ASTNode[]): Layer {

--- a/lib/dsn-pcb/types.ts
+++ b/lib/dsn-pcb/types.ts
@@ -23,6 +23,7 @@ export interface DsnPcb {
         index: number
       }
     }>
+    keepouts?: StructureKeepout[]
     boundary: {
       path: {
         layer: string
@@ -109,9 +110,15 @@ export interface Resolution {
 
 export interface Structure {
   layers: Layer[]
+  keepouts?: StructureKeepout[]
   boundary: Boundary
   via: string
   rule: Rule
+}
+
+export interface StructureKeepout {
+  kind: string
+  shape: Shape
 }
 
 export interface Layer {

--- a/tests/dsn-pcb/dsn-structure-keepout.test.ts
+++ b/tests/dsn-pcb/dsn-structure-keepout.test.ts
@@ -1,0 +1,64 @@
+import { expect, test } from "bun:test"
+import { type DsnPcb, parseDsnToDsnJson, stringifyDsnJson } from "lib"
+
+test("preserves structure keepout descriptors", () => {
+  const dsn = `(pcb keepout-test
+  (parser
+    (string_quote quote)
+    (space_in_quoted_tokens on)
+    (host_cad "test")
+    (host_version "1")
+  )
+  (resolution um 10)
+  (unit um)
+  (structure
+    (layer F.Cu
+      (type signal)
+      (property
+        (index 0)
+      )
+    )
+    (boundary
+      (path pcb 0 0 0 1000 0 1000 1000 0 1000 0 0)
+    )
+    (via Via[0-1])
+    (keepout (rect signal 10 20 30 40))
+    (via_keepout (rect signal 50 60 70 80))
+    (rule
+      (width 100)
+      (clearance 100)
+    )
+  )
+  (placement)
+  (library)
+  (network)
+  (wiring)
+)`
+
+  const dsnJson = parseDsnToDsnJson(dsn) as DsnPcb
+  expect(dsnJson.structure.keepouts).toEqual([
+    {
+      kind: "keepout",
+      shape: {
+        shapeType: "rect",
+        layer: "signal",
+        coordinates: [10, 20, 30, 40],
+      },
+    },
+    {
+      kind: "via_keepout",
+      shape: {
+        shapeType: "rect",
+        layer: "signal",
+        coordinates: [50, 60, 70, 80],
+      },
+    },
+  ])
+
+  const stringified = stringifyDsnJson(dsnJson)
+  expect(stringified).toContain("(keepout (rect signal 10 20 30 40))")
+  expect(stringified).toContain("(via_keepout (rect signal 50 60 70 80))")
+
+  const reparsed = parseDsnToDsnJson(stringified) as DsnPcb
+  expect(reparsed.structure.keepouts).toEqual(dsnJson.structure.keepouts)
+})


### PR DESCRIPTION
## Summary
- Preserve DSN structure-level keepout descriptors in the parsed DSN JSON model.
- Emit preserved `(keepout ...)` and `(via_keepout ...)` descriptors from `stringifyDsnJson`.
- Add focused parse -> stringify -> parse coverage for rect keepout/via_keepout records.

## Scope
This is limited to DSN PCB structure metadata round-tripping. It does not change Circuit JSON conversion, image keepouts, routing, placement, session, or geometry conversion behavior.

## Bounty
/claim #54

## Verification
- `npx --yes bun test tests/dsn-pcb/dsn-structure-keepout.test.ts`
- `npx --yes bun test tests/dsn-pcb/stringify-dsn-json.test.ts tests/dsn-pcb/dsn-structure-keepout.test.ts`
- `npx --yes bun test`
- `npx --yes bun x biome check lib/dsn-pcb/types.ts lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts tests/dsn-pcb/dsn-structure-keepout.test.ts`
- `npx --yes bun x tsc --noEmit`
- `npx --yes bun run build`
- `git diff --check`

Transparency note: AI-assisted with Codex; I reviewed the diff and local verification before submitting.