### PR TITLE
Fix DSN parser handling of bare string_quote token

### DIFF
--- a/lib/common/parse-sexpr.ts
+++ b/lib/common/parse-sexpr.ts
@@ -26,6 +26,12 @@ export function tokenizeDsn(input: string): Token[] {
       // Ignore whitespace
       i++
     } else if (char === '"') {
+      if (i + 1 >= length || input[i + 1] === ")") {
+        tokens.push({ type: "String", value: '"' })
+        i++
+        continue
+      }
+
       // Parse quoted string
       let value = ""
       i++ // Skip the opening quote

--- a/lib/common/parse-sexpr.ts
+++ b/lib/common/parse-sexpr.ts
@@ -26,7 +26,17 @@ export function tokenizeDsn(input: string): Token[] {
       // Ignore whitespace
       i++
     } else if (char === '"') {
-      if (i + 1 >= length || input[i + 1] === ")") {
+      let nextNonWhitespace = i + 1
+      while (
+        nextNonWhitespace < length &&
+        /\s/.test(input[nextNonWhitespace])
+      ) {
+        nextNonWhitespace++
+      }
+      if (
+        nextNonWhitespace >= length ||
+        input[nextNonWhitespace] === ")"
+      ) {
         tokens.push({ type: "String", value: '"' })
         i++
         continue

--- a/lib/common/parse-sexpr.ts
+++ b/lib/common/parse-sexpr.ts
@@ -33,10 +33,7 @@ export function tokenizeDsn(input: string): Token[] {
       ) {
         nextNonWhitespace++
       }
-      if (
-        nextNonWhitespace >= length ||
-        input[nextNonWhitespace] === ")"
-      ) {
+      if (nextNonWhitespace >= length || input[nextNonWhitespace] === ")") {
         tokens.push({ type: "String", value: '"' })
         i++
         continue

--- a/tests/common/parse-sexpr.test.ts
+++ b/tests/common/parse-sexpr.test.ts
@@ -1,0 +1,17 @@
+import { expect, test } from "bun:test"
+import { parseSexprToAst, tokenizeDsn } from "../../lib/common/parse-sexpr"
+
+test("tokenizes a bare DSN quote value without swallowing following content", () => {
+  const ast = parseSexprToAst(tokenizeDsn('(parser (string_quote "))'))
+
+  expect(ast.children?.[1]?.children?.[0]?.value).toBe("string_quote")
+  expect(ast.children?.[1]?.children?.[1]?.value).toBe('"')
+})
+
+test("preserves quoted strings that begin with whitespace", () => {
+  const ast = parseSexprToAst(tokenizeDsn('(net " GND" 1)'))
+
+  expect(ast.children?.[0]?.value).toBe("net")
+  expect(ast.children?.[1]?.value).toBe(" GND")
+  expect(ast.children?.[2]?.value).toBe(1)
+})

--- a/tests/common/parse-sexpr.test.ts
+++ b/tests/common/parse-sexpr.test.ts
@@ -8,6 +8,13 @@ test("tokenizes a bare DSN quote value without swallowing following content", ()
   expect(ast.children?.[1]?.children?.[1]?.value).toBe('"')
 })
 
+test("tokenizes a whitespace-separated bare DSN quote value", () => {
+  const ast = parseSexprToAst(tokenizeDsn('(parser (string_quote " ))'))
+
+  expect(ast.children?.[1]?.children?.[0]?.value).toBe("string_quote")
+  expect(ast.children?.[1]?.children?.[1]?.value).toBe('"')
+})
+
 test("preserves quoted strings that begin with whitespace", () => {
   const ast = parseSexprToAst(tokenizeDsn('(net " GND" 1)'))
 

--- a/tests/fixtures/get-test-debug-utils.ts
+++ b/tests/fixtures/get-test-debug-utils.ts
@@ -1,4 +1,5 @@
-import { mkdirSync } from "node:fs"
+import { mkdirSync, writeFileSync } from "node:fs"
+import { join } from "node:path"
 import Debug from "debug"
 
 /**
@@ -18,15 +19,17 @@ import Debug from "debug"
  * )
  */
 export const getTestDebugUtils = (testPath: string) => {
-  const testFileDir = testPath.split("/").pop()?.split(".")[0]
-  mkdirSync(`./debug-files/${testFileDir}`, { recursive: true })
+  const testFileName = testPath.split(/[\\/]/).pop() ?? "unknown-test"
+  const testFileDir = testFileName.split(".")[0] ?? "unknown-test"
+  const debugDir = join(".", "debug-files", testFileDir)
+  mkdirSync(debugDir, { recursive: true })
   return {
     debug: Debug(`dsn-converter:${testFileDir}`),
     writeDebugFile: (name: string, content: string) => {
-      Bun.write(`./debug-files/${testFileDir}/${name}`, content)
+      writeFileSync(join(debugDir, name), content)
     },
     getDebugFilePath: (name: string) => {
-      return `./debug-files/${testFileDir}/${name}`
+      return join(debugDir, name)
     },
   }
 }


### PR DESCRIPTION
## Summary
- Handle SPECCTRA DSN parser declarations like `(string_quote ")` as a bare quote token instead of consuming the following file content as an unterminated quoted string.
- Make the debug-file helper path-safe on Windows and write files synchronously so image comparison tests can read generated output immediately.

## Context
This came up while checking #54 / the Smoothie Board conversion path. It fixes a parser/test blocker without changing the existing Smoothie repro behavior.

## Test plan
- `npx --yes bun test`
- `npx --yes bun run build`
- `./node_modules/.bin/biome format lib/common/parse-sexpr.ts tests/fixtures/get-test-debug-utils.ts`
- `git diff --check`

If this contribution was useful and you'd like to support the work, tips are welcome here: https://buymeacoffee.com/domenglands

/claim #54

Claim scope: this PR fixes the parser/test blocker described above while checking #54; it does not claim the full Smoothie conversion is complete.