### PR TITLE
Align imported bottom pad port layers

### DIFF
--- a/lib/dsn-pcb/dsn-json-to-circuit-json/dsn-component-converters/convert-dsn-pcb-components-to-source-components-and-ports.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/dsn-component-converters/convert-dsn-pcb-components-to-source-components-and-ports.ts
@@ -2,6 +2,25 @@ import type { AnySourceComponent, PcbPort, SourcePort } from "circuit-json"
 import type { DsnPcb, Image, Pin } from "lib/dsn-pcb/types"
 import { type Matrix, applyToPoint } from "transformation-matrix"
 
+function getPcbPortLayersForPin({
+  dsnPcb,
+  pin,
+  side,
+}: {
+  dsnPcb: DsnPcb
+  pin: Pin
+  side: string
+}): Array<"top" | "bottom"> {
+  const padstack = dsnPcb.library.padstacks.find(
+    (p) => p.name === pin.padstack_name,
+  )
+  const layerName = padstack?.shapes[0]?.layer.toLowerCase() ?? ""
+  if (layerName.startsWith("b.") || layerName === "bottom") {
+    return ["bottom"]
+  }
+  return [side === "back" ? "bottom" : "top"]
+}
+
 export const convertDsnPcbComponentsToSourceComponentsAndPorts = ({
   dsnPcb,
   transformDsnUnitToMm,
@@ -55,7 +74,11 @@ export const convertDsnPcbComponentsToSourceComponentsAndPorts = ({
             pcb_component_id: component.name,
             x: pcb_port_center.x,
             y: pcb_port_center.y,
-            layers: [place.side === "back" ? "bottom" : "top"],
+            layers: getPcbPortLayersForPin({
+              dsnPcb,
+              pin,
+              side: place.side,
+            }),
           }
           result.push(port, pcb_port)
         }

--- a/tests/dsn-pcb/bottom-padstack-port-layer.test.ts
+++ b/tests/dsn-pcb/bottom-padstack-port-layer.test.ts
@@ -1,0 +1,74 @@
+import { expect, test } from "bun:test"
+import { type DsnPcb, convertDsnPcbToCircuitJson, parseDsnToDsnJson } from "lib"
+
+test("imports B.Cu padstack pins with matching bottom PCB port layers", () => {
+  const dsn = `(pcb "bottom-pad-port.dsn"
+  (parser
+    (string_quote ")
+    (space_in_quoted_tokens on)
+    (host_cad "KiCad's Pcbnew")
+    (host_version "8.0")
+  )
+  (resolution um 10)
+  (unit um)
+  (structure
+    (layer F.Cu
+      (type signal)
+      (property
+        (index 0)
+      )
+    )
+    (layer B.Cu
+      (type signal)
+      (property
+        (index 1)
+      )
+    )
+    (boundary
+      (path pcb 0 -1000 -1000 1000 -1000 1000 1000 -1000 1000 -1000 -1000)
+    )
+    (via "Via[0-1]_600:300_um")
+    (rule
+      (width 100)
+      (clearance 100)
+    )
+  )
+  (placement
+    (component "BottomPadComp"
+      (place U1 0 0 front 0 (PN "TEST"))
+    )
+  )
+  (library
+    (image "BottomPadComp"
+      (pin "BottomRect" 1 0 0)
+    )
+    (padstack "BottomRect"
+      (shape (rect B.Cu -100 -50 100 50))
+      (attach off)
+    )
+  )
+  (network
+    (net "Net-(U1-Pad1)"
+      (pins U1-1)
+    )
+    (class "kicad_default" "" "Net-(U1-Pad1)"
+      (circuit
+        (use_via "Via[0-1]_600:300_um")
+      )
+      (rule
+        (width 100)
+        (clearance 100)
+      )
+    )
+  )
+  (wiring)
+)`
+
+  const dsnJson = parseDsnToDsnJson(dsn) as DsnPcb
+  const circuitJson = convertDsnPcbToCircuitJson(dsnJson)
+  const pcbSmtpad = circuitJson.find((element) => element.type === "pcb_smtpad")
+  const pcbPort = circuitJson.find((element) => element.type === "pcb_port")
+
+  expect(pcbSmtpad?.layer).toBe("bottom")
+  expect(pcbPort?.layers).toEqual(["bottom"])
+})


### PR DESCRIPTION
Summary
- Derive imported PCB port layers from the referenced padstack shape when that shape is explicitly on B.Cu/Bottom.
- Keep the existing placement-side fallback for side-only padstacks.
- Add focused DSN -> Circuit JSON coverage proving a front-side component with a B.Cu rectangular padstack emits both the SMT pad and PCB port on bottom.

/claim #54

Verification
- bun test tests/dsn-pcb/bottom-padstack-port-layer.test.ts
- bunx biome check lib/dsn-pcb/dsn-json-to-circuit-json/dsn-component-converters/convert-dsn-pcb-components-to-source-components-and-ports.ts tests/dsn-pcb/bottom-padstack-port-layer.test.ts
- bunx tsc --noEmit
- bun run build
- bun test
- git diff --check

Transparency note: AI-assisted with Codex; I reviewed the diff and verified it locally before submission.