### PR TITLE
Fix DSN string_quote token parsing

### DIFF
--- a/lib/common/parse-sexpr.ts
+++ b/lib/common/parse-sexpr.ts
@@ -25,6 +25,9 @@ export function tokenizeDsn(input: string): Token[] {
     } else if (/\s/.test(char)) {
       // Ignore whitespace
       i++
+    } else if (char === '"' && input[i + 1] === ")") {
+      tokens.push({ type: "String", value: '"' })
+      i++
     } else if (char === '"') {
       // Parse quoted string
       let value = ""

--- a/tests/dsn-pcb/stringify-dsn-json.test.ts
+++ b/tests/dsn-pcb/stringify-dsn-json.test.ts
@@ -7,6 +7,13 @@ import testDsnFile from "../assets/testkicadproject/testkicadproject.dsn" with {
 
 test("stringify dsn json", () => {
   const dsnJson = parseDsnToDsnJson(testDsnFile) as DsnPcb
+  expect(dsnJson.parser).toEqual({
+    string_quote: '"',
+    space_in_quoted_tokens: "on",
+    host_cad: "KiCad's Pcbnew",
+    host_version: "8.0.3",
+  })
+
   const dsnString = stringifyDsnJson(dsnJson)
   const reparsedJson = parseDsnToDsnJson(dsnString) as DsnPcb
 


### PR DESCRIPTION
## Summary
- Handle DSN parser declarations like `(string_quote ")` as a standalone quote token instead of starting a quoted string.
- Add coverage that verifies parser metadata round-trips correctly.

## Context
This affects KiCad/Freerouting DSN files such as the Smoothie Board repro in #54. Before this change, `string_quote` swallowed the following parser fields into one string and left `space_in_quoted_tokens` / `host_cad` unset.

## Tests
- `npx --yes bun test tests/dsn-pcb/stringify-dsn-json.test.ts tests/repros/repro7-smoothie-board.test.ts`
- `npx --yes @biomejs/biome format lib/common/parse-sexpr.ts tests/dsn-pcb/stringify-dsn-json.test.ts`
- `npx --yes tsc --noEmit`

Full `npx --yes bun test` passes 45 tests and skips 1, but still fails 2 existing Windows-only debug path cases in `tests/fixtures/get-test-debug-utils.ts` where `testPath.split("/")` does not handle Windows paths.

Refs #54.