### PR TITLE
Preserve session placement status

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-session.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-session.ts
@@ -16,7 +16,8 @@ export const stringifyDsnSession = (session: DsnSession): string => {
   session.placement.components.forEach((component) => {
     result += `${indent}${indent}(component ${component.name}\n`
     component.places.forEach((place) => {
-      result += `${indent}${indent}${indent}(place ${place.refdes} ${place.x} ${place.y} ${place.side} ${place.rotation})\n`
+      const status = place.status ? ` (status ${place.status})` : ""
+      result += `${indent}${indent}${indent}(place ${place.refdes} ${place.x} ${place.y} ${place.side} ${place.rotation}${status})\n`
     })
     result += `${indent}${indent})\n`
   })

--- a/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
@@ -493,6 +493,22 @@ function processPlace(nodes: ASTNode[]): Places {
     }
   }
 
+  // Process optional placement status descriptors used in session files.
+  for (let i = coordIndex + 4; i < nodes.length; i++) {
+    const node = nodes[i]
+    if (
+      node.type === "List" &&
+      node.children &&
+      node.children[0].type === "Atom" &&
+      node.children[0].value === "status" &&
+      node.children[1] &&
+      node.children[1].type === "Atom"
+    ) {
+      places.status = String(node.children[1].value)
+      break
+    }
+  }
+
   // Set default values if not present
   places.PN = places.PN || ""
   places.side = places.side || "front"

--- a/lib/dsn-pcb/types.ts
+++ b/lib/dsn-pcb/types.ts
@@ -92,6 +92,7 @@ export interface ComponentPlacement {
     y: number
     side: "front" | "back"
     rotation: number
+    status?: string
   }>
 }
 
@@ -171,6 +172,7 @@ export interface Places {
   side: string
   rotation: number
   PN: string
+  status?: string
 }
 
 export interface Library {

--- a/tests/dsn-pcb/session-placement-status.test.ts
+++ b/tests/dsn-pcb/session-placement-status.test.ts
@@ -1,0 +1,38 @@
+import { expect, test } from "bun:test"
+import { type DsnSession, parseDsnToDsnJson, stringifyDsnSession } from "lib"
+
+test("preserves session placement status descriptors", () => {
+  const sessionJson = parseDsnToDsnJson(`(session routed-board
+  (base_design board.dsn)
+  (placement
+    (resolution um 10)
+    (component R_0603
+      (place R1 100 200 front 0 (status added))
+      (place R2 300 400 back 90 (status substituted))
+    )
+  )
+  (routes
+    (resolution um 10)
+    (parser
+      (host_cad "Freerouting")
+      (host_version "1.9.0")
+    )
+    (network_out
+      (net GND)
+    )
+  )
+)`) as DsnSession
+
+  const places = sessionJson.placement.components[0].places
+  expect(places[0].status).toBe("added")
+  expect(places[1].status).toBe("substituted")
+
+  const stringified = stringifyDsnSession(sessionJson)
+  expect(stringified).toContain("(status added)")
+  expect(stringified).toContain("(status substituted)")
+
+  const reparsed = parseDsnToDsnJson(stringified) as DsnSession
+  const reparsedPlaces = reparsed.placement.components[0].places
+  expect(reparsedPlaces[0].status).toBe("added")
+  expect(reparsedPlaces[1].status).toBe("substituted")
+})


### PR DESCRIPTION
Summary
- Preserve optional SPECCTRA session placement status descriptors such as `(status added)` and `(status substituted)` when parsing session placements.
- Emit the preserved status descriptors from `stringifyDsnSession` so session parse -> stringify -> parse keeps placement status metadata.
- Add focused regression coverage for two session placements with distinct status values.

Verification
- bun test tests/dsn-pcb/session-placement-status.test.ts
- bun test
- bunx tsc --noEmit
- bunx biome check lib/dsn-pcb/types.ts lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-session.ts tests/dsn-pcb/session-placement-status.test.ts
- bun run build
- git diff --check

/claim #54

Transparency note: AI-assisted with Codex; I reviewed the diff and verified it locally before submission.