### PR TITLE
Preserve session logical part descriptors

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-session.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-session.ts
@@ -16,7 +16,10 @@ export const stringifyDsnSession = (session: DsnSession): string => {
   session.placement.components.forEach((component) => {
     result += `${indent}${indent}(component ${component.name}\n`
     component.places.forEach((place) => {
-      result += `${indent}${indent}${indent}(place ${place.refdes} ${place.x} ${place.y} ${place.side} ${place.rotation})\n`
+      const logicalPart = place.logical_part
+        ? ` (logical_part ${place.logical_part})`
+        : ""
+      result += `${indent}${indent}${indent}(place ${place.refdes} ${place.x} ${place.y} ${place.side} ${place.rotation}${logicalPart})\n`
     })
     result += `${indent}${indent})\n`
   })

--- a/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
@@ -493,6 +493,22 @@ function processPlace(nodes: ASTNode[]): Places {
     }
   }
 
+  // Process optional logical_part descriptors used in session placement files.
+  for (let i = coordIndex + 4; i < nodes.length; i++) {
+    const node = nodes[i]
+    if (
+      node.type === "List" &&
+      node.children &&
+      node.children[0].type === "Atom" &&
+      node.children[0].value === "logical_part" &&
+      node.children[1] &&
+      node.children[1].type === "Atom"
+    ) {
+      places.logical_part = String(node.children[1].value)
+      break
+    }
+  }
+
   // Set default values if not present
   places.PN = places.PN || ""
   places.side = places.side || "front"

--- a/lib/dsn-pcb/types.ts
+++ b/lib/dsn-pcb/types.ts
@@ -88,6 +88,7 @@ export interface ComponentPlacement {
   places: Array<{
     refdes: string
     PN?: string
+    logical_part?: string
     x: number
     y: number
     side: "front" | "back"
@@ -171,6 +172,7 @@ export interface Places {
   side: string
   rotation: number
   PN: string
+  logical_part?: string
 }
 
 export interface Library {

--- a/tests/dsn-pcb/session-logical-part.test.ts
+++ b/tests/dsn-pcb/session-logical-part.test.ts
@@ -1,0 +1,35 @@
+import { expect, test } from "bun:test"
+import { stringifyDsnSession } from "lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-session"
+import { parseDsnToDsnJson } from "lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json"
+import type { DsnSession } from "lib/dsn-pcb/types"
+
+test("preserves session placement logical_part descriptors", () => {
+  const sessionJson = parseDsnToDsnJson(`(session board
+  (base_design board)
+  (placement
+    (resolution um 10)
+    (component IC_DIP
+      (place U1 100 200 front 0 (logical_part SN54HC688.part))
+      (place U2 300 400 back 90 (logical_part SN54HC139.part))
+    )
+  )
+  (routes
+    (resolution um 10)
+    (parser (host_cad "freerouting") (host_version "1.0"))
+    (network_out)
+  )
+)`) as DsnSession
+
+  const places = sessionJson.placement.components[0].places
+  expect(places[0].logical_part).toBe("SN54HC688.part")
+  expect(places[1].logical_part).toBe("SN54HC139.part")
+
+  const stringified = stringifyDsnSession(sessionJson)
+  expect(stringified).toContain("(logical_part SN54HC688.part)")
+  expect(stringified).toContain("(logical_part SN54HC139.part)")
+
+  const reparsed = parseDsnToDsnJson(stringified) as DsnSession
+  const reparsedPlaces = reparsed.placement.components[0].places
+  expect(reparsedPlaces[0].logical_part).toBe("SN54HC688.part")
+  expect(reparsedPlaces[1].logical_part).toBe("SN54HC139.part")
+})


### PR DESCRIPTION
Summary
- Preserve optional SPECCTRA session placement `(logical_part ...)` descriptors when parsing placement records.
- Emit preserved logical part descriptors from `stringifyDsnSession` so session parse -> stringify -> parse keeps logical-part metadata.
- Add focused regression coverage for two placements with distinct logical part ids.

Verification
- bun test tests/dsn-pcb/session-logical-part.test.ts
- bun test
- bunx tsc --noEmit
- bunx biome check lib/dsn-pcb/types.ts lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-session.ts tests/dsn-pcb/session-logical-part.test.ts
- bun run build
- git diff --check

/claim #54

Transparency note: AI-assisted with Codex; I reviewed the diff and verified it locally before submission.