### PR TITLE
Preserve session placement lock types

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-session.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-session.ts
@@ -16,7 +16,11 @@ export const stringifyDsnSession = (session: DsnSession): string => {
   session.placement.components.forEach((component) => {
     result += `${indent}${indent}(component ${component.name}\n`
     component.places.forEach((place) => {
-      result += `${indent}${indent}${indent}(place ${place.refdes} ${place.x} ${place.y} ${place.side} ${place.rotation})\n`
+      const lockType =
+        place.lock_type && place.lock_type.length > 0
+          ? ` (lock_type ${place.lock_type.join(" ")})`
+          : ""
+      result += `${indent}${indent}${indent}(place ${place.refdes} ${place.x} ${place.y} ${place.side} ${place.rotation}${lockType})\n`
     })
     result += `${indent}${indent})\n`
   })

--- a/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
@@ -493,6 +493,29 @@ function processPlace(nodes: ASTNode[]): Places {
     }
   }
 
+  // Process optional lock_type descriptors used in session placement files.
+  for (let i = coordIndex + 4; i < nodes.length; i++) {
+    const node = nodes[i]
+    if (
+      node.type === "List" &&
+      node.children &&
+      node.children[0].type === "Atom" &&
+      node.children[0].value === "lock_type"
+    ) {
+      const lockTypes = node.children
+        .slice(1)
+        .filter(
+          (child) => child.type === "Atom" && typeof child.value === "string",
+        )
+        .map((child) => String(child.value))
+
+      if (lockTypes.length > 0) {
+        places.lock_type = lockTypes
+      }
+      break
+    }
+  }
+
   // Set default values if not present
   places.PN = places.PN || ""
   places.side = places.side || "front"

--- a/lib/dsn-pcb/types.ts
+++ b/lib/dsn-pcb/types.ts
@@ -88,6 +88,7 @@ export interface ComponentPlacement {
   places: Array<{
     refdes: string
     PN?: string
+    lock_type?: string[]
     x: number
     y: number
     side: "front" | "back"
@@ -171,6 +172,7 @@ export interface Places {
   side: string
   rotation: number
   PN: string
+  lock_type?: string[]
 }
 
 export interface Library {

--- a/tests/dsn-pcb/session-placement-lock-type.test.ts
+++ b/tests/dsn-pcb/session-placement-lock-type.test.ts
@@ -1,0 +1,35 @@
+import { expect, test } from "bun:test"
+import { stringifyDsnSession } from "lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-session"
+import { parseDsnToDsnJson } from "lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json"
+import type { DsnSession } from "lib/dsn-pcb/types"
+
+test("preserves session placement lock_type descriptors", () => {
+  const sessionJson = parseDsnToDsnJson(`(session board
+  (base_design board)
+  (placement
+    (resolution um 10)
+    (component IC_DIP
+      (place U1 100 200 front 0 (lock_type position gate))
+      (place U2 300 400 back 90 (lock_type subgate pin))
+    )
+  )
+  (routes
+    (resolution um 10)
+    (parser (host_cad "freerouting") (host_version "1.0"))
+    (network_out)
+  )
+)`) as DsnSession
+
+  const places = sessionJson.placement.components[0].places
+  expect(places[0].lock_type).toEqual(["position", "gate"])
+  expect(places[1].lock_type).toEqual(["subgate", "pin"])
+
+  const stringified = stringifyDsnSession(sessionJson)
+  expect(stringified).toContain("(lock_type position gate)")
+  expect(stringified).toContain("(lock_type subgate pin)")
+
+  const reparsed = parseDsnToDsnJson(stringified) as DsnSession
+  const reparsedPlaces = reparsed.placement.components[0].places
+  expect(reparsedPlaces[0].lock_type).toEqual(["position", "gate"])
+  expect(reparsedPlaces[1].lock_type).toEqual(["subgate", "pin"])
+})


### PR DESCRIPTION
Summary
- Preserve optional SPECCTRA session placement `(lock_type ...)` descriptors when parsing placement records.
- Emit preserved lock type descriptors from `stringifyDsnSession` so session parse -> stringify -> parse keeps placement lock metadata.
- Add focused regression coverage for two placements with distinct lock type lists.

Verification
- bun test tests/dsn-pcb/session-placement-lock-type.test.ts
- bun test
- bunx tsc --noEmit
- bunx biome check lib/dsn-pcb/types.ts lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-session.ts tests/dsn-pcb/session-placement-lock-type.test.ts
- bun run build
- git diff --check

/claim #54

Transparency note: AI-assisted with Codex; I reviewed the diff and verified it locally before submission.