### PR TITLE
Preserve placement place control

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
@@ -67,6 +67,12 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
 
   // Placement section
   result += `${indent}(placement\n`
+  if (dsnJson.placement.place_control) {
+    const flipStyle = dsnJson.placement.place_control.flip_style
+      ? ` (flip_style ${dsnJson.placement.place_control.flip_style})`
+      : ""
+    result += `${indent}${indent}(place_control${flipStyle})\n`
+  }
   dsnJson.placement.components.forEach((component) => {
     result += `${indent}${indent}(component ${stringifyValue(component.name)}\n`
     if (component.places) {

--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-session.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-session.ts
@@ -13,6 +13,12 @@ export const stringifyDsnSession = (session: DsnSession): string => {
   // Placement section
   result += `${indent}(placement\n`
   result += `${indent}${indent}(resolution ${session.placement.resolution.unit} ${session.placement.resolution.value})\n`
+  if (session.placement.place_control) {
+    const flipStyle = session.placement.place_control.flip_style
+      ? ` (flip_style ${session.placement.place_control.flip_style})`
+      : ""
+    result += `${indent}${indent}(place_control${flipStyle})\n`
+  }
   session.placement.components.forEach((component) => {
     result += `${indent}${indent}(component ${component.name}\n`
     component.places.forEach((place) => {

--- a/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
@@ -28,6 +28,7 @@ import type {
   Path,
   PathShape,
   Pin,
+  PlaceControl,
   Placement,
   Places,
   PolygonShape,
@@ -404,16 +405,33 @@ export function processPlacement(nodes: ASTNode[]): Placement {
   }
 
   nodes.forEach((node) => {
-    if (
-      node.type === "List" &&
-      node.children![0].type === "Atom" &&
-      node.children![0].value === "component"
-    ) {
-      placement.components!.push(processComponent(node.children!))
+    if (node.type === "List" && node.children?.[0].type === "Atom") {
+      if (node.children[0].value === "component") {
+        placement.components!.push(processComponent(node.children))
+      } else if (node.children[0].value === "place_control") {
+        placement.place_control = processPlaceControl(node.children)
+      }
     }
   })
 
   return placement as Placement
+}
+
+function processPlaceControl(nodes: ASTNode[]): PlaceControl {
+  const placeControl: PlaceControl = {}
+
+  for (const node of nodes.slice(1)) {
+    if (
+      node.type === "List" &&
+      node.children?.[0].type === "Atom" &&
+      node.children[0].value === "flip_style" &&
+      node.children[1]?.type === "Atom"
+    ) {
+      placeControl.flip_style = String(node.children[1].value)
+    }
+  }
+
+  return placeControl
 }
 
 function processComponent(nodes: ASTNode[]): ComponentPlacement {
@@ -1060,9 +1078,9 @@ function processSessionNode(ast: ASTNode): DsnSession {
     if (resolutionNode) {
       session.placement.resolution = processResolution(resolutionNode.children!)
     }
-    session.placement.components = processPlacement(
-      placementNode.children!.slice(1),
-    ).components
+    const placement = processPlacement(placementNode.children!.slice(1))
+    session.placement.place_control = placement.place_control
+    session.placement.components = placement.components
   }
 
   // Extract routes section

--- a/lib/dsn-pcb/types.ts
+++ b/lib/dsn-pcb/types.ts
@@ -40,6 +40,7 @@ export interface DsnPcb {
     }
   }
   placement: {
+    place_control?: PlaceControl
     components: Array<ComponentPlacement>
   }
   library: {
@@ -156,7 +157,12 @@ export interface Clearance {
 }
 
 export interface Placement {
+  place_control?: PlaceControl
   components: ComponentPlacement[]
+}
+
+export interface PlaceControl {
+  flip_style?: string
 }
 
 export interface Component {
@@ -295,6 +301,7 @@ export interface DsnSession {
   filename: string
   placement: {
     resolution: Resolution
+    place_control?: PlaceControl
     components: Array<ComponentPlacement>
   }
   routes: {

--- a/tests/dsn-pcb/placement-place-control.test.ts
+++ b/tests/dsn-pcb/placement-place-control.test.ts
@@ -1,0 +1,30 @@
+import { expect, test } from "bun:test"
+import { stringifyDsnSession } from "lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-session"
+import { parseDsnToDsnJson } from "lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json"
+import type { DsnSession } from "lib/dsn-pcb/types"
+
+test("preserves placement place_control flip_style descriptors", () => {
+  const sessionJson = parseDsnToDsnJson(`(session board
+  (base_design board)
+  (placement
+    (resolution um 10)
+    (place_control (flip_style rotate_first))
+    (component R_0603
+      (place R1 100 200 front 0)
+    )
+  )
+  (routes
+    (resolution um 10)
+    (parser (host_cad "freerouting") (host_version "1.0"))
+    (network_out)
+  )
+)`) as DsnSession
+
+  expect(sessionJson.placement.place_control?.flip_style).toBe("rotate_first")
+
+  const stringified = stringifyDsnSession(sessionJson)
+  expect(stringified).toContain("(place_control (flip_style rotate_first))")
+
+  const reparsed = parseDsnToDsnJson(stringified) as DsnSession
+  expect(reparsed.placement.place_control?.flip_style).toBe("rotate_first")
+})


### PR DESCRIPTION
Summary
- Preserve optional SPECCTRA placement `(place_control (flip_style ...))` descriptors when parsing placement sections.
- Emit preserved place_control flip_style metadata from both DSN PCB and session stringifiers.
- Add focused regression coverage proving session parse -> stringify -> parse keeps `rotate_first` flip_style metadata.

Verification
- bun test tests/dsn-pcb/placement-place-control.test.ts
- bun test
- bunx tsc --noEmit
- bunx biome check lib/dsn-pcb/types.ts lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-session.ts tests/dsn-pcb/placement-place-control.test.ts
- bun run build
- git diff --check

/claim #54

Transparency note: AI-assisted with Codex; I reviewed the diff and verified it locally before submission.