### PR TITLE
Preserve placement resolution

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
@@ -67,6 +67,9 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
 
   // Placement section
   result += `${indent}(placement\n`
+  if (dsnJson.placement.resolution) {
+    result += `${indent}${indent}(resolution ${dsnJson.placement.resolution.unit} ${dsnJson.placement.resolution.value})\n`
+  }
   dsnJson.placement.components.forEach((component) => {
     result += `${indent}${indent}(component ${stringifyValue(component.name)}\n`
     if (component.places) {

--- a/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
@@ -404,12 +404,12 @@ export function processPlacement(nodes: ASTNode[]): Placement {
   }
 
   nodes.forEach((node) => {
-    if (
-      node.type === "List" &&
-      node.children![0].type === "Atom" &&
-      node.children![0].value === "component"
-    ) {
-      placement.components!.push(processComponent(node.children!))
+    if (node.type === "List" && node.children?.[0].type === "Atom") {
+      if (node.children[0].value === "component") {
+        placement.components!.push(processComponent(node.children))
+      } else if (node.children[0].value === "resolution") {
+        placement.resolution = processResolution(node.children)
+      }
     }
   })
 

--- a/lib/dsn-pcb/types.ts
+++ b/lib/dsn-pcb/types.ts
@@ -40,6 +40,7 @@ export interface DsnPcb {
     }
   }
   placement: {
+    resolution?: Resolution
     components: Array<ComponentPlacement>
   }
   library: {
@@ -156,6 +157,7 @@ export interface Clearance {
 }
 
 export interface Placement {
+  resolution?: Resolution
   components: ComponentPlacement[]
 }
 

--- a/tests/dsn-pcb/placement-resolution.test.ts
+++ b/tests/dsn-pcb/placement-resolution.test.ts
@@ -1,0 +1,47 @@
+import { expect, test } from "bun:test"
+import { stringifyDsnJson } from "lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json"
+import { parseDsnToDsnJson } from "lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json"
+import type { DsnPcb } from "lib/dsn-pcb/types"
+
+test("preserves placement-level resolution descriptors", () => {
+  const dsnJson = parseDsnToDsnJson(`(pcb board
+  (parser
+    (space_in_quoted_tokens on)
+    (host_cad "test")
+    (host_version "1")
+  )
+  (resolution um 10)
+  (unit um)
+  (structure
+    (layer F.Cu
+      (type signal)
+      (property (index 0))
+    )
+    (boundary
+      (path pcb 0 0 0 100 0 100 100 0 100 0 0)
+    )
+    (via Via)
+    (rule
+      (width 100)
+      (clearance 100)
+    )
+  )
+  (placement
+    (resolution mil 1)
+    (component R_0603
+      (place R1 100 200 front 0)
+    )
+  )
+  (library)
+  (network)
+  (wiring)
+)`) as DsnPcb
+
+  expect(dsnJson.placement.resolution).toEqual({ unit: "mil", value: 1 })
+
+  const stringified = stringifyDsnJson(dsnJson)
+  expect(stringified).toContain("(resolution mil 1)")
+
+  const reparsed = parseDsnToDsnJson(stringified) as DsnPcb
+  expect(reparsed.placement.resolution).toEqual({ unit: "mil", value: 1 })
+})


### PR DESCRIPTION
Summary
- Preserve optional SPECCTRA placement-level `(resolution ...)` descriptors when parsing DSN PCB placement sections.
- Emit preserved placement resolution metadata from `stringifyDsnJson` so PCB parse -> stringify -> parse keeps section-specific placement units.
- Add focused regression coverage for `(resolution mil 1)` inside `placement`.

Verification
- bun test tests/dsn-pcb/placement-resolution.test.ts
- bun test
- bunx tsc --noEmit
- bunx biome check lib/dsn-pcb/types.ts lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts tests/dsn-pcb/placement-resolution.test.ts
- bun run build
- git diff --check

/claim #54

Transparency note: AI-assisted with Codex; I reviewed the diff and verified it locally before submission.