### PR TITLE
Preserve placement unit

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
@@ -67,6 +67,9 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
 
   // Placement section
   result += `${indent}(placement\n`
+  if (dsnJson.placement.unit) {
+    result += `${indent}${indent}(unit ${dsnJson.placement.unit})\n`
+  }
   dsnJson.placement.components.forEach((component) => {
     result += `${indent}${indent}(component ${stringifyValue(component.name)}\n`
     if (component.places) {

--- a/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
@@ -404,12 +404,15 @@ export function processPlacement(nodes: ASTNode[]): Placement {
   }
 
   nodes.forEach((node) => {
-    if (
-      node.type === "List" &&
-      node.children![0].type === "Atom" &&
-      node.children![0].value === "component"
-    ) {
-      placement.components!.push(processComponent(node.children!))
+    if (node.type === "List" && node.children?.[0].type === "Atom") {
+      if (node.children[0].value === "component") {
+        placement.components!.push(processComponent(node.children))
+      } else if (
+        node.children[0].value === "unit" &&
+        node.children[1]?.type === "Atom"
+      ) {
+        placement.unit = String(node.children[1].value)
+      }
     }
   })
 

--- a/lib/dsn-pcb/types.ts
+++ b/lib/dsn-pcb/types.ts
@@ -40,6 +40,7 @@ export interface DsnPcb {
     }
   }
   placement: {
+    unit?: string
     components: Array<ComponentPlacement>
   }
   library: {
@@ -156,6 +157,7 @@ export interface Clearance {
 }
 
 export interface Placement {
+  unit?: string
   components: ComponentPlacement[]
 }
 

--- a/tests/dsn-pcb/placement-unit.test.ts
+++ b/tests/dsn-pcb/placement-unit.test.ts
@@ -1,0 +1,47 @@
+import { expect, test } from "bun:test"
+import { stringifyDsnJson } from "lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json"
+import { parseDsnToDsnJson } from "lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json"
+import type { DsnPcb } from "lib/dsn-pcb/types"
+
+test("preserves placement-level unit descriptors", () => {
+  const dsnJson = parseDsnToDsnJson(`(pcb board
+  (parser
+    (space_in_quoted_tokens on)
+    (host_cad "test")
+    (host_version "1")
+  )
+  (resolution um 10)
+  (unit um)
+  (structure
+    (layer F.Cu
+      (type signal)
+      (property (index 0))
+    )
+    (boundary
+      (path pcb 0 0 0 100 0 100 100 0 100 0 0)
+    )
+    (via Via)
+    (rule
+      (width 100)
+      (clearance 100)
+    )
+  )
+  (placement
+    (unit mil)
+    (component R_0603
+      (place R1 100 200 front 0)
+    )
+  )
+  (library)
+  (network)
+  (wiring)
+)`) as DsnPcb
+
+  expect(dsnJson.placement.unit).toBe("mil")
+
+  const stringified = stringifyDsnJson(dsnJson)
+  expect(stringified).toContain("(unit mil)")
+
+  const reparsed = parseDsnToDsnJson(stringified) as DsnPcb
+  expect(reparsed.placement.unit).toBe("mil")
+})


### PR DESCRIPTION
Summary
- Preserve optional SPECCTRA placement-level `(unit ...)` descriptors when parsing DSN PCB placement sections.
- Emit preserved placement unit metadata from `stringifyDsnJson` so PCB parse -> stringify -> parse keeps section-specific placement units.
- Add focused regression coverage for `(unit mil)` inside `placement`.

Verification
- bun test tests/dsn-pcb/placement-unit.test.ts
- bun test
- bunx tsc --noEmit
- bunx biome check lib/dsn-pcb/types.ts lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts tests/dsn-pcb/placement-unit.test.ts
- bun run build
- git diff --check

/claim #54

Transparency note: AI-assisted with Codex; I reviewed the diff and verified it locally before submission.