### PR TITLE
Preserve library unit

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
@@ -80,6 +80,9 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
 
   // Library section
   result += `${indent}(library\n`
+  if (dsnJson.library.unit) {
+    result += `${indent}${indent}(unit ${dsnJson.library.unit})\n`
+  }
   dsnJson.library.images.forEach((image) => {
     result += `${indent}${indent}(image ${stringifyValue(image.name)}\n`
     image.outlines.forEach((outline) => {

--- a/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
@@ -513,6 +513,11 @@ export function processLibrary(nodes: ASTNode[]): Library {
       if (keyNode.type === "Atom" && typeof keyNode.value === "string") {
         const key = keyNode.value
         switch (key) {
+          case "unit":
+            if (rest[0]?.type === "Atom") {
+              library.unit = String(rest[0].value)
+            }
+            break
           case "image":
             library.images!.push(processImage(node.children!))
             break

--- a/lib/dsn-pcb/types.ts
+++ b/lib/dsn-pcb/types.ts
@@ -43,6 +43,7 @@ export interface DsnPcb {
     components: Array<ComponentPlacement>
   }
   library: {
+    unit?: string
     images: Image[]
     padstacks: Padstack[]
   }
@@ -174,6 +175,7 @@ export interface Places {
 }
 
 export interface Library {
+  unit?: string
   images: Image[]
   padstacks: Padstack[]
 }

--- a/tests/dsn-pcb/library-unit.test.ts
+++ b/tests/dsn-pcb/library-unit.test.ts
@@ -1,0 +1,48 @@
+import { expect, test } from "bun:test"
+import { stringifyDsnJson } from "lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json"
+import { parseDsnToDsnJson } from "lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json"
+import type { DsnPcb } from "lib/dsn-pcb/types"
+
+test("preserves library-level unit descriptors", () => {
+  const dsnJson = parseDsnToDsnJson(`(pcb board
+  (parser
+    (space_in_quoted_tokens on)
+    (host_cad "test")
+    (host_version "1")
+  )
+  (resolution um 10)
+  (unit um)
+  (structure
+    (layer F.Cu
+      (type signal)
+      (property (index 0))
+    )
+    (boundary
+      (path pcb 0 0 0 100 0 100 100 0 100 0 0)
+    )
+    (via Via)
+    (rule
+      (width 100)
+      (clearance 100)
+    )
+  )
+  (placement)
+  (library
+    (unit mil)
+    (padstack Via
+      (shape (circle signal 60))
+      (attach off)
+    )
+  )
+  (network)
+  (wiring)
+)`) as DsnPcb
+
+  expect(dsnJson.library.unit).toBe("mil")
+
+  const stringified = stringifyDsnJson(dsnJson)
+  expect(stringified).toContain("(unit mil)")
+
+  const reparsed = parseDsnToDsnJson(stringified) as DsnPcb
+  expect(reparsed.library.unit).toBe("mil")
+})


### PR DESCRIPTION
Summary
- Preserve optional SPECCTRA library-level `(unit ...)` descriptors when parsing DSN PCB library sections.
- Emit preserved library unit metadata from `stringifyDsnJson` so PCB parse -> stringify -> parse keeps section-specific library units.
- Add focused regression coverage for `(unit mil)` inside `library`.

Verification
- bun test tests/dsn-pcb/library-unit.test.ts
- bun test
- bunx tsc --noEmit
- bunx biome check lib/dsn-pcb/types.ts lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts tests/dsn-pcb/library-unit.test.ts
- bun run build
- git diff --check

/claim #54

Transparency note: AI-assisted with Codex; I reviewed the diff and verified it locally before submission.