### PR TITLE
Preserve parser flags

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
@@ -35,6 +35,12 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
   result += `${indent}${indent}(space_in_quoted_tokens on)\n`
   result += `${indent}${indent}(host_cad "KiCad's Pcbnew")\n`
   result += `${indent}${indent}(host_version "${dsnJson.parser.host_version}")\n`
+  if (dsnJson.parser.case_sensitive) {
+    result += `${indent}${indent}(case_sensitive ${dsnJson.parser.case_sensitive})\n`
+  }
+  if (dsnJson.parser.rotate_first) {
+    result += `${indent}${indent}(rotate_first ${dsnJson.parser.rotate_first})\n`
+  }
   result += `${indent})\n`
 
   // Resolution and unit

--- a/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
@@ -184,6 +184,12 @@ export function processParser(nodes: ASTNode[]): ParserType {
           case "host_version":
             if (typeof value === "string") parser.host_version = value
             break
+          case "case_sensitive":
+            if (typeof value === "string") parser.case_sensitive = value
+            break
+          case "rotate_first":
+            if (typeof value === "string") parser.rotate_first = value
+            break
         }
       }
     }

--- a/lib/dsn-pcb/types.ts
+++ b/lib/dsn-pcb/types.ts
@@ -4,12 +4,7 @@ export interface DsnPcb {
   is_dsn_pcb: true
   is_dsn_session?: false
   filename: string
-  parser: {
-    string_quote: string
-    host_version: string
-    space_in_quoted_tokens: string
-    host_cad: string
-  }
+  parser: Parser
   resolution: {
     unit: string
     value: number
@@ -100,6 +95,8 @@ export interface Parser {
   space_in_quoted_tokens: string
   host_cad: string
   host_version: string
+  case_sensitive?: string
+  rotate_first?: string
 }
 
 export interface Resolution {

--- a/tests/dsn-pcb/parser-flags.test.ts
+++ b/tests/dsn-pcb/parser-flags.test.ts
@@ -1,0 +1,47 @@
+import { expect, test } from "bun:test"
+import { stringifyDsnJson } from "lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json"
+import { parseDsnToDsnJson } from "lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json"
+import type { DsnPcb } from "lib/dsn-pcb/types"
+
+test("preserves parser case_sensitive and rotate_first flags", () => {
+  const dsnJson = parseDsnToDsnJson(`(pcb board
+  (parser
+    (space_in_quoted_tokens on)
+    (host_cad "test")
+    (host_version "1")
+    (case_sensitive off)
+    (rotate_first on)
+  )
+  (resolution um 10)
+  (unit um)
+  (structure
+    (layer F.Cu
+      (type signal)
+      (property (index 0))
+    )
+    (boundary
+      (path pcb 0 0 0 100 0 100 100 0 100 0 0)
+    )
+    (via Via)
+    (rule
+      (width 100)
+      (clearance 100)
+    )
+  )
+  (placement)
+  (library)
+  (network)
+  (wiring)
+)`) as DsnPcb
+
+  expect(dsnJson.parser.case_sensitive).toBe("off")
+  expect(dsnJson.parser.rotate_first).toBe("on")
+
+  const stringified = stringifyDsnJson(dsnJson)
+  expect(stringified).toContain("(case_sensitive off)")
+  expect(stringified).toContain("(rotate_first on)")
+
+  const reparsed = parseDsnToDsnJson(stringified) as DsnPcb
+  expect(reparsed.parser.case_sensitive).toBe("off")
+  expect(reparsed.parser.rotate_first).toBe("on")
+})


### PR DESCRIPTION
Summary
- Preserve optional SPECCTRA parser `(case_sensitive ...)` and `(rotate_first ...)` flags when parsing DSN PCB parser sections.
- Emit preserved parser flags from `stringifyDsnJson` so PCB parse -> stringify -> parse keeps parser behavior metadata.
- Add focused regression coverage for `case_sensitive off` and `rotate_first on`.

Verification
- bun test tests/dsn-pcb/parser-flags.test.ts
- bun test
- bunx tsc --noEmit
- bunx biome check lib/dsn-pcb/types.ts lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts tests/dsn-pcb/parser-flags.test.ts
- bun run build
- git diff --check

/claim #54

Transparency note: AI-assisted with Codex; I reviewed the diff and verified it locally before submission.