### PR TITLE
Preserve parser include options

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
@@ -35,6 +35,12 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
   result += `${indent}${indent}(space_in_quoted_tokens on)\n`
   result += `${indent}${indent}(host_cad "KiCad's Pcbnew")\n`
   result += `${indent}${indent}(host_version "${dsnJson.parser.host_version}")\n`
+  if (dsnJson.parser.routes_include?.length) {
+    result += `${indent}${indent}(routes_include ${dsnJson.parser.routes_include.join(" ")})\n`
+  }
+  if (dsnJson.parser.wires_include?.length) {
+    result += `${indent}${indent}(wires_include ${dsnJson.parser.wires_include.join(" ")})\n`
+  }
   result += `${indent})\n`
 
   // Resolution and unit

--- a/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
@@ -184,6 +184,24 @@ export function processParser(nodes: ASTNode[]): ParserType {
           case "host_version":
             if (typeof value === "string") parser.host_version = value
             break
+          case "routes_include":
+            parser.routes_include = node.children
+              .slice(1)
+              .filter(
+                (child) =>
+                  child.type === "Atom" && typeof child.value === "string",
+              )
+              .map((child) => String(child.value))
+            break
+          case "wires_include":
+            parser.wires_include = node.children
+              .slice(1)
+              .filter(
+                (child) =>
+                  child.type === "Atom" && typeof child.value === "string",
+              )
+              .map((child) => String(child.value))
+            break
         }
       }
     }

--- a/lib/dsn-pcb/types.ts
+++ b/lib/dsn-pcb/types.ts
@@ -4,12 +4,7 @@ export interface DsnPcb {
   is_dsn_pcb: true
   is_dsn_session?: false
   filename: string
-  parser: {
-    string_quote: string
-    host_version: string
-    space_in_quoted_tokens: string
-    host_cad: string
-  }
+  parser: Parser
   resolution: {
     unit: string
     value: number
@@ -100,6 +95,8 @@ export interface Parser {
   space_in_quoted_tokens: string
   host_cad: string
   host_version: string
+  routes_include?: string[]
+  wires_include?: string[]
 }
 
 export interface Resolution {

--- a/tests/dsn-pcb/parser-include-options.test.ts
+++ b/tests/dsn-pcb/parser-include-options.test.ts
@@ -1,0 +1,57 @@
+import { expect, test } from "bun:test"
+import { stringifyDsnJson } from "lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json"
+import { parseDsnToDsnJson } from "lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json"
+import type { DsnPcb } from "lib/dsn-pcb/types"
+
+test("preserves parser route and wire include options", () => {
+  const dsnJson = parseDsnToDsnJson(`(pcb board
+  (parser
+    (space_in_quoted_tokens on)
+    (host_cad "test")
+    (host_version "1")
+    (routes_include testpoint guides image_conductor)
+    (wires_include testpoint)
+  )
+  (resolution um 10)
+  (unit um)
+  (structure
+    (layer F.Cu
+      (type signal)
+      (property (index 0))
+    )
+    (boundary
+      (path pcb 0 0 0 100 0 100 100 0 100 0 0)
+    )
+    (via Via)
+    (rule
+      (width 100)
+      (clearance 100)
+    )
+  )
+  (placement)
+  (library)
+  (network)
+  (wiring)
+)`) as DsnPcb
+
+  expect(dsnJson.parser.routes_include).toEqual([
+    "testpoint",
+    "guides",
+    "image_conductor",
+  ])
+  expect(dsnJson.parser.wires_include).toEqual(["testpoint"])
+
+  const stringified = stringifyDsnJson(dsnJson)
+  expect(stringified).toContain(
+    "(routes_include testpoint guides image_conductor)",
+  )
+  expect(stringified).toContain("(wires_include testpoint)")
+
+  const reparsed = parseDsnToDsnJson(stringified) as DsnPcb
+  expect(reparsed.parser.routes_include).toEqual([
+    "testpoint",
+    "guides",
+    "image_conductor",
+  ])
+  expect(reparsed.parser.wires_include).toEqual(["testpoint"])
+})


### PR DESCRIPTION
Summary
- Preserve optional SPECCTRA parser `(routes_include ...)` and `(wires_include ...)` descriptors when parsing DSN PCB parser sections.
- Emit preserved parser include metadata from `stringifyDsnJson` so PCB parse -> stringify -> parse keeps route/wire inclusion options.
- Add focused regression coverage for `routes_include testpoint guides image_conductor` and `wires_include testpoint`.

Verification
- bun test tests/dsn-pcb/parser-include-options.test.ts
- bun test
- bunx tsc --noEmit
- bunx biome check lib/dsn-pcb/types.ts lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts tests/dsn-pcb/parser-include-options.test.ts
- bun run build
- git diff --check

/claim #54

Transparency note: AI-assisted with Codex; I reviewed the diff and verified it locally before submission.