### PR TITLE
Preserve parser constants

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
@@ -35,6 +35,9 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
   result += `${indent}${indent}(space_in_quoted_tokens on)\n`
   result += `${indent}${indent}(host_cad "KiCad's Pcbnew")\n`
   result += `${indent}${indent}(host_version "${dsnJson.parser.host_version}")\n`
+  dsnJson.parser.constants?.forEach((constant) => {
+    result += `${indent}${indent}(constant ${constant.name} ${constant.value})\n`
+  })
   result += `${indent})\n`
 
   // Resolution and unit

--- a/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
@@ -184,6 +184,22 @@ export function processParser(nodes: ASTNode[]): ParserType {
           case "host_version":
             if (typeof value === "string") parser.host_version = value
             break
+          case "constant":
+            if (
+              valueNode.type === "Atom" &&
+              (typeof valueNode.value === "string" ||
+                typeof valueNode.value === "number") &&
+              node.children[2]?.type === "Atom" &&
+              (typeof node.children[2].value === "string" ||
+                typeof node.children[2].value === "number")
+            ) {
+              parser.constants ??= []
+              parser.constants.push({
+                name: String(valueNode.value),
+                value: String(node.children[2].value),
+              })
+            }
+            break
         }
       }
     }

--- a/lib/dsn-pcb/types.ts
+++ b/lib/dsn-pcb/types.ts
@@ -4,12 +4,7 @@ export interface DsnPcb {
   is_dsn_pcb: true
   is_dsn_session?: false
   filename: string
-  parser: {
-    string_quote: string
-    host_version: string
-    space_in_quoted_tokens: string
-    host_cad: string
-  }
+  parser: Parser
   resolution: {
     unit: string
     value: number
@@ -100,6 +95,10 @@ export interface Parser {
   space_in_quoted_tokens: string
   host_cad: string
   host_version: string
+  constants?: Array<{
+    name: string
+    value: string
+  }>
 }
 
 export interface Resolution {

--- a/tests/dsn-pcb/parser-constants.test.ts
+++ b/tests/dsn-pcb/parser-constants.test.ts
@@ -1,0 +1,51 @@
+import { expect, test } from "bun:test"
+import { stringifyDsnJson } from "lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json"
+import { parseDsnToDsnJson } from "lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json"
+import type { DsnPcb } from "lib/dsn-pcb/types"
+
+test("preserves parser constant descriptors", () => {
+  const dsnJson = parseDsnToDsnJson(`(pcb board
+  (parser
+    (space_in_quoted_tokens on)
+    (host_cad "test")
+    (host_version "1")
+    (constant DEFAULT_WIDTH 100)
+    (constant DEFAULT_CLEARANCE 50)
+  )
+  (resolution um 10)
+  (unit um)
+  (structure
+    (layer F.Cu
+      (type signal)
+      (property (index 0))
+    )
+    (boundary
+      (path pcb 0 0 0 100 0 100 100 0 100 0 0)
+    )
+    (via Via)
+    (rule
+      (width 100)
+      (clearance 100)
+    )
+  )
+  (placement)
+  (library)
+  (network)
+  (wiring)
+)`) as DsnPcb
+
+  expect(dsnJson.parser.constants).toEqual([
+    { name: "DEFAULT_WIDTH", value: "100" },
+    { name: "DEFAULT_CLEARANCE", value: "50" },
+  ])
+
+  const stringified = stringifyDsnJson(dsnJson)
+  expect(stringified).toContain("(constant DEFAULT_WIDTH 100)")
+  expect(stringified).toContain("(constant DEFAULT_CLEARANCE 50)")
+
+  const reparsed = parseDsnToDsnJson(stringified) as DsnPcb
+  expect(reparsed.parser.constants).toEqual([
+    { name: "DEFAULT_WIDTH", value: "100" },
+    { name: "DEFAULT_CLEARANCE", value: "50" },
+  ])
+})


### PR DESCRIPTION
Summary
- Preserve optional SPECCTRA parser `(constant ...)` descriptors when parsing DSN PCB parser sections.
- Emit preserved parser constants from `stringifyDsnJson` so PCB parse -> stringify -> parse keeps parser constant metadata.
- Add focused regression coverage for two parser constants.

Verification
- bun test tests/dsn-pcb/parser-constants.test.ts
- bun test
- bunx tsc --noEmit
- bunx biome check lib/dsn-pcb/types.ts lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts tests/dsn-pcb/parser-constants.test.ts
- bun run build
- git diff --check

/claim #54

Transparency note: AI-assisted with Codex; I reviewed the diff and verified it locally before submission.