### PR TITLE
Preserve parser write resolution

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
@@ -35,6 +35,9 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
   result += `${indent}${indent}(space_in_quoted_tokens on)\n`
   result += `${indent}${indent}(host_cad "KiCad's Pcbnew")\n`
   result += `${indent}${indent}(host_version "${dsnJson.parser.host_version}")\n`
+  if (dsnJson.parser.write_resolution) {
+    result += `${indent}${indent}(write_resolution ${dsnJson.parser.write_resolution.unit} ${dsnJson.parser.write_resolution.value})\n`
+  }
   result += `${indent})\n`
 
   // Resolution and unit

--- a/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
@@ -184,6 +184,18 @@ export function processParser(nodes: ASTNode[]): ParserType {
           case "host_version":
             if (typeof value === "string") parser.host_version = value
             break
+          case "write_resolution":
+            if (
+              typeof value === "string" &&
+              node.children[2]?.type === "Atom" &&
+              typeof node.children[2].value === "number"
+            ) {
+              parser.write_resolution = {
+                unit: value,
+                value: node.children[2].value,
+              }
+            }
+            break
         }
       }
     }

--- a/lib/dsn-pcb/types.ts
+++ b/lib/dsn-pcb/types.ts
@@ -4,12 +4,7 @@ export interface DsnPcb {
   is_dsn_pcb: true
   is_dsn_session?: false
   filename: string
-  parser: {
-    string_quote: string
-    host_version: string
-    space_in_quoted_tokens: string
-    host_cad: string
-  }
+  parser: Parser
   resolution: {
     unit: string
     value: number
@@ -100,6 +95,10 @@ export interface Parser {
   space_in_quoted_tokens: string
   host_cad: string
   host_version: string
+  write_resolution?: {
+    unit: string
+    value: number
+  }
 }
 
 export interface Resolution {

--- a/tests/dsn-pcb/parser-write-resolution.test.ts
+++ b/tests/dsn-pcb/parser-write-resolution.test.ts
@@ -1,0 +1,49 @@
+import { expect, test } from "bun:test"
+import { stringifyDsnJson } from "lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json"
+import { parseDsnToDsnJson } from "lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json"
+import type { DsnPcb } from "lib/dsn-pcb/types"
+
+test("preserves parser write_resolution descriptors", () => {
+  const dsnJson = parseDsnToDsnJson(`(pcb board
+  (parser
+    (space_in_quoted_tokens on)
+    (host_cad "test")
+    (host_version "1")
+    (write_resolution um 5)
+  )
+  (resolution um 10)
+  (unit um)
+  (structure
+    (layer F.Cu
+      (type signal)
+      (property (index 0))
+    )
+    (boundary
+      (path pcb 0 0 0 100 0 100 100 0 100 0 0)
+    )
+    (via Via)
+    (rule
+      (width 100)
+      (clearance 100)
+    )
+  )
+  (placement)
+  (library)
+  (network)
+  (wiring)
+)`) as DsnPcb
+
+  expect(dsnJson.parser.write_resolution).toEqual({
+    unit: "um",
+    value: 5,
+  })
+
+  const stringified = stringifyDsnJson(dsnJson)
+  expect(stringified).toContain("(write_resolution um 5)")
+
+  const reparsed = parseDsnToDsnJson(stringified) as DsnPcb
+  expect(reparsed.parser.write_resolution).toEqual({
+    unit: "um",
+    value: 5,
+  })
+})


### PR DESCRIPTION
Summary
- Preserve optional SPECCTRA parser `(write_resolution ...)` descriptors when parsing DSN PCB parser sections.
- Emit preserved parser write_resolution metadata from `stringifyDsnJson` so PCB parse -> stringify -> parse keeps the descriptor.
- Add focused regression coverage for parser write_resolution round-tripping.

Verification
- bun test tests/dsn-pcb/parser-write-resolution.test.ts
- bun test
- bunx tsc --noEmit
- bunx biome check lib/dsn-pcb/types.ts lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts tests/dsn-pcb/parser-write-resolution.test.ts
- bun run build
- git diff --check

/claim #54

Transparency note: AI-assisted with Codex; I reviewed the diff and verified it locally before submission.