### PR TITLE
Preserve wire metadata

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
@@ -26,6 +26,11 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
     return `${padding}(path ${path.layer} ${path.width}  ${stringifyCoordinates(path.coordinates)})`
   }
 
+  const stringifyPolylinePath = (path: any, level: number): string => {
+    const padding = indent.repeat(level)
+    return `${padding}(polyline_path ${path.layer} ${path.width} ${stringifyCoordinates(path.coordinates)})`
+  }
+
   // Start with pcb
   result += `(pcb ${dsnJson.filename ? dsnJson.filename : "./converted_dsn.dsn"}\n`
 
@@ -138,7 +143,10 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
     if (wire.type === "via") {
       result += `${indent}${indent}(via ${stringifyPath(wire.path, 3)}(net ${stringifyValue(wire.net)}))\n`
     } else {
-      result += `${indent}${indent}(wire ${stringifyPath(wire.path, 3)}(net ${stringifyValue(wire.net)})(type ${wire.type}))\n`
+      const wirePath = wire.polyline_path
+        ? stringifyPolylinePath(wire.polyline_path, 3)
+        : stringifyPath(wire.path, 3)
+      result += `${indent}${indent}(wire ${wirePath}(net ${stringifyValue(wire.net)})${wire.clearance_class ? `(clearance_class ${wire.clearance_class})` : ""}(type ${wire.type}))\n`
     }
   })
   result += `${indent})\n`

--- a/lib/dsn-pcb/types.ts
+++ b/lib/dsn-pcb/types.ts
@@ -67,20 +67,7 @@ export interface DsnPcb {
       }
     }>
   }
-  wiring: {
-    wires: Array<{
-      path: {
-        layer: string
-        width: number
-        /**
-         * TODO UNIT?
-         */
-        coordinates: number[]
-      }
-      net: string
-      type: string
-    }>
-  }
+  wiring: Wiring
 }
 
 export interface ComponentPlacement {

--- a/tests/dsn-pcb/wire-metadata.test.ts
+++ b/tests/dsn-pcb/wire-metadata.test.ts
@@ -1,0 +1,60 @@
+import { expect, test } from "bun:test"
+import { stringifyDsnJson } from "lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json"
+import { parseDsnToDsnJson } from "lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json"
+import type { DsnPcb } from "lib/dsn-pcb/types"
+
+test("preserves wire polyline_path and clearance_class metadata", () => {
+  const dsnJson = parseDsnToDsnJson(`(pcb board
+  (parser
+    (space_in_quoted_tokens on)
+    (host_cad "test")
+    (host_version "1")
+  )
+  (resolution um 10)
+  (unit um)
+  (structure
+    (layer F.Cu
+      (type signal)
+      (property (index 0))
+    )
+    (boundary
+      (path pcb 0 0 0 100 0 100 100 0 100 0 0)
+    )
+    (via Via)
+    (rule
+      (width 100)
+      (clearance 100)
+    )
+  )
+  (placement)
+  (library)
+  (network)
+  (wiring
+    (wire
+      (polyline_path F.Cu 100 0 0 50 50 100 0)
+      (net N1)
+      (clearance_class DEFAULT)
+      (type route)
+    )
+  )
+)`) as DsnPcb
+
+  expect(dsnJson.wiring.wires[0].polyline_path).toEqual({
+    layer: "F.Cu",
+    width: 100,
+    coordinates: [0, 0, 50, 50, 100, 0],
+  })
+  expect(dsnJson.wiring.wires[0].clearance_class).toBe("DEFAULT")
+
+  const stringified = stringifyDsnJson(dsnJson)
+  expect(stringified).toContain("(polyline_path F.Cu 100 0 0 50 50 100 0)")
+  expect(stringified).toContain("(clearance_class DEFAULT)")
+
+  const reparsed = parseDsnToDsnJson(stringified) as DsnPcb
+  expect(reparsed.wiring.wires[0].polyline_path).toEqual({
+    layer: "F.Cu",
+    width: 100,
+    coordinates: [0, 0, 50, 50, 100, 0],
+  })
+  expect(reparsed.wiring.wires[0].clearance_class).toBe("DEFAULT")
+})


### PR DESCRIPTION
Summary
- Emit parsed DSN wire `polyline_path` data from `stringifyDsnJson` instead of falling back to only regular `path` output.
- Preserve parsed wire `clearance_class` metadata when stringifying DSN PCB wiring sections.
- Reuse the existing `Wire` type at the top-level DSN PCB wiring shape and add focused round-trip regression coverage.

Verification
- bun test tests/dsn-pcb/wire-metadata.test.ts
- bun test
- bunx tsc --noEmit
- bunx biome check lib/dsn-pcb/types.ts lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts tests/dsn-pcb/wire-metadata.test.ts
- bun run build
- git diff --check

/claim #54

Transparency note: AI-assisted with Codex; I reviewed the diff and verified it locally before submission.