### PR TITLE
Preserve rectangular padstack shapes

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
@@ -97,6 +97,8 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
         result += `${indent}${indent}${indent}(shape (polygon ${shape.layer} ${shape.width} ${stringifyCoordinates(shape.coordinates)}))\n`
       } else if (shape.shapeType === "circle") {
         result += `${indent}${indent}${indent}(shape (circle ${shape.layer} ${shape.diameter}))\n`
+      } else if (shape.shapeType === "rect") {
+        result += `${indent}${indent}${indent}(shape (rect ${shape.layer} ${stringifyCoordinates(shape.coordinates)}))\n`
       } else if (shape.shapeType === "path") {
         result += `${indent}${indent}${indent}(shape (path ${shape.layer} ${shape.width} ${stringifyCoordinates(shape.coordinates)}))\n`
       }

--- a/tests/dsn-pcb/rect-padstack-shapes.test.ts
+++ b/tests/dsn-pcb/rect-padstack-shapes.test.ts
@@ -1,0 +1,55 @@
+import { expect, test } from "bun:test"
+import { stringifyDsnJson } from "lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json"
+import { parseDsnToDsnJson } from "lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json"
+import type { DsnPcb } from "lib/dsn-pcb/types"
+
+test("preserves rectangular padstack shapes", () => {
+  const dsnJson = parseDsnToDsnJson(`(pcb board
+  (parser
+    (space_in_quoted_tokens on)
+    (host_cad "test")
+    (host_version "1")
+  )
+  (resolution um 10)
+  (unit um)
+  (structure
+    (layer F.Cu
+      (type signal)
+      (property (index 0))
+    )
+    (boundary
+      (path pcb 0 0 0 100 0 100 100 0 100 0 0)
+    )
+    (via Via)
+    (rule
+      (width 100)
+      (clearance 100)
+    )
+  )
+  (placement)
+  (library
+    (padstack RectPad
+      (shape (rect F.Cu -50 -25 50 25))
+      (attach off)
+    )
+  )
+  (network)
+  (wiring)
+)`) as DsnPcb
+
+  expect(dsnJson.library.padstacks[0].shapes[0]).toEqual({
+    shapeType: "rect",
+    layer: "F.Cu",
+    coordinates: [-50, -25, 50, 25],
+  })
+
+  const stringified = stringifyDsnJson(dsnJson)
+  expect(stringified).toContain("(shape (rect F.Cu -50 -25 50 25))")
+
+  const reparsed = parseDsnToDsnJson(stringified) as DsnPcb
+  expect(reparsed.library.padstacks[0].shapes[0]).toEqual({
+    shapeType: "rect",
+    layer: "F.Cu",
+    coordinates: [-50, -25, 50, 25],
+  })
+})


### PR DESCRIPTION
Summary
- Emit parsed DSN padstack `(shape (rect ...))` entries from `stringifyDsnJson` instead of dropping rectangular shapes.
- Add focused PCB round-trip regression coverage for rectangular padstack shapes.

Verification
- bun test tests/dsn-pcb/rect-padstack-shapes.test.ts
- bun test
- bunx tsc --noEmit
- bunx biome check lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts tests/dsn-pcb/rect-padstack-shapes.test.ts
- bun run build
- git diff --check

/claim #54

Transparency note: AI-assisted with Codex; I reviewed the diff and verified it locally before submission.