### PR TITLE
Preserve wire attributes

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
@@ -138,7 +138,7 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
     if (wire.type === "via") {
       result += `${indent}${indent}(via ${stringifyPath(wire.path, 3)}(net ${stringifyValue(wire.net)}))\n`
     } else {
-      result += `${indent}${indent}(wire ${stringifyPath(wire.path, 3)}(net ${stringifyValue(wire.net)})(type ${wire.type}))\n`
+      result += `${indent}${indent}(wire ${stringifyPath(wire.path, 3)}(net ${stringifyValue(wire.net)})(type ${wire.type})${wire.attr ? `(attr ${wire.attr})` : ""}${wire.shield ? `(shield ${wire.shield})` : ""}${wire.supply ? "(supply)" : ""})\n`
     }
   })
   result += `${indent})\n`

--- a/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
@@ -1010,6 +1010,19 @@ function processWire(nodes: ASTNode[]): Wire {
               wire.type = rest[0].value
             }
             break
+          case "attr":
+            if (rest[0].type === "Atom" && typeof rest[0].value === "string") {
+              wire.attr = rest[0].value
+            }
+            break
+          case "shield":
+            if (rest[0].type === "Atom" && typeof rest[0].value === "string") {
+              wire.shield = rest[0].value
+            }
+            break
+          case "supply":
+            wire.supply = true
+            break
         }
       }
     }

--- a/lib/dsn-pcb/types.ts
+++ b/lib/dsn-pcb/types.ts
@@ -67,20 +67,7 @@ export interface DsnPcb {
       }
     }>
   }
-  wiring: {
-    wires: Array<{
-      path: {
-        layer: string
-        width: number
-        /**
-         * TODO UNIT?
-         */
-        coordinates: number[]
-      }
-      net: string
-      type: string
-    }>
-  }
+  wiring: Wiring
 }
 
 export interface ComponentPlacement {
@@ -282,6 +269,9 @@ export interface Wire {
   net?: string
   clearance_class?: string
   type?: string
+  attr?: string
+  shield?: string
+  supply?: boolean
 }
 
 export interface Via {

--- a/tests/dsn-pcb/wire-attributes.test.ts
+++ b/tests/dsn-pcb/wire-attributes.test.ts
@@ -1,0 +1,57 @@
+import { expect, test } from "bun:test"
+import { stringifyDsnJson } from "lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json"
+import { parseDsnToDsnJson } from "lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json"
+import type { DsnPcb } from "lib/dsn-pcb/types"
+
+test("preserves wire attr shield and supply metadata", () => {
+  const dsnJson = parseDsnToDsnJson(`(pcb board
+  (parser
+    (space_in_quoted_tokens on)
+    (host_cad "test")
+    (host_version "1")
+  )
+  (resolution um 10)
+  (unit um)
+  (structure
+    (layer F.Cu
+      (type signal)
+      (property (index 0))
+    )
+    (boundary
+      (path pcb 0 0 0 100 0 100 100 0 100 0 0)
+    )
+    (via Via)
+    (rule
+      (width 100)
+      (clearance 100)
+    )
+  )
+  (placement)
+  (library)
+  (network)
+  (wiring
+    (wire
+      (path F.Cu 100 0 0 100 0)
+      (net N1)
+      (type route)
+      (attr fanout)
+      (shield GND)
+      (supply)
+    )
+  )
+)`) as DsnPcb
+
+  expect(dsnJson.wiring.wires[0].attr).toBe("fanout")
+  expect(dsnJson.wiring.wires[0].shield).toBe("GND")
+  expect(dsnJson.wiring.wires[0].supply).toBe(true)
+
+  const stringified = stringifyDsnJson(dsnJson)
+  expect(stringified).toContain("(attr fanout)")
+  expect(stringified).toContain("(shield GND)")
+  expect(stringified).toContain("(supply)")
+
+  const reparsed = parseDsnToDsnJson(stringified) as DsnPcb
+  expect(reparsed.wiring.wires[0].attr).toBe("fanout")
+  expect(reparsed.wiring.wires[0].shield).toBe("GND")
+  expect(reparsed.wiring.wires[0].supply).toBe(true)
+})


### PR DESCRIPTION
Summary
- Preserve DSN wire `(attr ...)`, `(shield ...)`, and `(supply)` metadata while parsing PCB wiring sections.
- Emit preserved wire attributes from `stringifyDsnJson` so PCB parse -> stringify -> parse keeps the metadata.
- Reuse the existing `Wire` type at the top-level DSN PCB wiring shape and add focused round-trip regression coverage.

Verification
- bun test tests/dsn-pcb/wire-attributes.test.ts
- bun test
- bunx tsc --noEmit
- bunx biome check lib/dsn-pcb/types.ts lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts tests/dsn-pcb/wire-attributes.test.ts
- bun run build
- git diff --check

/claim #54

Transparency note: AI-assisted with Codex; I reviewed the diff and verified it locally before submission.