### PR TITLE
Preserve padstack flags

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
@@ -102,6 +102,12 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
       }
     })
     result += `${indent}${indent}${indent}(attach ${padstack.attach})\n`
+    if (padstack.rotate) {
+      result += `${indent}${indent}${indent}(rotate ${padstack.rotate})\n`
+    }
+    if (padstack.absolute) {
+      result += `${indent}${indent}${indent}(absolute ${padstack.absolute})\n`
+    }
     result += `${indent}${indent})\n`
   })
   result += `${indent})\n`

--- a/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
@@ -659,6 +659,14 @@ function processPadstack(nodes: ASTNode[]): Padstack {
           if (rest[0].type === "Atom" && typeof rest[0].value === "string") {
             padstack.attach = rest[0].value
           }
+        } else if (key === "rotate") {
+          if (rest[0].type === "Atom" && typeof rest[0].value === "string") {
+            padstack.rotate = rest[0].value
+          }
+        } else if (key === "absolute") {
+          if (rest[0].type === "Atom" && typeof rest[0].value === "string") {
+            padstack.absolute = rest[0].value
+          }
         }
       }
     }

--- a/lib/dsn-pcb/types.ts
+++ b/lib/dsn-pcb/types.ts
@@ -199,6 +199,8 @@ export interface Padstack {
   name: string
   shapes: Shape[]
   attach: string
+  rotate?: string
+  absolute?: string
   hole?: {
     shape: "circle" | "square" | "oval"
     width?: number

--- a/tests/dsn-pcb/padstack-flags.test.ts
+++ b/tests/dsn-pcb/padstack-flags.test.ts
@@ -1,0 +1,52 @@
+import { expect, test } from "bun:test"
+import { stringifyDsnJson } from "lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json"
+import { parseDsnToDsnJson } from "lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json"
+import type { DsnPcb } from "lib/dsn-pcb/types"
+
+test("preserves padstack rotate and absolute flags", () => {
+  const dsnJson = parseDsnToDsnJson(`(pcb board
+  (parser
+    (space_in_quoted_tokens on)
+    (host_cad "test")
+    (host_version "1")
+  )
+  (resolution um 10)
+  (unit um)
+  (structure
+    (layer F.Cu
+      (type signal)
+      (property (index 0))
+    )
+    (boundary
+      (path pcb 0 0 0 100 0 100 100 0 100 0 0)
+    )
+    (via Via)
+    (rule
+      (width 100)
+      (clearance 100)
+    )
+  )
+  (placement)
+  (library
+    (padstack FlagPad
+      (shape (circle F.Cu 100))
+      (attach off)
+      (rotate on)
+      (absolute on)
+    )
+  )
+  (network)
+  (wiring)
+)`) as DsnPcb
+
+  expect(dsnJson.library.padstacks[0].rotate).toBe("on")
+  expect(dsnJson.library.padstacks[0].absolute).toBe("on")
+
+  const stringified = stringifyDsnJson(dsnJson)
+  expect(stringified).toContain("(rotate on)")
+  expect(stringified).toContain("(absolute on)")
+
+  const reparsed = parseDsnToDsnJson(stringified) as DsnPcb
+  expect(reparsed.library.padstacks[0].rotate).toBe("on")
+  expect(reparsed.library.padstacks[0].absolute).toBe("on")
+})


### PR DESCRIPTION
Summary
- Preserve DSN padstack `(rotate ...)` and `(absolute ...)` flags while parsing PCB library padstacks.
- Emit preserved padstack flags from `stringifyDsnJson` so PCB parse -> stringify -> parse keeps padstack metadata.
- Add focused round-trip regression coverage for padstack rotate and absolute flags.

Verification
- bun test tests/dsn-pcb/padstack-flags.test.ts
- bun test
- bunx tsc --noEmit
- bunx biome check lib/dsn-pcb/types.ts lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts tests/dsn-pcb/padstack-flags.test.ts
- bun run build
- git diff --check

/claim #54

Transparency note: AI-assisted with Codex; I reviewed the diff and verified it locally before submission.