### PR TITLE
Preserve padstack via sites

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
@@ -102,6 +102,13 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
       }
     })
     result += `${indent}${indent}${indent}(attach ${padstack.attach})\n`
+    padstack.via_sites?.forEach((viaSite) => {
+      if (viaSite === "off") {
+        result += `${indent}${indent}${indent}(via_site off)\n`
+      } else {
+        result += `${indent}${indent}${indent}(via_site ${viaSite.x} ${viaSite.y})\n`
+      }
+    })
     result += `${indent}${indent})\n`
   })
   result += `${indent})\n`

--- a/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
@@ -659,6 +659,22 @@ function processPadstack(nodes: ASTNode[]): Padstack {
           if (rest[0].type === "Atom" && typeof rest[0].value === "string") {
             padstack.attach = rest[0].value
           }
+        } else if (key === "via_site") {
+          if (rest[0]?.type === "Atom" && rest[0].value === "off") {
+            padstack.via_sites ??= []
+            padstack.via_sites.push("off")
+          } else if (
+            rest[0]?.type === "Atom" &&
+            typeof rest[0].value === "number" &&
+            rest[1]?.type === "Atom" &&
+            typeof rest[1].value === "number"
+          ) {
+            padstack.via_sites ??= []
+            padstack.via_sites.push({
+              x: rest[0].value,
+              y: rest[1].value,
+            })
+          }
         }
       }
     }

--- a/lib/dsn-pcb/types.ts
+++ b/lib/dsn-pcb/types.ts
@@ -195,10 +195,18 @@ export interface Pin {
   y: number
 }
 
+export type PadViaSite =
+  | {
+      x: number
+      y: number
+    }
+  | "off"
+
 export interface Padstack {
   name: string
   shapes: Shape[]
   attach: string
+  via_sites?: PadViaSite[]
   hole?: {
     shape: "circle" | "square" | "oval"
     width?: number

--- a/tests/dsn-pcb/padstack-via-sites.test.ts
+++ b/tests/dsn-pcb/padstack-via-sites.test.ts
@@ -1,0 +1,56 @@
+import { expect, test } from "bun:test"
+import { stringifyDsnJson } from "lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json"
+import { parseDsnToDsnJson } from "lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json"
+import type { DsnPcb } from "lib/dsn-pcb/types"
+
+test("preserves padstack via_site descriptors", () => {
+  const dsnJson = parseDsnToDsnJson(`(pcb board
+  (parser
+    (space_in_quoted_tokens on)
+    (host_cad "test")
+    (host_version "1")
+  )
+  (resolution um 10)
+  (unit um)
+  (structure
+    (layer F.Cu
+      (type signal)
+      (property (index 0))
+    )
+    (boundary
+      (path pcb 0 0 0 100 0 100 100 0 100 0 0)
+    )
+    (via Via)
+    (rule
+      (width 100)
+      (clearance 100)
+    )
+  )
+  (placement)
+  (library
+    (padstack ViaSitePad
+      (shape (circle F.Cu 100))
+      (attach off)
+      (via_site 10 20)
+      (via_site off)
+    )
+  )
+  (network)
+  (wiring)
+)`) as DsnPcb
+
+  expect(dsnJson.library.padstacks[0].via_sites).toEqual([
+    { x: 10, y: 20 },
+    "off",
+  ])
+
+  const stringified = stringifyDsnJson(dsnJson)
+  expect(stringified).toContain("(via_site 10 20)")
+  expect(stringified).toContain("(via_site off)")
+
+  const reparsed = parseDsnToDsnJson(stringified) as DsnPcb
+  expect(reparsed.library.padstacks[0].via_sites).toEqual([
+    { x: 10, y: 20 },
+    "off",
+  ])
+})


### PR DESCRIPTION
Summary
- Preserve DSN padstack `(via_site ...)` descriptors while parsing PCB library padstacks.
- Emit preserved via_site descriptors from `stringifyDsnJson`, including coordinate sites and `off` markers.
- Add focused round-trip regression coverage for padstack via_site metadata.

Verification
- bun test tests/dsn-pcb/padstack-via-sites.test.ts
- bun test
- bunx tsc --noEmit
- bunx biome check lib/dsn-pcb/types.ts lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts tests/dsn-pcb/padstack-via-sites.test.ts
- bun run build
- git diff --check

/claim #54

Transparency note: AI-assisted with Codex; I reviewed the diff and verified it locally before submission.