### PR TITLE
Preserve class priority

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
@@ -119,6 +119,9 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
     result += `${indent}${indent}(class ${stringifyValue(cls.name)} ${stringifyValue(cls.description)}${cls.net_names.map((n) => ` ${stringifyValue(n)}`).join("")}\n`
     result += `${indent}${indent}${indent}(circuit\n`
     result += `${indent}${indent}${indent}${indent}(use_via ${stringifyValue(cls.circuit.use_via)})\n`
+    if (cls.circuit.priority !== undefined) {
+      result += `${indent}${indent}${indent}${indent}(priority ${cls.circuit.priority})\n`
+    }
     result += `${indent}${indent}${indent})\n`
     if (cls.rule) {
       result += `${indent}${indent}${indent}(rule\n`

--- a/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
@@ -890,16 +890,22 @@ function processClass(nodes: ASTNode[]): Class {
 function processCircuit(nodes: ASTNode[]): Circuit {
   const circuit: Partial<Circuit> = {}
   nodes.forEach((node) => {
-    if (
-      node.type === "List" &&
-      node.children![0].type === "Atom" &&
-      node.children![0].value === "use_via"
-    ) {
-      if (
-        node.children![1].type === "Atom" &&
-        typeof node.children![1].value === "string"
-      ) {
-        circuit.use_via = node.children![1].value
+    if (node.type === "List") {
+      const [keyNode, valueNode] = node.children!
+      if (keyNode.type === "Atom" && typeof keyNode.value === "string") {
+        if (
+          keyNode.value === "use_via" &&
+          valueNode.type === "Atom" &&
+          typeof valueNode.value === "string"
+        ) {
+          circuit.use_via = valueNode.value
+        } else if (
+          keyNode.value === "priority" &&
+          valueNode.type === "Atom" &&
+          typeof valueNode.value === "number"
+        ) {
+          circuit.priority = valueNode.value
+        }
       }
     }
   })

--- a/lib/dsn-pcb/types.ts
+++ b/lib/dsn-pcb/types.ts
@@ -55,9 +55,7 @@ export interface DsnPcb {
       name: string
       description: string
       net_names: string[]
-      circuit: {
-        use_via: string
-      }
+      circuit: Circuit
       rule: {
         clearances: Array<{
           type?: any
@@ -262,6 +260,7 @@ export interface Class {
 
 export interface Circuit {
   use_via: string
+  priority?: number
 }
 
 export interface Wiring {

--- a/tests/dsn-pcb/class-priority.test.ts
+++ b/tests/dsn-pcb/class-priority.test.ts
@@ -1,0 +1,56 @@
+import { expect, test } from "bun:test"
+import { stringifyDsnJson } from "lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json"
+import { parseDsnToDsnJson } from "lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json"
+import type { DsnPcb } from "lib/dsn-pcb/types"
+
+test("preserves class circuit priority descriptors", () => {
+  const dsnJson = parseDsnToDsnJson(`(pcb board
+  (parser
+    (space_in_quoted_tokens on)
+    (host_cad "test")
+    (host_version "1")
+  )
+  (resolution um 10)
+  (unit um)
+  (structure
+    (layer F.Cu
+      (type signal)
+      (property (index 0))
+    )
+    (boundary
+      (path pcb 0 0 0 100 0 100 100 0 100 0 0)
+    )
+    (via Via)
+    (rule
+      (width 100)
+      (clearance 100)
+    )
+  )
+  (placement)
+  (library)
+  (network
+    (net N1
+      (pins U1-1 U2-1)
+    )
+    (class C1 "" N1
+      (circuit
+        (use_via Via)
+        (priority 42)
+      )
+      (rule
+        (width 100)
+        (clearance 100)
+      )
+    )
+  )
+  (wiring)
+)`) as DsnPcb
+
+  expect(dsnJson.network.classes[0].circuit.priority).toBe(42)
+
+  const stringified = stringifyDsnJson(dsnJson)
+  expect(stringified).toContain("(priority 42)")
+
+  const reparsed = parseDsnToDsnJson(stringified) as DsnPcb
+  expect(reparsed.network.classes[0].circuit.priority).toBe(42)
+})


### PR DESCRIPTION
Summary
- Preserve DSN class circuit `(priority ...)` descriptors while parsing PCB network classes.
- Emit preserved priority metadata from `stringifyDsnJson` so PCB parse -> stringify -> parse keeps class routing priority.
- Add focused round-trip regression coverage for class circuit priority descriptors.

Verification
- bun test tests/dsn-pcb/class-priority.test.ts
- bun test
- bunx tsc --noEmit
- bunx biome check lib/dsn-pcb/types.ts lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts tests/dsn-pcb/class-priority.test.ts
- bun run build
- git diff --check

/claim #54

Transparency note: AI-assisted with Codex; I reviewed the diff and verified it locally before submission.