### PR TITLE
Preserve clearance layer depth

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
@@ -26,6 +26,21 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
     return `${padding}(path ${path.layer} ${path.width}  ${stringifyCoordinates(path.coordinates)})`
   }
 
+  const stringifyClearance = (clearance: {
+    value: number
+    type?: string
+    layer_depth?: number
+  }): string => {
+    if (!clearance.type) {
+      return `(clearance ${clearance.value})`
+    }
+    const layerDepth =
+      clearance.layer_depth !== undefined
+        ? ` (layer_depth ${clearance.layer_depth})`
+        : ""
+    return `(clearance ${clearance.value} (type ${clearance.type}${layerDepth}))`
+  }
+
   // Start with pcb
   result += `(pcb ${dsnJson.filename ? dsnJson.filename : "./converted_dsn.dsn"}\n`
 
@@ -60,7 +75,7 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
   result += `${indent}${indent}(rule\n`
   result += `${indent}${indent}${indent}(width ${dsnJson.structure.rule.width})\n`
   dsnJson.structure.rule.clearances.forEach((clearance) => {
-    result += `${indent}${indent}${indent}(clearance ${clearance.value}${clearance.type ? ` (type ${clearance.type})` : ""})\n`
+    result += `${indent}${indent}${indent}${stringifyClearance(clearance)}\n`
   })
   result += `${indent}${indent})\n`
   result += `${indent})\n`
@@ -124,7 +139,7 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
       result += `${indent}${indent}${indent}(rule\n`
       result += `${indent}${indent}${indent}${indent}(width ${cls.rule.width})\n`
       cls.rule.clearances.forEach((clearance) => {
-        result += `${indent}${indent}${indent}${indent}(clearance ${clearance.value}${clearance.type ? ` (type ${clearance.type})` : ""})\n`
+        result += `${indent}${indent}${indent}${indent}${stringifyClearance(clearance)}\n`
       })
       result += `${indent}${indent}${indent})\n`
     }

--- a/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
@@ -391,6 +391,19 @@ function processClearance(nodes: ASTNode[]): Clearance {
         typeof valueNode.value === "string"
       ) {
         clearance.type = valueNode.value
+        const layerDepthNode = node.children!.find(
+          (child) =>
+            child.type === "List" &&
+            child.children?.[0]?.type === "Atom" &&
+            child.children[0].value === "layer_depth",
+        )
+        if (
+          layerDepthNode?.type === "List" &&
+          layerDepthNode.children?.[1]?.type === "Atom" &&
+          typeof layerDepthNode.children[1].value === "number"
+        ) {
+          clearance.layer_depth = layerDepthNode.children[1].value
+        }
       }
     }
   }

--- a/lib/dsn-pcb/types.ts
+++ b/lib/dsn-pcb/types.ts
@@ -35,6 +35,7 @@ export interface DsnPcb {
       clearances: Array<{
         value: number
         type?: string
+        layer_depth?: number
       }>
       width: number
     }
@@ -62,6 +63,7 @@ export interface DsnPcb {
         clearances: Array<{
           type?: any
           value: number
+          layer_depth?: number
         }>
         width: number
       }
@@ -153,6 +155,7 @@ export interface Rule {
 export interface Clearance {
   value: number
   type?: string
+  layer_depth?: number
 }
 
 export interface Placement {

--- a/tests/dsn-pcb/clearance-layer-depth.test.ts
+++ b/tests/dsn-pcb/clearance-layer-depth.test.ts
@@ -1,0 +1,52 @@
+import { expect, test } from "bun:test"
+import { stringifyDsnJson } from "lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json"
+import { parseDsnToDsnJson } from "lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json"
+import type { DsnPcb } from "lib/dsn-pcb/types"
+
+test("preserves clearance layer_depth metadata", () => {
+  const dsnJson = parseDsnToDsnJson(`(pcb board
+  (parser
+    (space_in_quoted_tokens on)
+    (host_cad "test")
+    (host_version "1")
+  )
+  (resolution um 10)
+  (unit um)
+  (structure
+    (layer F.Cu
+      (type signal)
+      (property (index 0))
+    )
+    (boundary
+      (path pcb 0 0 0 100 0 100 100 0 100 0 0)
+    )
+    (via Via)
+    (rule
+      (width 100)
+      (clearance 80 (type buried_via_gap (layer_depth 2)))
+    )
+  )
+  (placement)
+  (library)
+  (network)
+  (wiring)
+)`) as DsnPcb
+
+  expect(dsnJson.structure.rule.clearances[0]).toMatchObject({
+    value: 80,
+    type: "buried_via_gap",
+    layer_depth: 2,
+  })
+
+  const stringified = stringifyDsnJson(dsnJson)
+  expect(stringified).toContain(
+    "(clearance 80 (type buried_via_gap (layer_depth 2)))",
+  )
+
+  const reparsed = parseDsnToDsnJson(stringified) as DsnPcb
+  expect(reparsed.structure.rule.clearances[0]).toMatchObject({
+    value: 80,
+    type: "buried_via_gap",
+    layer_depth: 2,
+  })
+})


### PR DESCRIPTION
Summary
- Preserve optional SPECCTRA clearance `(layer_depth ...)` metadata nested under clearance type descriptors.
- Emit preserved clearance layer_depth metadata from `stringifyDsnJson` for structure and class rules.
- Add focused round-trip regression coverage for buried_via_gap clearance layer_depth metadata.

Verification
- bun test tests/dsn-pcb/clearance-layer-depth.test.ts
- bun test
- bunx tsc --noEmit
- bunx biome check lib/dsn-pcb/types.ts lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts tests/dsn-pcb/clearance-layer-depth.test.ts
- bun run build
- git diff --check

/claim #54

Transparency note: AI-assisted with Codex; I reviewed the diff and verified it locally before submission.