### PR TITLE
Preserve padstack attach use via

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
@@ -101,7 +101,7 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
         result += `${indent}${indent}${indent}(shape (path ${shape.layer} ${shape.width} ${stringifyCoordinates(shape.coordinates)}))\n`
       }
     })
-    result += `${indent}${indent}${indent}(attach ${padstack.attach})\n`
+    result += `${indent}${indent}${indent}(attach ${padstack.attach}${padstack.attach_use_via ? ` (use_via ${padstack.attach_use_via})` : ""})\n`
     result += `${indent}${indent})\n`
   })
   result += `${indent})\n`

--- a/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
@@ -659,6 +659,19 @@ function processPadstack(nodes: ASTNode[]): Padstack {
           if (rest[0].type === "Atom" && typeof rest[0].value === "string") {
             padstack.attach = rest[0].value
           }
+          const useViaNode = rest.find(
+            (child) =>
+              child.type === "List" &&
+              child.children?.[0]?.type === "Atom" &&
+              child.children[0].value === "use_via",
+          )
+          if (
+            useViaNode?.type === "List" &&
+            useViaNode.children?.[1]?.type === "Atom" &&
+            typeof useViaNode.children[1].value === "string"
+          ) {
+            padstack.attach_use_via = useViaNode.children[1].value
+          }
         }
       }
     }

--- a/lib/dsn-pcb/types.ts
+++ b/lib/dsn-pcb/types.ts
@@ -199,6 +199,7 @@ export interface Padstack {
   name: string
   shapes: Shape[]
   attach: string
+  attach_use_via?: string
   hole?: {
     shape: "circle" | "square" | "oval"
     width?: number

--- a/tests/dsn-pcb/padstack-attach-use-via.test.ts
+++ b/tests/dsn-pcb/padstack-attach-use-via.test.ts
@@ -1,0 +1,49 @@
+import { expect, test } from "bun:test"
+import { stringifyDsnJson } from "lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json"
+import { parseDsnToDsnJson } from "lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json"
+import type { DsnPcb } from "lib/dsn-pcb/types"
+
+test("preserves padstack attach use_via descriptors", () => {
+  const dsnJson = parseDsnToDsnJson(`(pcb board
+  (parser
+    (space_in_quoted_tokens on)
+    (host_cad "test")
+    (host_version "1")
+  )
+  (resolution um 10)
+  (unit um)
+  (structure
+    (layer F.Cu
+      (type signal)
+      (property (index 0))
+    )
+    (boundary
+      (path pcb 0 0 0 100 0 100 100 0 100 0 0)
+    )
+    (via Via)
+    (rule
+      (width 100)
+      (clearance 100)
+    )
+  )
+  (placement)
+  (library
+    (padstack AttachPad
+      (shape (circle F.Cu 100))
+      (attach on (use_via Via))
+    )
+  )
+  (network)
+  (wiring)
+)`) as DsnPcb
+
+  expect(dsnJson.library.padstacks[0].attach).toBe("on")
+  expect(dsnJson.library.padstacks[0].attach_use_via).toBe("Via")
+
+  const stringified = stringifyDsnJson(dsnJson)
+  expect(stringified).toContain("(attach on (use_via Via))")
+
+  const reparsed = parseDsnToDsnJson(stringified) as DsnPcb
+  expect(reparsed.library.padstacks[0].attach).toBe("on")
+  expect(reparsed.library.padstacks[0].attach_use_via).toBe("Via")
+})


### PR DESCRIPTION
Summary
- Preserve optional SPECCTRA padstack `(attach on (use_via ...))` metadata while parsing PCB library padstacks.
- Emit preserved attach use_via metadata from `stringifyDsnJson` so PCB parse -> stringify -> parse keeps the selected via padstack.
- Add focused round-trip regression coverage for padstack attach use_via metadata.

Verification
- bun test tests/dsn-pcb/padstack-attach-use-via.test.ts
- bun test
- bunx tsc --noEmit
- bunx biome check lib/dsn-pcb/types.ts lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts tests/dsn-pcb/padstack-attach-use-via.test.ts
- bun run build
- git diff --check

/claim #54

Transparency note: AI-assisted with Codex; I reviewed the diff and verified it locally before submission.