### PR TITLE
Preserve net exposure metadata

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
@@ -113,6 +113,12 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
     if (net.pins.length > 0) {
       result += `${indent}${indent}${indent}(pins ${net.pins.join(" ")})\n`
     }
+    if (net.expose?.length) {
+      result += `${indent}${indent}${indent}(expose ${net.expose.join(" ")})\n`
+    }
+    if (net.noexpose?.length) {
+      result += `${indent}${indent}${indent}(noexpose ${net.noexpose.join(" ")})\n`
+    }
     result += `${indent}${indent})\n`
   })
   dsnJson.network.classes.forEach((cls) => {

--- a/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
@@ -825,18 +825,25 @@ function processNet(nodes: ASTNode[]): Net {
   }
 
   nodes.slice(2).forEach((node) => {
-    if (
-      node.type === "List" &&
-      node.children![0].type === "Atom" &&
-      node.children![0].value === "pins"
-    ) {
-      net.pins = node.children!.slice(1).map((pinNode) => {
-        if (pinNode.type === "Atom" && typeof pinNode.value === "string") {
-          return pinNode.value
-        } else {
-          throw new Error("Invalid pin in net")
-        }
-      })
+    if (node.type === "List" && node.children![0].type === "Atom") {
+      const key = node.children![0].value
+      if (key === "pins") {
+        net.pins = node.children!.slice(1).map((pinNode) => {
+          if (pinNode.type === "Atom" && typeof pinNode.value === "string") {
+            return pinNode.value
+          } else {
+            throw new Error("Invalid pin in net")
+          }
+        })
+      } else if (key === "expose" || key === "noexpose") {
+        net[key] = node
+          .children!.slice(1)
+          .filter(
+            (pinNode) =>
+              pinNode.type === "Atom" && typeof pinNode.value === "string",
+          )
+          .map((pinNode) => String(pinNode.value))
+      }
     }
   })
   return net as Net

--- a/lib/dsn-pcb/types.ts
+++ b/lib/dsn-pcb/types.ts
@@ -47,10 +47,7 @@ export interface DsnPcb {
     padstacks: Padstack[]
   }
   network: {
-    nets: Array<{
-      name: string
-      pins: string[]
-    }>
+    nets: Net[]
     classes: Array<{
       name: string
       description: string
@@ -250,6 +247,8 @@ export interface Network {
 export interface Net {
   name: string
   pins: string[]
+  expose?: string[]
+  noexpose?: string[]
 }
 
 export interface Class {

--- a/tests/dsn-pcb/net-exposure.test.ts
+++ b/tests/dsn-pcb/net-exposure.test.ts
@@ -1,0 +1,51 @@
+import { expect, test } from "bun:test"
+import { stringifyDsnJson } from "lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json"
+import { parseDsnToDsnJson } from "lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json"
+import type { DsnPcb } from "lib/dsn-pcb/types"
+
+test("preserves net expose and noexpose descriptors", () => {
+  const dsnJson = parseDsnToDsnJson(`(pcb board
+  (parser
+    (space_in_quoted_tokens on)
+    (host_cad "test")
+    (host_version "1")
+  )
+  (resolution um 10)
+  (unit um)
+  (structure
+    (layer F.Cu
+      (type signal)
+      (property (index 0))
+    )
+    (boundary
+      (path pcb 0 0 0 100 0 100 100 0 100 0 0)
+    )
+    (via Via)
+    (rule
+      (width 100)
+      (clearance 100)
+    )
+  )
+  (placement)
+  (library)
+  (network
+    (net N1
+      (pins U1-1 U2-1 U3-1)
+      (expose U1-1 U2-1)
+      (noexpose U3-1)
+    )
+  )
+  (wiring)
+)`) as DsnPcb
+
+  expect(dsnJson.network.nets[0].expose).toEqual(["U1-1", "U2-1"])
+  expect(dsnJson.network.nets[0].noexpose).toEqual(["U3-1"])
+
+  const stringified = stringifyDsnJson(dsnJson)
+  expect(stringified).toContain("(expose U1-1 U2-1)")
+  expect(stringified).toContain("(noexpose U3-1)")
+
+  const reparsed = parseDsnToDsnJson(stringified) as DsnPcb
+  expect(reparsed.network.nets[0].expose).toEqual(["U1-1", "U2-1"])
+  expect(reparsed.network.nets[0].noexpose).toEqual(["U3-1"])
+})


### PR DESCRIPTION
Summary
- Preserve DSN net `(expose ...)` and `(noexpose ...)` descriptors while parsing PCB network nets.
- Emit preserved net exposure metadata from `stringifyDsnJson` so PCB parse -> stringify -> parse keeps exposure constraints.
- Add focused round-trip regression coverage for net exposure metadata.

Verification
- bun test tests/dsn-pcb/net-exposure.test.ts
- bun test
- bunx tsc --noEmit
- bunx biome check lib/dsn-pcb/types.ts lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts tests/dsn-pcb/net-exposure.test.ts
- bun run build
- git diff --check

/claim #54

Transparency note: AI-assisted with Codex; I reviewed the diff and verified it locally before submission.