### PR TITLE
Preserve image unit metadata

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
@@ -82,6 +82,9 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
   result += `${indent}(library\n`
   dsnJson.library.images.forEach((image) => {
     result += `${indent}${indent}(image ${stringifyValue(image.name)}\n`
+    if (image.unit) {
+      result += `${indent}${indent}${indent}(unit ${image.unit})\n`
+    }
     image.outlines.forEach((outline) => {
       result += `${indent}${indent}${indent}(outline ${stringifyPath(outline.path, 4)})\n`
     })

--- a/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
@@ -540,7 +540,11 @@ function processImage(nodes: ASTNode[]): Image {
       const [keyNode, ...rest] = node.children!
       if (keyNode.type === "Atom" && typeof keyNode.value === "string") {
         const key = keyNode.value
-        if (key === "outline") {
+        if (key === "unit") {
+          if (rest[0]?.type === "Atom" && typeof rest[0].value === "string") {
+            image.unit = rest[0].value
+          }
+        } else if (key === "outline") {
           image.outlines!.push(processOutline(node.children!))
         } else if (key === "pin") {
           const pin = processPin(node.children!)

--- a/lib/dsn-pcb/types.ts
+++ b/lib/dsn-pcb/types.ts
@@ -180,6 +180,7 @@ export interface Library {
 
 export interface Image {
   name: string
+  unit?: string
   outlines: Outline[]
   pins: Pin[]
 }

--- a/tests/dsn-pcb/image-unit.test.ts
+++ b/tests/dsn-pcb/image-unit.test.ts
@@ -1,0 +1,53 @@
+import { expect, test } from "bun:test"
+import { type DsnPcb, parseDsnToDsnJson, stringifyDsnJson } from "lib"
+
+const imageUnitDsn = `(pcb image_unit_test
+  (parser
+    (space_in_quoted_tokens on)
+    (host_cad "unit test")
+    (host_version "1")
+  )
+  (resolution um 10)
+  (unit um)
+  (structure
+    (layer F.Cu
+      (type signal)
+      (property
+        (index 0)
+      )
+    )
+    (boundary
+      (path pcb 0 0 0 1000 0 1000 1000 0 1000 0 0)
+    )
+    (via Via)
+    (rule
+      (width 100)
+      (clearance 100)
+    )
+  )
+  (placement)
+  (library
+    (image U1
+      (unit mil)
+      (pin PAD 1 0 0)
+    )
+    (padstack PAD
+      (shape (circle F.Cu 10))
+      (attach off)
+    )
+  )
+  (network)
+  (wiring)
+)`
+
+test("preserves image-level unit descriptors", () => {
+  const parsed = parseDsnToDsnJson(imageUnitDsn) as DsnPcb
+
+  expect(parsed.library.images[0].unit).toBe("mil")
+
+  const stringified = stringifyDsnJson(parsed)
+  expect(stringified).toContain("(unit mil)")
+
+  const reparsed = parseDsnToDsnJson(stringified) as DsnPcb
+  expect(reparsed.library.images[0].unit).toBe("mil")
+})


### PR DESCRIPTION
Summary
- Preserve image-level DSN `(unit ...)` descriptors while parsing PCB library images.
- Emit preserved image unit metadata from `stringifyDsnJson` so image-local units survive parse -> stringify -> parse.
- Add focused round-trip regression coverage for image unit metadata.

Verification
- bun test tests/dsn-pcb/image-unit.test.ts
- bun test
- bunx tsc --noEmit
- bunx biome check lib/dsn-pcb/types.ts lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts tests/dsn-pcb/image-unit.test.ts
- bun run build
- git diff --check

/claim #54

Transparency note: AI-assisted with Codex; I reviewed the diff and verified it locally before submission.