### PR TITLE
Preserve numeric parser host_version values

### DIFF
--- a/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
@@ -182,7 +182,7 @@ export function processParser(nodes: ASTNode[]): ParserType {
             if (typeof value === "string") parser.host_cad = value
             break
           case "host_version":
-            if (typeof value === "string") parser.host_version = value
+            parser.host_version = String(value)
             break
         }
       }

--- a/tests/dsn-pcb/parser-host-version.test.ts
+++ b/tests/dsn-pcb/parser-host-version.test.ts
@@ -1,0 +1,46 @@
+import { expect, test } from "bun:test"
+import { stringifyDsnJson } from "../../lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json"
+import { parseDsnToDsnJson } from "../../lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json"
+import type { DsnPcb } from "../../lib/dsn-pcb/types"
+
+test("preserves numeric parser host version", () => {
+  const dsn = `(pcb numeric-host-version
+  (parser
+    (string_quote ")
+    (space_in_quoted_tokens on)
+    (host_cad "KiCad")
+    (host_version 2024)
+  )
+  (resolution um 10)
+  (unit um)
+  (structure
+    (layer F.Cu
+      (type signal)
+      (property
+        (index 0)
+      )
+    )
+    (via "Via")
+    (rule
+      (width 100)
+      (clearance 100)
+    )
+  )
+  (placement)
+  (library)
+  (network)
+  (wiring)
+)`
+
+  const dsnJson = parseDsnToDsnJson(dsn) as DsnPcb
+
+  expect(dsnJson.parser.host_version).toBe("2024")
+
+  const dsnString = stringifyDsnJson(dsnJson)
+
+  expect(dsnString).toContain('(host_version "2024")')
+
+  const reparsedJson = parseDsnToDsnJson(dsnString) as DsnPcb
+
+  expect(reparsedJson.parser.host_version).toBe("2024")
+})


### PR DESCRIPTION
﻿## Summary
- Normalize numeric DSN parser `host_version` atoms to strings instead of dropping them.
- Add a focused parse -> stringify -> parse regression for `(host_version 2024)`.
- Keep the change scoped to parser metadata; no Circuit JSON conversion behavior changes.

## Verification
- `npx.cmd bun --config=.codex-empty-bunfig.toml test tests/dsn-pcb/parser-host-version.test.ts` (1 pass; temporary empty config used locally to avoid the unrelated `bun-match-svg`/`sharp` preload issue on Windows)
- `npm.cmd run build`
- `npx.cmd --yes @biomejs/biome@1.9.4 format lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts tests/dsn-pcb/parser-host-version.test.ts`
- `git diff --check`

/claim #54

Transparency: AI-assisted with Codex; I reviewed the diff and local verification before submission.
