### PR TITLE
fix: tokenizer corrupts voltage net names (3.3V→3.3, 5V→5, 12VREG→12)

### DIFF
--- a/lib/common/parse-sexpr.ts
+++ b/lib/common/parse-sexpr.ts
@@ -45,7 +45,7 @@ export function tokenizeDsn(input: string): Token[] {
       i++ // Skip the closing quote
       tokens.push({ type: "String", value })
     } else if (char === "-" || /\d/.test(char)) {
-      // Parse number (integer or float)
+      // Parse number or symbol starting with digit/minus (e.g. "3.3V", "5V", "-5V")
       let numStr = ""
       if (char === "-") {
         numStr += "-"
@@ -55,7 +55,27 @@ export function tokenizeDsn(input: string): Token[] {
         numStr += input[i]
         i++
       }
-      tokens.push({ type: "Number", value: parseFloat(numStr) })
+      // Handle scientific notation (e.g. 1.23e-10, 5E+3)
+      if (
+        i < length &&
+        (input[i] === "e" || input[i] === "E") &&
+        i + 1 < length &&
+        (/\d/.test(input[i + 1]) ||
+          ((input[i + 1] === "-" || input[i + 1] === "+") &&
+            i + 2 < length &&
+            /\d/.test(input[i + 2])))
+      ) {
+        numStr += input[i++]
+        if (input[i] === "-" || input[i] === "+") numStr += input[i++]
+        while (i < length && /\d/.test(input[i])) numStr += input[i++]
+      }
+      // If followed by a non-delimiter, this is a symbol not a plain number
+      if (i < length && !/[\s()"]/.test(input[i])) {
+        while (i < length && !/[\s()"]/.test(input[i])) numStr += input[i++]
+        tokens.push({ type: "Symbol", value: numStr })
+      } else {
+        tokens.push({ type: "Number", value: parseFloat(numStr) })
+      }
     } else {
       // Parse symbol
       let sym = ""

--- a/tests/dsn-pcb/tokenize-number-like-symbols.test.ts
+++ b/tests/dsn-pcb/tokenize-number-like-symbols.test.ts
@@ -1,0 +1,48 @@
+import { expect, test } from "bun:test"
+import { tokenizeDsn } from "../../lib/common/parse-sexpr"
+
+test("tokenizes voltage net names as symbols, not truncated numbers", () => {
+  // Before fix: "3.3V" was tokenized as Number(3.3) + Symbol("V"), causing
+  // net names like "3.3V" to be stored as "3.3" after the number parser consumed
+  // the leading digits and dropped the trailing "V".
+  const tokens = tokenizeDsn("(net 3.3V)")
+  expect(tokens[2]).toEqual({ type: "Symbol", value: "3.3V" })
+
+  const tokens2 = tokenizeDsn("(net 5V)")
+  expect(tokens2[2]).toEqual({ type: "Symbol", value: "5V" })
+
+  const tokens3 = tokenizeDsn("(net 12VREG)")
+  expect(tokens3[2]).toEqual({ type: "Symbol", value: "12VREG" })
+
+  const tokens4 = tokenizeDsn("(net -5V)")
+  expect(tokens4[2]).toEqual({ type: "Symbol", value: "-5V" })
+})
+
+test("still parses plain numbers correctly", () => {
+  const tokens = tokenizeDsn("(pin Rect 1 -650 3.14)")
+  expect(tokens[3]).toEqual({ type: "Number", value: 1 })
+  expect(tokens[4]).toEqual({ type: "Number", value: -650 })
+  expect(tokens[5]).toEqual({ type: "Number", value: 3.14 })
+})
+
+test("parses scientific notation as numbers", () => {
+  // (rule (clearance 5.68e-11)) → LParen Symbol LParen Symbol Number RParen RParen
+  const tokens = tokenizeDsn("(rule (clearance 5.68e-11))")
+  expect(tokens[4]).toEqual({ type: "Number", value: 5.68e-11 })
+
+  const tokens2 = tokenizeDsn("(rule (clearance 1.2E+3))")
+  expect(tokens2[4]).toEqual({ type: "Number", value: 1.2e3 })
+})
+
+test("smoothieboard net names are preserved after tokenizer fix", async () => {
+  const { parseDsnToDsnJson } = await import("../../lib/index")
+  // @ts-ignore
+  const dsnText = await Bun.file(
+    "tests/assets/repro/smoothieboard-repro.dsn",
+  ).text()
+  const dsnJson = parseDsnToDsnJson(dsnText) as any
+  const netNames = (dsnJson.network?.nets ?? []).map((n: any) => n.name)
+  expect(netNames).toContain("3.3V")
+  expect(netNames).toContain("5V")
+  expect(netNames).toContain("12VREG")
+})


### PR DESCRIPTION
## Root cause

The DSN s-expression tokenizer treated every token starting with a digit as a `Number`. When it encountered `3.3V`, it consumed `3.3` as a number and then discarded the trailing `V` (the symbol branch never ran for the remainder). Net names like `3.3V`, `5V`, and `12VREG` from the Smoothie Board were silently stored as `3.3`, `5`, and `12`.

## Fix (`lib/common/parse-sexpr.ts`)

After consuming the numeric prefix (`3.3`, `5`, `12`), peek at the next character. If it is not a delimiter (`\s`, `(`, `)`, `"`), continue reading the rest as part of the token and emit a `Symbol` instead of a `Number`. Scientific notation (`5.68e-11`, `1.2E+3`) is handled before this check and still emits a `Number`.

## Tests

`tests/dsn-pcb/tokenize-number-like-symbols.test.ts` — 4 cases:
1. Voltage net names tokenized as `Symbol`, not truncated `Number`
2. Plain integers and floats still tokenized as `Number`
3. Scientific notation still tokenized as `Number`
4. Integration: Smoothie Board net names `3.3V`, `5V`, `12VREG` present after parse

## CI

- format-check: ✓
- type-check: ✓
- bun-test: ✓ (51/51 pass)

/claim #54