### PR TITLE
fix: preserve voltage-style DSN net names during tokenization

### DIFF
--- a/lib/common/parse-sexpr.ts
+++ b/lib/common/parse-sexpr.ts
@@ -44,26 +44,23 @@ export function tokenizeDsn(input: string): Token[] {
       }
       i++ // Skip the closing quote
       tokens.push({ type: "String", value })
-    } else if (char === "-" || /\d/.test(char)) {
-      // Parse number (integer or float)
-      let numStr = ""
-      if (char === "-") {
-        numStr += "-"
-        i++
-      }
-      while (i < length && /[\d.]/.test(input[i])) {
-        numStr += input[i]
-        i++
-      }
-      tokens.push({ type: "Number", value: parseFloat(numStr) })
     } else {
-      // Parse symbol
-      let sym = ""
+      // Parse an unquoted atom. DSN atom names can start with digits, e.g.
+      // voltage-like net names such as 3.3V, 5V, 12VREG, or -5V. Read the
+      // whole atom first, then classify it as a number only when the entire
+      // atom is numeric.
+      let atom = ""
       while (i < length && !/\s|\(|\)/.test(input[i])) {
-        sym += input[i]
+        atom += input[i]
         i++
       }
-      tokens.push({ type: "Symbol", value: sym })
+
+      const numberPattern = /^[+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?$/
+      if (numberPattern.test(atom)) {
+        tokens.push({ type: "Number", value: Number(atom) })
+      } else {
+        tokens.push({ type: "Symbol", value: atom })
+      }
     }
   }
 

--- a/tests/dsn-pcb/tokenize-number-like-symbols.test.ts
+++ b/tests/dsn-pcb/tokenize-number-like-symbols.test.ts
@@ -1,0 +1,46 @@
+import { expect, test } from "bun:test"
+import { parseSexprToAst, tokenizeDsn } from "../../lib/common/parse-sexpr"
+
+test("tokenizeDsn treats voltage-style net names as symbols, not split numbers", () => {
+  const tokens = tokenizeDsn("(network (net 3.3V) (net 5V) (net 12VREG) (net -5V) (point -12.5 3.14 5.68e-11))")
+
+  expect(tokens).toContainEqual({ type: "Symbol", value: "3.3V" })
+  expect(tokens).toContainEqual({ type: "Symbol", value: "5V" })
+  expect(tokens).toContainEqual({ type: "Symbol", value: "12VREG" })
+  expect(tokens).toContainEqual({ type: "Symbol", value: "-5V" })
+  expect(tokens).toContainEqual({ type: "Number", value: -12.5 })
+  expect(tokens).toContainEqual({ type: "Number", value: 3.14 })
+  expect(tokens).toContainEqual({ type: "Number", value: 5.68e-11 })
+})
+
+test("parseSexprToAst preserves number-like net atom values", () => {
+  const ast = parseSexprToAst(tokenizeDsn("(network (net 3.3V) (net 5V) (net 12VREG))"))
+
+  expect(ast).toEqual({
+    type: "List",
+    children: [
+      { type: "Atom", value: "network" },
+      {
+        type: "List",
+        children: [
+          { type: "Atom", value: "net" },
+          { type: "Atom", value: "3.3V" },
+        ],
+      },
+      {
+        type: "List",
+        children: [
+          { type: "Atom", value: "net" },
+          { type: "Atom", value: "5V" },
+        ],
+      },
+      {
+        type: "List",
+        children: [
+          { type: "Atom", value: "net" },
+          { type: "Atom", value: "12VREG" },
+        ],
+      },
+    ],
+  })
+})

--- a/tests/repros/repro7-smoothie-board.test.ts
+++ b/tests/repros/repro7-smoothie-board.test.ts
@@ -9,6 +9,11 @@ import dsnFileWithFreeroutingTrace from "../assets/repro/smoothieboard-repro.dsn
 
 test("smoothieboard repro", async () => {
   const dsnJson = parseDsnToDsnJson(dsnFileWithFreeroutingTrace) as DsnPcb
+  const netNames = dsnJson.network.nets.map((net) => net.name)
+
+  expect(netNames).toContain("3.3V")
+  expect(netNames).toContain("5V")
+  expect(netNames).toContain("12VREG")
 
   const circuitJson = convertDsnPcbToCircuitJson(dsnJson)
 


### PR DESCRIPTION
## Maintainer / Algora note

PR #451 was an accidental duplicate from an auth watcher and has been closed; its duplicate claim command has now been removed from the closed PR body. This PR (#450) is the active PR for the same branch/commit and `/claim #54`. The current Algora claim page now resolves to this active PR: https://algora.io/claims/b6GMigvFnmTj8nZX. I also checked the overlapping tokenizer PRs (#446/#444/#148): this one keeps the classifier at whole-atom level, so pure numeric DSN atoms still parse as numbers while voltage-style/net-name atoms such as `3.3V`, `5V`, `12VREG`, and `-5V` stay symbols. The Smoothieboard repro assertions are included here.

## Summary
- Tokenize unquoted DSN atoms by reading the whole atom first.
- Parse an atom as a `Number` only when the full atom matches a numeric literal.
- Preserve voltage-style Smoothieboard net names like `3.3V`, `5V`, `12VREG`, and `-5V` as symbols.
- Add regression tests for the tokenizer and the Smoothieboard repro.

## Test Plan
- [x] `bun test tests/dsn-pcb/tokenize-number-like-symbols.test.ts tests/repros/repro7-smoothie-board.test.ts`
- [x] `bun test`
- [x] `bun run build`

/claim #54
