### PR TITLE
Preserve wiring via type metadata

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
@@ -136,7 +136,7 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
   result += `${indent}(wiring\n`
   ;(dsnJson.wiring?.wires ?? []).forEach((wire) => {
     if (wire.type === "via") {
-      result += `${indent}${indent}(via ${stringifyPath(wire.path, 3)}(net ${stringifyValue(wire.net)}))\n`
+      result += `${indent}${indent}(via ${stringifyPath(wire.path, 3)}(net ${stringifyValue(wire.net)})${wire.via_type ? `(type ${wire.via_type})` : ""})\n`
     } else {
       result += `${indent}${indent}(wire ${stringifyPath(wire.path, 3)}(net ${stringifyValue(wire.net)})(type ${wire.type}))\n`
     }

--- a/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
@@ -959,6 +959,17 @@ function processVia(nodes: ASTNode[]): Wire | null {
     wire.net = String(netNode.children[1].value)
   }
 
+  const typeNode = nodes.find(
+    (node) =>
+      node.type === "List" &&
+      node.children?.[0]?.type === "Atom" &&
+      node.children[0].value === "type",
+  )
+
+  if (typeNode?.children?.[1]?.type === "Atom") {
+    wire.via_type = String(typeNode.children[1].value)
+  }
+
   return wire as Wire
 }
 

--- a/lib/dsn-pcb/types.ts
+++ b/lib/dsn-pcb/types.ts
@@ -79,6 +79,7 @@ export interface DsnPcb {
       }
       net: string
       type: string
+      via_type?: string
     }>
   }
 }
@@ -282,6 +283,7 @@ export interface Wire {
   net?: string
   clearance_class?: string
   type?: string
+  via_type?: string
 }
 
 export interface Via {

--- a/tests/dsn-pcb/dsn-wiring-via-type.test.ts
+++ b/tests/dsn-pcb/dsn-wiring-via-type.test.ts
@@ -1,0 +1,54 @@
+import { expect, test } from "bun:test"
+import { type DsnPcb, parseDsnToDsnJson, stringifyDsnJson } from "lib"
+
+test("preserves wiring via type metadata", () => {
+  const dsn = `(pcb "via-type.dsn"
+  (parser
+    (string_quote ")
+    (space_in_quoted_tokens on)
+    (host_cad "KiCad's Pcbnew")
+    (host_version "8.0")
+  )
+  (resolution um 10)
+  (unit um)
+  (structure
+    (layer F.Cu (type signal) (property (index 0)))
+    (layer B.Cu (type signal) (property (index 1)))
+    (boundary (path pcb 0 0 0 10000 0 10000 10000 0 10000 0 0))
+    (via "Via[0-1]_800:400_um")
+    (rule (width 200) (clearance 200))
+  )
+  (placement)
+  (library
+    (padstack "Via[0-1]_800:400_um"
+      (shape (circle F.Cu 800))
+      (shape (circle B.Cu 800))
+      (attach off)
+    )
+  )
+  (network
+    (net AGND
+      (pins U1-1)
+    )
+    (class kicad_default "" AGND
+      (circuit (use_via "Via[0-1]_800:400_um"))
+      (rule (width 200) (clearance 200))
+    )
+  )
+  (wiring
+    (via "Via[0-1]_800:400_um" 198628 -77470 (net AGND)(type protect))
+  )
+)`
+
+  const dsnJson = parseDsnToDsnJson(dsn) as DsnPcb
+  expect(dsnJson.wiring.wires[0]).toMatchObject({
+    type: "via",
+    via_type: "protect",
+  })
+
+  const reparsed = parseDsnToDsnJson(stringifyDsnJson(dsnJson)) as DsnPcb
+  expect(reparsed.wiring.wires[0]).toMatchObject({
+    type: "via",
+    via_type: "protect",
+  })
+})


### PR DESCRIPTION
## Summary
- preserve DSN wiring via `(type ...)` metadata while parsing PCB wiring via records
- emit preserved via type metadata from `stringifyDsnJson` so parse -> stringify -> parse keeps Smoothieboard-style `(type protect)` vias
- add focused regression coverage for wiring via type round-tripping

## Verification
- `bun test tests/dsn-pcb/dsn-wiring-via-type.test.ts --preload ./tests/fixtures/preload.ts`
- `bun test tests/repros/repro7-smoothie-board.test.ts --preload ./tests/fixtures/preload.ts`
- `bun test --preload ./tests/fixtures/preload.ts`
- `bun x biome check lib/dsn-pcb/types.ts lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts tests/dsn-pcb/dsn-wiring-via-type.test.ts`
- `bun x tsc --noEmit`
- `bun run build`
- `git diff --check`

/claim #54

Transparency: AI-assisted with OpenAI Codex; I reviewed the diff and kept the change scoped to wiring via type metadata preservation.