### PR TITLE
Preserve DSN session route metadata

### DIFF
--- a/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
@@ -1073,6 +1073,26 @@ function processSessionNode(ast: ASTNode): DsnSession {
       child.children[0].value === "routes",
   )
   if (routesNode) {
+    const resolutionNode = routesNode.children!.find(
+      (child) =>
+        child.type === "List" &&
+        child.children?.[0].type === "Atom" &&
+        child.children[0].value === "resolution",
+    )
+    if (resolutionNode) {
+      session.routes.resolution = processResolution(resolutionNode.children!)
+    }
+
+    const parserNode = routesNode.children!.find(
+      (child) =>
+        child.type === "List" &&
+        child.children?.[0].type === "Atom" &&
+        child.children[0].value === "parser",
+    )
+    if (parserNode) {
+      session.routes.parser = processParser(parserNode.children!.slice(1))
+    }
+
     // Extract library_out section
     const libraryNode = routesNode.children!.find(
       (child) =>

--- a/tests/dsn-pcb/stringify-dsn-session.test.ts
+++ b/tests/dsn-pcb/stringify-dsn-session.test.ts
@@ -25,3 +25,42 @@ test("stringify session file", () => {
   expect(reparsedNet.name).toBe(originalNet.name)
   expect(reparsedNet.wires).toHaveLength(originalNet.wires.length)
 })
+
+test("preserves session routes resolution and parser metadata", () => {
+  const sessionJson = parseDsnToDsnJson(`(session metadata-test
+    (base_design metadata-test)
+    (placement
+      (resolution mil 25)
+    )
+    (routes
+      (resolution mil 25)
+      (parser
+        (string_quote "'")
+        (space_in_quoted_tokens off)
+        (host_cad "freerouting")
+        (host_version "2.1.0")
+      )
+      (network_out)
+    )
+  )`) as DsnSession
+
+  expect(sessionJson.routes.resolution).toEqual({ unit: "mil", value: 25 })
+  expect(sessionJson.routes.parser).toEqual({
+    string_quote: "'",
+    space_in_quoted_tokens: "off",
+    host_cad: "freerouting",
+    host_version: "2.1.0",
+  })
+
+  const reparsed = parseDsnToDsnJson(
+    stringifyDsnSession(sessionJson),
+  ) as DsnSession
+
+  expect(reparsed.routes.resolution).toEqual(sessionJson.routes.resolution)
+  expect(reparsed.routes.parser.host_cad).toBe(
+    sessionJson.routes.parser.host_cad,
+  )
+  expect(reparsed.routes.parser.host_version).toBe(
+    sessionJson.routes.parser.host_version,
+  )
+})


### PR DESCRIPTION
## Summary
- preserve `(routes (resolution ...))` when parsing DSN session files
- preserve `(routes (parser ...))` metadata instead of leaving session routes on defaults
- add focused session parse/stringify coverage for non-default route metadata

/claim #54

## Verification
- `npx --yes bun test tests/dsn-pcb/stringify-dsn-session.test.ts`
- `npx --yes biome check lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts tests/dsn-pcb/stringify-dsn-session.test.ts`
- `npm run build`
- `git diff --check`

AI-assisted with OpenAI Codex; I reviewed the diff and local verification before submitting.