### PR TITLE
Preserve DSN colors metadata

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
@@ -41,6 +41,17 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
   result += `${indent}(resolution ${dsnJson.resolution.unit} ${dsnJson.resolution.value})\n`
   result += `${indent}(unit ${dsnJson.unit})\n`
 
+  if (dsnJson.colors?.length) {
+    result += `${indent}(colors\n`
+    dsnJson.colors.forEach((colorRecord) => {
+      const values = colorRecord.values
+        .map((value) => stringifyValue(value))
+        .join(" ")
+      result += `${indent}${indent}(${colorRecord.kind}${values ? ` ${values}` : ""})\n`
+    })
+    result += `${indent})\n`
+  }
+
   // Structure section
   result += `${indent}(structure\n`
   dsnJson.structure.layers.forEach((layer) => {

--- a/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
@@ -14,6 +14,7 @@ import type {
   Clearance,
   Component,
   ComponentPlacement,
+  DsnColorRecord,
   DsnJson,
   DsnPcb,
   DsnSession,
@@ -134,6 +135,9 @@ export function processPCB(nodes: ASTNode[]): DsnPcb {
               pcb.unit = element.children![1].value
             }
             break
+          case "colors":
+            pcb.colors = processColors(element.children!.slice(1))
+            break
           case "structure":
             pcb.structure = processStructure(element.children!.slice(1)) as any
             break
@@ -155,6 +159,31 @@ export function processPCB(nodes: ASTNode[]): DsnPcb {
   }
 
   return pcb as DsnPcb
+}
+
+function processColors(nodes: ASTNode[]): DsnColorRecord[] {
+  return nodes.flatMap((node) => {
+    if (
+      node.type !== "List" ||
+      !node.children ||
+      node.children[0]?.type !== "Atom" ||
+      typeof node.children[0].value !== "string"
+    ) {
+      return []
+    }
+
+    const values = node.children.slice(1).flatMap((child) => {
+      if (
+        child.type === "Atom" &&
+        (typeof child.value === "string" || typeof child.value === "number")
+      ) {
+        return [child.value]
+      }
+      return []
+    })
+
+    return [{ kind: node.children[0].value, values }]
+  })
 }
 
 export function processParser(nodes: ASTNode[]): ParserType {

--- a/lib/dsn-pcb/types.ts
+++ b/lib/dsn-pcb/types.ts
@@ -15,6 +15,7 @@ export interface DsnPcb {
     value: number
   }
   unit: string
+  colors?: DsnColorRecord[]
   structure: {
     layers: Array<{
       name: string
@@ -105,6 +106,11 @@ export interface Parser {
 export interface Resolution {
   unit: string
   value: number
+}
+
+export interface DsnColorRecord {
+  kind: string
+  values: Array<string | number>
 }
 
 export interface Structure {

--- a/tests/dsn-pcb/preserve-colors-metadata.test.ts
+++ b/tests/dsn-pcb/preserve-colors-metadata.test.ts
@@ -1,0 +1,55 @@
+import { expect, test } from "bun:test"
+import { type DsnPcb, parseDsnToDsnJson, stringifyDsnJson } from "lib"
+
+test("preserves top-level colors metadata through dsn json round trip", () => {
+  const dsn = `
+    (pcb "colors board.dsn"
+      (parser
+        (string_quote ')
+        (space_in_quoted_tokens on)
+        (host_cad "KiCad")
+        (host_version "8.0")
+      )
+      (resolution um 10)
+      (unit um)
+      (colors
+        (color signal 0 128 255)
+        (set_color F.Cu red)
+        (set_pattern signal solid)
+      )
+      (structure
+        (layer F.Cu
+          (type signal)
+          (property
+            (index 0)
+          )
+        )
+        (via "Via[0-1]_600:300_um")
+        (rule
+          (width 150)
+        )
+      )
+      (placement)
+      (library)
+      (network)
+      (wiring)
+    )
+  `
+
+  const dsnJson = parseDsnToDsnJson(dsn) as DsnPcb
+
+  expect(dsnJson.colors).toEqual([
+    { kind: "color", values: ["signal", 0, 128, 255] },
+    { kind: "set_color", values: ["F.Cu", "red"] },
+    { kind: "set_pattern", values: ["signal", "solid"] },
+  ])
+
+  const stringifiedDsn = stringifyDsnJson(dsnJson)
+  expect(stringifiedDsn).toContain("(colors")
+  expect(stringifiedDsn).toContain('(color "signal" 0 128 255)')
+  expect(stringifiedDsn).toContain('(set_color "F.Cu" "red")')
+  expect(stringifiedDsn).toContain('(set_pattern "signal" "solid")')
+
+  const reparsedDsnJson = parseDsnToDsnJson(stringifiedDsn) as DsnPcb
+  expect(reparsedDsnJson.colors).toEqual(dsnJson.colors)
+})


### PR DESCRIPTION
## Summary
- parse top-level DSN `(colors ...)` descriptors into `DsnPcb.colors`
- stringify preserved color records back into PCB DSN output
- add focused parse -> stringify -> parse coverage for `color`, `set_color`, and `set_pattern` records

## Verification
- `bun x biome check lib/dsn-pcb/types.ts lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts tests/dsn-pcb/preserve-colors-metadata.test.ts --write`
- `bun test tests/dsn-pcb/preserve-colors-metadata.test.ts`
- `bun test`
- `bun x tsc --noEmit`
- `bun run build`
- `git diff --check`

/claim #54