### PR TITLE
Preserve DSN placement component properties

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
@@ -69,6 +69,13 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
   result += `${indent}(placement\n`
   dsnJson.placement.components.forEach((component) => {
     result += `${indent}${indent}(component ${stringifyValue(component.name)}\n`
+    if (component.properties?.length) {
+      result += `${indent}${indent}${indent}(property\n`
+      component.properties.forEach((property) => {
+        result += `${indent}${indent}${indent}${indent}(${property.name} ${stringifyValue(property.value)})\n`
+      })
+      result += `${indent}${indent}${indent})\n`
+    }
     if (component.places) {
       component.places.forEach((place) => {
         result += `${indent}${indent}${indent}(place ${place.refdes} ${place.x} ${place.y} ${place.side} ${place.rotation}${place.PN ? ` (PN ${stringifyValue(place.PN)})` : ""})\n`

--- a/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
@@ -417,25 +417,58 @@ export function processPlacement(nodes: ASTNode[]): Placement {
 }
 
 function processComponent(nodes: ASTNode[]): ComponentPlacement {
-  const component: Partial<Component> = {
+  const component: Partial<Component> & {
+    properties?: ComponentPlacement["properties"]
+  } = {
     name:
       nodes[1].type === "Atom" && typeof nodes[1].value === "string"
         ? nodes[1].value
         : "",
     places: [],
   }
+  const properties: ComponentPlacement["properties"] = []
 
   nodes.slice(2).forEach((node) => {
-    if (
-      node.type === "List" &&
-      node.children![0].type === "Atom" &&
-      node.children![0].value === "place"
-    ) {
-      component.places!.push(processPlace(node.children!))
+    if (node.type === "List" && node.children![0].type === "Atom") {
+      if (node.children![0].value === "place") {
+        component.places!.push(processPlace(node.children!))
+      } else if (node.children![0].value === "property") {
+        properties.push(...processComponentProperties(node.children!.slice(1)))
+      }
     }
   })
 
+  if (properties.length > 0) {
+    component.properties = properties
+  }
+
   return component as ComponentPlacement
+}
+
+function processComponentProperties(
+  nodes: ASTNode[],
+): NonNullable<ComponentPlacement["properties"]> {
+  return nodes.flatMap((node) => {
+    if (
+      node.type !== "List" ||
+      !node.children ||
+      node.children.length < 2 ||
+      node.children[0].type !== "Atom" ||
+      typeof node.children[0].value !== "string" ||
+      node.children[1].type !== "Atom" ||
+      (typeof node.children[1].value !== "string" &&
+        typeof node.children[1].value !== "number")
+    ) {
+      return []
+    }
+
+    return [
+      {
+        name: node.children[0].value,
+        value: node.children[1].value,
+      },
+    ]
+  })
 }
 
 function processPlace(nodes: ASTNode[]): Places {

--- a/lib/dsn-pcb/types.ts
+++ b/lib/dsn-pcb/types.ts
@@ -85,6 +85,10 @@ export interface DsnPcb {
 
 export interface ComponentPlacement {
   name: string
+  properties?: Array<{
+    name: string
+    value: string | number
+  }>
   places: Array<{
     refdes: string
     PN?: string

--- a/tests/dsn-pcb/stringify-dsn-json.test.ts
+++ b/tests/dsn-pcb/stringify-dsn-json.test.ts
@@ -17,3 +17,76 @@ test("stringify dsn json", () => {
   // Test that we can parse the generated string back to the same structure
   // expect(reparsedJson).toEqual(dsnJson)
 })
+
+test("preserves placement component property metadata", () => {
+  const dsnJson = parseDsnToDsnJson(`(pcb component-property-test.dsn
+    (parser
+      (string_quote ")
+      (space_in_quoted_tokens on)
+      (host_cad "KiCad's Pcbnew")
+      (host_version "8.0.3")
+    )
+    (resolution um 10)
+    (unit um)
+    (structure
+      (layer F.Cu
+        (type signal)
+        (property
+          (index 0)
+        )
+      )
+      (boundary
+        (path pcb 0 0 0 100 0 100 100 0 100 0 0)
+      )
+      (via "Via[0-1]_600:300_um")
+      (rule
+        (width 200)
+        (clearance 200)
+      )
+    )
+    (placement
+      (component "Connector:USB_C_Receptacle"
+        (property
+          (source_library "Connector.pretty")
+          (component_height 1200)
+        )
+        (place J1 1000 2000 front 90 (PN "USB-C"))
+      )
+    )
+    (library
+      (image "Connector:USB_C_Receptacle"
+        (pin "RoundPad" 1 0 0)
+      )
+      (padstack "RoundPad"
+        (shape (circle F.Cu 600))
+        (attach off)
+      )
+    )
+    (network
+      (net "VBUS"
+        (pins J1-1)
+      )
+      (class kicad_default "" "VBUS"
+        (circuit
+          (use_via "Via[0-1]_600:300_um")
+        )
+        (rule
+          (width 200)
+          (clearance 200)
+        )
+      )
+    )
+  )`) as DsnPcb
+
+  expect(dsnJson.placement.components[0].properties).toEqual([
+    { name: "source_library", value: "Connector.pretty" },
+    { name: "component_height", value: 1200 },
+  ])
+
+  const dsnString = stringifyDsnJson(dsnJson)
+  const reparsedJson = parseDsnToDsnJson(dsnString) as DsnPcb
+
+  expect(reparsedJson.placement.components[0].properties).toEqual(
+    dsnJson.placement.components[0].properties,
+  )
+})


### PR DESCRIPTION
## Summary
- Preserve `(property ...)` entries nested directly under DSN placement `(component ...)` records
- Emit preserved component-level placement properties from `stringifyDsnJson` so parse -> stringify -> parse keeps that metadata
- Add focused round-trip coverage for string and numeric component property values

/claim #54

## Verification
- `npx bun test tests/dsn-pcb/stringify-dsn-json.test.ts`
- `npx tsc --noEmit`
- `npx biome check lib/dsn-pcb/types.ts lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts tests/dsn-pcb/stringify-dsn-json.test.ts`
- `npm run build`
- `git diff --check`

Transparency: AI-assisted with OpenAI Codex; I reviewed the diff and local verification before submitting.