### PR TITLE
Preserve DSN autoroute via cost metadata

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
@@ -57,6 +57,16 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
     result += `${indent}${indent})\n`
   }
   result += `${indent}${indent}(via ${stringifyValue(dsnJson.structure.via)})\n`
+  if (dsnJson.structure.autoroute_settings) {
+    result += `${indent}${indent}(autoroute_settings\n`
+    if (dsnJson.structure.autoroute_settings.via_costs !== undefined) {
+      result += `${indent}${indent}${indent}(via_costs ${dsnJson.structure.autoroute_settings.via_costs})\n`
+    }
+    if (dsnJson.structure.autoroute_settings.plane_via_costs !== undefined) {
+      result += `${indent}${indent}${indent}(plane_via_costs ${dsnJson.structure.autoroute_settings.plane_via_costs})\n`
+    }
+    result += `${indent}${indent})\n`
+  }
   result += `${indent}${indent}(rule\n`
   result += `${indent}${indent}${indent}(width ${dsnJson.structure.rule.width})\n`
   dsnJson.structure.rule.clearances.forEach((clearance) => {

--- a/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
@@ -7,6 +7,7 @@ import {
   tokenizeDsn,
 } from "../../common/parse-sexpr"
 import type {
+  AutorouteSettings,
   Boundary,
   CircleShape,
   Circuit,
@@ -233,6 +234,9 @@ export function processStructure(nodes: ASTNode[]): Structure {
               structure.via = node.children![1].value
             }
             break
+          case "autoroute_settings":
+            structure.autoroute_settings = processAutorouteSettings(rest)
+            break
           case "rule":
             structure.rule = processRule(node.children!.slice(1))
             break
@@ -242,6 +246,34 @@ export function processStructure(nodes: ASTNode[]): Structure {
   })
 
   return structure as Structure
+}
+
+function processAutorouteSettings(nodes: ASTNode[]): AutorouteSettings {
+  const autorouteSettings: AutorouteSettings = {}
+
+  nodes.forEach((node) => {
+    if (node.type !== "List") return
+    const [keyNode, valueNode] = node.children!
+    if (
+      keyNode?.type !== "Atom" ||
+      typeof keyNode.value !== "string" ||
+      valueNode?.type !== "Atom" ||
+      typeof valueNode.value !== "number"
+    ) {
+      return
+    }
+
+    switch (keyNode.value) {
+      case "via_costs":
+        autorouteSettings.via_costs = valueNode.value
+        break
+      case "plane_via_costs":
+        autorouteSettings.plane_via_costs = valueNode.value
+        break
+    }
+  })
+
+  return autorouteSettings
 }
 
 function processLayer(nodes: ASTNode[]): Layer {

--- a/lib/dsn-pcb/types.ts
+++ b/lib/dsn-pcb/types.ts
@@ -31,6 +31,7 @@ export interface DsnPcb {
       }
     }
     via: string
+    autoroute_settings?: AutorouteSettings
     rule: {
       clearances: Array<{
         value: number
@@ -111,7 +112,13 @@ export interface Structure {
   layers: Layer[]
   boundary: Boundary
   via: string
+  autoroute_settings?: AutorouteSettings
   rule: Rule
+}
+
+export interface AutorouteSettings {
+  via_costs?: number
+  plane_via_costs?: number
 }
 
 export interface Layer {

--- a/tests/dsn-pcb/stringify-dsn-json.test.ts
+++ b/tests/dsn-pcb/stringify-dsn-json.test.ts
@@ -17,3 +17,54 @@ test("stringify dsn json", () => {
   // Test that we can parse the generated string back to the same structure
   // expect(reparsedJson).toEqual(dsnJson)
 })
+
+test("preserves autoroute via cost settings", () => {
+  const dsnJson = parseDsnToDsnJson(`(pcb test.dsn
+    (parser
+      (string_quote ")
+      (space_in_quoted_tokens on)
+      (host_cad "KiCad's Pcbnew")
+      (host_version "8.0")
+    )
+    (resolution um 10)
+    (unit um)
+    (structure
+      (layer F.Cu
+        (type signal)
+        (property
+          (index 0)
+        )
+      )
+      (boundary
+        (path signal 0 0 0 1000 0 1000 1000 0 1000)
+      )
+      (via Via[0-1]_600:300_um)
+      (autoroute_settings
+        (via_costs 50)
+        (plane_via_costs 5)
+      )
+      (rule
+        (width 200)
+        (clearance 200)
+      )
+    )
+    (placement)
+    (library)
+    (network)
+    (wiring)
+  )`) as DsnPcb
+
+  expect(dsnJson.structure.autoroute_settings).toEqual({
+    via_costs: 50,
+    plane_via_costs: 5,
+  })
+
+  const dsnString = stringifyDsnJson(dsnJson)
+  expect(dsnString).toContain("(via_costs 50)")
+  expect(dsnString).toContain("(plane_via_costs 5)")
+
+  const reparsedJson = parseDsnToDsnJson(dsnString) as DsnPcb
+  expect(reparsedJson.structure.autoroute_settings).toEqual(
+    dsnJson.structure.autoroute_settings,
+  )
+})


### PR DESCRIPTION
## Summary

Preserves the DSN `structure` autoroute via cost metadata during parse -> stringify -> parse round trips:

- parses `(via_costs ...)` and `(plane_via_costs ...)` from `autoroute_settings`
- emits those settings when stringifying PCB DSN JSON
- adds focused round-trip coverage for the preserved values

/claim #54

## Verification

- `bun test tests/dsn-pcb/stringify-dsn-json.test.ts`
- `bun test tests/dsn-pcb`
- `bun test`
- `bunx biome check lib/dsn-pcb/types.ts lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts tests/dsn-pcb/stringify-dsn-json.test.ts`
- `bun run build`
- `git diff --check`
