### PR TITLE
Preserve DSN autoroute settings

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
@@ -63,6 +63,50 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
     result += `${indent}${indent}${indent}(clearance ${clearance.value}${clearance.type ? ` (type ${clearance.type})` : ""})\n`
   })
   result += `${indent}${indent})\n`
+  if (dsnJson.structure.autoroute_settings) {
+    const settings = dsnJson.structure.autoroute_settings
+    result += `${indent}${indent}(autoroute_settings\n`
+
+    const emitStringSetting = (
+      key: "fanout" | "autoroute" | "postroute" | "vias",
+    ) => {
+      if (settings[key] !== undefined) {
+        result += `${indent}${indent}${indent}(${key} ${settings[key]})\n`
+      }
+    }
+
+    const emitNumberSetting = (key: "start_ripup_costs" | "start_pass_no") => {
+      if (settings[key] !== undefined) {
+        result += `${indent}${indent}${indent}(${key} ${settings[key]})\n`
+      }
+    }
+
+    emitStringSetting("fanout")
+    emitStringSetting("autoroute")
+    emitStringSetting("postroute")
+    emitStringSetting("vias")
+    emitNumberSetting("start_ripup_costs")
+    emitNumberSetting("start_pass_no")
+
+    settings.layer_rules?.forEach((layerRule) => {
+      result += `${indent}${indent}${indent}(layer_rule ${layerRule.layer}\n`
+      if (layerRule.active !== undefined) {
+        result += `${indent}${indent}${indent}${indent}(active ${layerRule.active})\n`
+      }
+      if (layerRule.preferred_direction !== undefined) {
+        result += `${indent}${indent}${indent}${indent}(preferred_direction ${layerRule.preferred_direction})\n`
+      }
+      if (layerRule.preferred_direction_trace_costs !== undefined) {
+        result += `${indent}${indent}${indent}${indent}(preferred_direction_trace_costs ${layerRule.preferred_direction_trace_costs})\n`
+      }
+      if (layerRule.against_preferred_direction_trace_costs !== undefined) {
+        result += `${indent}${indent}${indent}${indent}(against_preferred_direction_trace_costs ${layerRule.against_preferred_direction_trace_costs})\n`
+      }
+      result += `${indent}${indent}${indent})\n`
+    })
+
+    result += `${indent}${indent})\n`
+  }
   result += `${indent})\n`
 
   // Placement section

--- a/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
@@ -7,6 +7,8 @@ import {
   tokenizeDsn,
 } from "../../common/parse-sexpr"
 import type {
+  AutorouteLayerRule,
+  AutorouteSettings,
   Boundary,
   CircleShape,
   Circuit,
@@ -236,12 +238,87 @@ export function processStructure(nodes: ASTNode[]): Structure {
           case "rule":
             structure.rule = processRule(node.children!.slice(1))
             break
+          case "autoroute_settings":
+            structure.autoroute_settings = processAutorouteSettings(
+              node.children!.slice(1),
+            )
+            break
         }
       }
     }
   })
 
   return structure as Structure
+}
+
+function processAutorouteSettings(nodes: ASTNode[]): AutorouteSettings {
+  const settings: AutorouteSettings = {}
+
+  nodes.forEach((node) => {
+    if (node.type !== "List") return
+
+    const [keyNode, ...rest] = node.children!
+    if (keyNode.type !== "Atom" || typeof keyNode.value !== "string") return
+
+    const key = keyNode.value
+    const first = rest[0]
+
+    switch (key) {
+      case "fanout":
+      case "autoroute":
+      case "postroute":
+      case "vias":
+        if (first?.type === "Atom" && typeof first.value === "string") {
+          settings[key] = first.value
+        }
+        break
+      case "start_ripup_costs":
+      case "start_pass_no":
+        if (first?.type === "Atom" && typeof first.value === "number") {
+          settings[key] = first.value
+        }
+        break
+      case "layer_rule":
+        settings.layer_rules ??= []
+        settings.layer_rules.push(processAutorouteLayerRule(rest))
+        break
+    }
+  })
+
+  return settings
+}
+
+function processAutorouteLayerRule(nodes: ASTNode[]): AutorouteLayerRule {
+  const layerRule: AutorouteLayerRule = {
+    layer:
+      nodes[0]?.type === "Atom" && typeof nodes[0].value === "string"
+        ? nodes[0].value
+        : "",
+  }
+
+  nodes.slice(1).forEach((node) => {
+    if (node.type !== "List") return
+
+    const [keyNode, valueNode] = node.children!
+    if (keyNode.type !== "Atom" || typeof keyNode.value !== "string") return
+
+    switch (keyNode.value) {
+      case "active":
+      case "preferred_direction":
+        if (valueNode?.type === "Atom" && typeof valueNode.value === "string") {
+          layerRule[keyNode.value] = valueNode.value
+        }
+        break
+      case "preferred_direction_trace_costs":
+      case "against_preferred_direction_trace_costs":
+        if (valueNode?.type === "Atom" && typeof valueNode.value === "number") {
+          layerRule[keyNode.value] = valueNode.value
+        }
+        break
+    }
+  })
+
+  return layerRule
 }
 
 function processLayer(nodes: ASTNode[]): Layer {

--- a/lib/dsn-pcb/types.ts
+++ b/lib/dsn-pcb/types.ts
@@ -38,6 +38,7 @@ export interface DsnPcb {
       }>
       width: number
     }
+    autoroute_settings?: AutorouteSettings
   }
   placement: {
     components: Array<ComponentPlacement>
@@ -112,6 +113,25 @@ export interface Structure {
   boundary: Boundary
   via: string
   rule: Rule
+  autoroute_settings?: AutorouteSettings
+}
+
+export interface AutorouteSettings {
+  fanout?: string
+  autoroute?: string
+  postroute?: string
+  vias?: string
+  start_ripup_costs?: number
+  start_pass_no?: number
+  layer_rules?: AutorouteLayerRule[]
+}
+
+export interface AutorouteLayerRule {
+  layer: string
+  active?: string
+  preferred_direction?: string
+  preferred_direction_trace_costs?: number
+  against_preferred_direction_trace_costs?: number
 }
 
 export interface Layer {

--- a/tests/dsn-pcb/stringify-dsn-json.test.ts
+++ b/tests/dsn-pcb/stringify-dsn-json.test.ts
@@ -17,3 +17,93 @@ test("stringify dsn json", () => {
   // Test that we can parse the generated string back to the same structure
   // expect(reparsedJson).toEqual(dsnJson)
 })
+
+test("preserves autoroute settings switches and layer rules", () => {
+  const dsnJson = parseDsnToDsnJson(`(pcb "autoroute-settings.dsn"
+  (parser
+    (string_quote ")
+    (space_in_quoted_tokens on)
+    (host_cad "KiCad's Pcbnew")
+    (host_version "(8.0.0)")
+  )
+  (resolution um 10)
+  (unit um)
+  (structure
+    (layer F.Cu
+      (type signal)
+      (property
+        (index 0)
+      )
+    )
+    (layer B.Cu
+      (type signal)
+      (property
+        (index 1)
+      )
+    )
+    (boundary
+      (path pcb 0  0 0  1000 0  1000 1000  0 1000  0 0)
+    )
+    (via "Via[0-1]_600:300_um")
+    (rule
+      (width 200)
+      (clearance 200)
+    )
+    (autoroute_settings
+      (fanout off)
+      (autoroute on)
+      (postroute on)
+      (vias on)
+      (start_ripup_costs 100)
+      (start_pass_no 4)
+      (layer_rule F.Cu
+        (active on)
+        (preferred_direction horizontal)
+        (preferred_direction_trace_costs 1.0)
+        (against_preferred_direction_trace_costs 2.7)
+      )
+      (layer_rule B.Cu
+        (active on)
+        (preferred_direction vertical)
+        (preferred_direction_trace_costs 1.0)
+        (against_preferred_direction_trace_costs 1.6)
+      )
+    )
+  )
+  (placement)
+  (library)
+  (network)
+  (wiring)
+)`) as DsnPcb
+
+  expect(dsnJson.structure.autoroute_settings).toEqual({
+    fanout: "off",
+    autoroute: "on",
+    postroute: "on",
+    vias: "on",
+    start_ripup_costs: 100,
+    start_pass_no: 4,
+    layer_rules: [
+      {
+        layer: "F.Cu",
+        active: "on",
+        preferred_direction: "horizontal",
+        preferred_direction_trace_costs: 1,
+        against_preferred_direction_trace_costs: 2.7,
+      },
+      {
+        layer: "B.Cu",
+        active: "on",
+        preferred_direction: "vertical",
+        preferred_direction_trace_costs: 1,
+        against_preferred_direction_trace_costs: 1.6,
+      },
+    ],
+  })
+
+  const reparsedJson = parseDsnToDsnJson(stringifyDsnJson(dsnJson)) as DsnPcb
+
+  expect(reparsedJson.structure.autoroute_settings).toEqual(
+    dsnJson.structure.autoroute_settings,
+  )
+})


### PR DESCRIPTION
## Summary
- preserve DSN autoroute_settings switches for fanout, autoroute, postroute, and vias
- preserve start_ripup_costs, start_pass_no, and per-layer autoroute rules through parse -> stringify -> parse
- intentionally leave via_costs and plane_via_costs untouched to avoid overlap with the active cost-metadata PR

/claim #54

## Verification
- npx --yes @biomejs/biome check lib/dsn-pcb/types.ts lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts tests/dsn-pcb/stringify-dsn-json.test.ts
- npx --yes bun@latest test tests/dsn-pcb/stringify-dsn-json.test.ts
- npx --yes tsc --noEmit
- npm run build
- git diff --check

AI-assisted with Codex; I reviewed the diff and local verification before submitting.


Fixes #54

