### PR TITLE
Preserve empty session parser values

### DIFF
--- a/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
@@ -160,29 +160,31 @@ export function processPCB(nodes: ASTNode[]): DsnPcb {
 export function processParser(nodes: ASTNode[]): ParserType {
   const parser: Partial<ParserType> = {}
   nodes.forEach((node) => {
-    if (node.type === "List" && node.children && node.children.length >= 2) {
+    if (node.type === "List" && node.children && node.children.length >= 1) {
       const [keyNode, valueNode] = node.children
       if (
         keyNode?.type === "Atom" &&
-        typeof keyNode.value === "string" &&
-        valueNode?.type === "Atom" &&
-        (typeof valueNode.value === "string" ||
-          typeof valueNode.value === "number")
+        typeof keyNode.value === "string"
       ) {
         const key = keyNode.value
-        const value = valueNode.value
+        const value =
+          valueNode?.type === "Atom" &&
+          (typeof valueNode.value === "string" ||
+            typeof valueNode.value === "number")
+            ? String(valueNode.value)
+            : ""
         switch (key) {
           case "string_quote":
-            if (typeof value === "string") parser.string_quote = value
+            parser.string_quote = value
             break
           case "space_in_quoted_tokens":
-            if (typeof value === "string") parser.space_in_quoted_tokens = value
+            parser.space_in_quoted_tokens = value
             break
           case "host_cad":
-            if (typeof value === "string") parser.host_cad = value
+            parser.host_cad = value
             break
           case "host_version":
-            if (typeof value === "string") parser.host_version = value
+            parser.host_version = value
             break
         }
       }

--- a/tests/dsn-pcb/stringify-dsn-session.test.ts
+++ b/tests/dsn-pcb/stringify-dsn-session.test.ts
@@ -25,3 +25,14 @@ test("stringify session file", () => {
   expect(reparsedNet.name).toBe(originalNet.name)
   expect(reparsedNet.wires).toHaveLength(originalNet.wires.length)
 })
+
+test("preserves empty session parser host_version", () => {
+  const sessionJson = parseDsnToDsnJson(sessionFile) as DsnSession
+
+  expect(sessionJson.routes.parser.host_version).toBe("")
+
+  const stringified = stringifyDsnSession(sessionJson)
+
+  expect(stringified).toContain("(host_version \"\")")
+  expect(stringified).not.toContain("(host_version undefined)")
+})


### PR DESCRIPTION
## Summary
- preserve empty parser values such as session `(host_version )` as empty strings
- prevent session stringification from emitting `undefined` for empty host metadata
- add focused coverage for the empty session `host_version` case

## Verification
- npm run build
- git diff --check

/claim #54