### PR TITLE
Preserve DSN session was_is mappings

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-session.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-session.ts
@@ -22,8 +22,11 @@ export const stringifyDsnSession = (session: DsnSession): string => {
   })
   result += `${indent})\n`
 
-  // Was_is section (if needed)
-  result += `${indent}(was_is\n${indent})\n`
+  result += `${indent}(was_is\n`
+  session.was_is?.forEach((entry) => {
+    result += `${indent}${indent}(${entry.type} ${entry.from} ${entry.to})\n`
+  })
+  result += `${indent})\n`
 
   // Routes section
   result += `${indent}(routes \n`

--- a/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
@@ -1065,6 +1065,16 @@ function processSessionNode(ast: ASTNode): DsnSession {
     ).components
   }
 
+  const wasIsNode = ast.children!.find(
+    (child) =>
+      child.type === "List" &&
+      child.children?.[0].type === "Atom" &&
+      child.children[0].value === "was_is",
+  )
+  if (wasIsNode) {
+    session.was_is = processWasIs(wasIsNode.children!.slice(1))
+  }
+
   // Extract routes section
   const routesNode = ast.children!.find(
     (child) =>
@@ -1144,6 +1154,29 @@ function processSessionNode(ast: ASTNode): DsnSession {
   }
 
   return session
+}
+
+function processWasIs(nodes: ASTNode[]): DsnSession["was_is"] {
+  return nodes
+    .map((node) => {
+      if (
+        node.type === "List" &&
+        node.children?.[0].type === "Atom" &&
+        typeof node.children[0].value === "string" &&
+        node.children[1]?.type === "Atom" &&
+        node.children[2]?.type === "Atom"
+      ) {
+        return {
+          type: node.children[0].value,
+          from: String(node.children[1].value),
+          to: String(node.children[2].value),
+        }
+      }
+      return null
+    })
+    .filter((entry): entry is NonNullable<DsnSession["was_is"]>[number] =>
+      Boolean(entry),
+    )
 }
 
 function processPathShape(nodes: ASTNode[]): PathShape {

--- a/lib/dsn-pcb/types.ts
+++ b/lib/dsn-pcb/types.ts
@@ -293,6 +293,11 @@ export interface DsnSession {
   is_dsn_session: true
   is_dsn_pcb?: false
   filename: string
+  was_is?: Array<{
+    type: string
+    from: string
+    to: string
+  }>
   placement: {
     resolution: Resolution
     components: Array<ComponentPlacement>

--- a/tests/dsn-pcb/stringify-dsn-session.test.ts
+++ b/tests/dsn-pcb/stringify-dsn-session.test.ts
@@ -25,3 +25,35 @@ test("stringify session file", () => {
   expect(reparsedNet.name).toBe(originalNet.name)
   expect(reparsedNet.wires).toHaveLength(originalNet.wires.length)
 })
+
+test("preserves session was_is pin mappings", () => {
+  const sessionJson = parseDsnToDsnJson(`(session routed-board
+    (base_design original-board)
+    (placement
+      (resolution um 10)
+    )
+    (was_is
+      (pins R1-1 R1-Pad1)
+      (pins U1-2 U1-Pad2)
+    )
+    (routes
+      (resolution um 10)
+      (parser
+        (host_cad "Freerouting")
+        (host_version "1.9.0")
+      )
+      (network_out)
+    )
+  )`) as DsnSession
+
+  expect(sessionJson.was_is).toEqual([
+    { type: "pins", from: "R1-1", to: "R1-Pad1" },
+    { type: "pins", from: "U1-2", to: "U1-Pad2" },
+  ])
+
+  const reparsed = parseDsnToDsnJson(
+    stringifyDsnSession(sessionJson),
+  ) as DsnSession
+
+  expect(reparsed.was_is).toEqual(sessionJson.was_is)
+})


### PR DESCRIPTION
## Summary
- Preserve session `(was_is ...)` pin mappings in the `DsnSession` model
- Parse session `was_is` entries into `{ type, from, to }` records
- Emit preserved mappings from `stringifyDsnSession` and cover parse -> stringify -> parse round-tripping

## Scope / non-overlap
This is intentionally limited to session-level `was_is` mappings. It does not touch PCB DSN metadata, session route metadata, vias, parser tokenization, placement, or Circuit JSON conversion behavior.

## Verification
- `npx --cache /tmp/npm-cache-dsn --yes bun@1.1.38 test tests/dsn-pcb/stringify-dsn-session.test.ts` -> 2 pass, 0 fail
- `npm run format:check` -> checked 103 files, no fixes applied
- `npx tsc --noEmit` -> exit 0
- `npm run build` -> ESM and DTS build success
- `git diff --check HEAD~1 HEAD` -> exit 0

Transparency: AI-assisted with OpenAI Codex; I reviewed the diff and local verification before submitting.

/claim #54