### PR TITLE
Fix rotated DSN pin labels for Smoothieboard

### DIFF
--- a/lib/dsn-pcb/dsn-json-to-circuit-json/dsn-component-converters/convert-dsn-pcb-components-to-source-components-and-ports.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/dsn-component-converters/convert-dsn-pcb-components-to-source-components-and-ports.ts
@@ -33,13 +33,18 @@ export const convertDsnPcbComponentsToSourceComponentsAndPorts = ({
       // Create ports for each pin in the image
       if (image.pins) {
         for (const pin of image.pins) {
+          const pinLabel = String(pin.pin_number)
+          const numericPinNumber =
+            typeof pin.pin_number === "number" ? pin.pin_number : undefined
           const port: SourcePort = {
             type: "source_port",
-            source_port_id: `source_port_${component.name}-Pad${pin.pin_number}_${place.refdes}`,
+            source_port_id: `source_port_${component.name}-Pad${pinLabel}_${place.refdes}`,
             source_component_id: sourceComponent.source_component_id,
-            name: `${place.refdes}-${pin.pin_number}`,
-            pin_number: Number(pin.pin_number),
-            port_hints: [],
+            name: `${place.refdes}-${pinLabel}`,
+            port_hints: [pinLabel],
+          }
+          if (numericPinNumber !== undefined) {
+            port.pin_number = numericPinNumber
           }
           // Handle case where place coordinates might be null/undefined
           const placeX = place.x || 0
@@ -49,7 +54,7 @@ export const convertDsnPcbComponentsToSourceComponentsAndPorts = ({
             y: placeY + pin.y,
           })
           const pcb_port: PcbPort = {
-            pcb_port_id: `pcb_port_${component.name}-Pad${pin.pin_number}_${place.refdes}`,
+            pcb_port_id: `pcb_port_${component.name}-Pad${pinLabel}_${place.refdes}`,
             type: "pcb_port",
             source_port_id: port.source_port_id,
             pcb_component_id: component.name,

--- a/lib/dsn-pcb/dsn-json-to-circuit-json/dsn-component-converters/convert-padstacks-to-smtpads.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/dsn-component-converters/convert-padstacks-to-smtpads.ts
@@ -30,6 +30,7 @@ export function convertPadstacksToSmtPads(
       const { x: compX, y: compY, side } = place
 
       image.pins.forEach((pin) => {
+        const pinLabel = String(pin.pin_number)
         // Find the corresponding padstack
         const padstack = padstacks.find((p) => p.name === pin.padstack_name)
         debug("found padstack", { padstack })
@@ -126,29 +127,29 @@ export function convertPadstacksToSmtPads(
           })
           pcbPad = {
             type: "pcb_smtpad",
-            pcb_smtpad_id: `pcb_smtpad_${componentId}_${place.refdes}_${Number(pin.pin_number) - 1}`,
+            pcb_smtpad_id: `pcb_smtpad_${componentId}_${place.refdes}_${pinLabel}`,
             pcb_component_id: `${componentId}_${place.refdes}`,
-            pcb_port_id: `pcb_port_${componentId}-Pad${pin.pin_number}_${place.refdes}`,
+            pcb_port_id: `pcb_port_${componentId}-Pad${pinLabel}_${place.refdes}`,
             shape: "rect",
             x: circuitX,
             y: circuitY,
             width,
             height,
             layer,
-            port_hints: [pin.pin_number.toString()],
+            port_hints: [pinLabel],
           }
         } else {
           pcbPad = {
             type: "pcb_smtpad",
-            pcb_smtpad_id: `pcb_smtpad_${componentId}_${place.refdes}_${Number(pin.pin_number) - 1}`,
+            pcb_smtpad_id: `pcb_smtpad_${componentId}_${place.refdes}_${pinLabel}`,
             pcb_component_id: `${componentId}_${place.refdes}`,
-            pcb_port_id: `pcb_port_${componentId}-Pad${pin.pin_number}_${place.refdes}`,
+            pcb_port_id: `pcb_port_${componentId}-Pad${pinLabel}_${place.refdes}`,
             shape: "circle",
             x: circuitX,
             y: circuitY,
             radius: circleShape!.diameter / 2 / 1000,
             layer: side === "front" ? "top" : "bottom",
-            port_hints: [pin.pin_number.toString()],
+            port_hints: [pinLabel],
           }
         }
 

--- a/lib/utils/get-pin-number.ts
+++ b/lib/utils/get-pin-number.ts
@@ -8,16 +8,23 @@ const debug = Debug("dsn-converter:getPinNum")
  * Handles both extraction from nodes and type conversion in one step
  */
 export function getPinNum(nodes: ASTNode[]): number | string | null {
-  // Extract pin number from AST nodes
-  let pinNumber
+  let pinNumber: string | number | undefined
 
-  if (nodes[2]?.type === "List" && nodes[2].children) {
-    // Pin number is in a List structure
-    pinNumber = nodes[2].children[0]?.value
-  } else if (nodes[2]?.type === "Atom") {
-    // Pin number is direct value
-    pinNumber = nodes[2].value
-  } else {
+  for (const node of nodes.slice(2)) {
+    if (node.type === "List") {
+      continue
+    }
+    if (typeof node.value === "string") {
+      pinNumber = node.value
+      break
+    }
+    if (typeof node.value === "number") {
+      pinNumber = node.value
+      break
+    }
+  }
+
+  if (pinNumber === undefined) {
     debug("Unsupported pin number format:", nodes)
     return null
   }

--- a/tests/repros/repro7-smoothie-board.test.ts
+++ b/tests/repros/repro7-smoothie-board.test.ts
@@ -11,6 +11,26 @@ test("smoothieboard repro", async () => {
   const dsnJson = parseDsnToDsnJson(dsnFileWithFreeroutingTrace) as DsnPcb
 
   const circuitJson = convertDsnPcbToCircuitJson(dsnJson)
+  const sourcePorts = circuitJson.filter((elm) => elm.type === "source_port")
+  const sourceTraces = circuitJson.filter((elm) => elm.type === "source_trace")
+
+  expect(
+    sourcePorts.some((port) => port.name === "RJ1-G+"),
+    "rotated non-numeric pins should keep their DSN pin label",
+  ).toBe(true)
+  expect(sourcePorts.some((port) => port.name === "RJ1-NC")).toBe(true)
+  expect(
+    sourceTraces.find((trace) =>
+      trace.connected_source_net_ids.includes(
+        "source_net_/smoothieboard-5driver_3/LED1/REGOFF",
+      ),
+    )?.connected_source_port_ids.length,
+  ).toBe(2)
+  expect(
+    sourceTraces.find((trace) =>
+      trace.connected_source_net_ids.includes("source_net_Net-(RJ1-PadNC)"),
+    )?.connected_source_port_ids.length,
+  ).toBe(1)
 
   expect(convertCircuitJsonToPcbSvg(circuitJson)).toMatchSvgSnapshot(
     import.meta.path,


### PR DESCRIPTION
## Summary
- Fix DSN pin parsing when an optional rotate clause appears before the pin label.
- Preserve non-numeric pin labels such as G+ and NC in source ports, PCB ports, SMT pad IDs, and port hints.
- Add Smoothieboard assertions proving RJ1-G+ and RJ1-NC are connected to their source traces.

Fixes #54

/claim #54

## Test plan
- `npx bun test tests/repros/repro7-smoothie-board.test.ts`
- `npx bun test tests/dsn-pcb/parse-dsn-json-to-circuit-json.test.ts tests/dsn-pcb/convert-dsn-file-to-circuit-json.test.ts tests/repros/repro7-smoothie-board.test.ts tests/repros/repro13-missing-traces-waterCounter.test.ts`
- `npm run build`

Note: full `npx bun test` still has unrelated existing `.tsx` failures in `@tscircuit/core` with `TypeError: Attempting to define property on object that is not extensible`.
