### PR TITLE
Preserve DSN structure boundary shapes

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
@@ -26,6 +26,30 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
     return `${padding}(path ${path.layer} ${path.width}  ${stringifyCoordinates(path.coordinates)})`
   }
 
+  const stringifyBoundary = (
+    boundary: DsnPcb["structure"]["boundary"],
+    level: number,
+  ): string[] => {
+    const padding = indent.repeat(level)
+    const entries: string[] = []
+
+    if (boundary.path) {
+      entries.push(stringifyPath(boundary.path, level))
+    }
+    if (boundary.rect) {
+      entries.push(
+        `${padding}(rect ${boundary.rect.type} ${stringifyCoordinates(boundary.rect.coordinates)})`,
+      )
+    }
+    if (boundary.polygon) {
+      entries.push(
+        `${padding}(polygon ${boundary.polygon.type} ${boundary.polygon.width} ${stringifyCoordinates(boundary.polygon.coordinates)})`,
+      )
+    }
+
+    return entries
+  }
+
   // Start with pcb
   result += `(pcb ${dsnJson.filename ? dsnJson.filename : "./converted_dsn.dsn"}\n`
 
@@ -53,7 +77,9 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
   })
   if (dsnJson.structure.boundary) {
     result += `${indent}${indent}(boundary\n`
-    result += `${indent}${indent}${indent}${stringifyPath(dsnJson.structure.boundary.path, 0)}\n`
+    stringifyBoundary(dsnJson.structure.boundary, 3).forEach((entry) => {
+      result += `${entry}\n`
+    })
     result += `${indent}${indent})\n`
   }
   result += `${indent}${indent}(via ${stringifyValue(dsnJson.structure.via)})\n`

--- a/lib/dsn-pcb/dsn-json-to-circuit-json/convert-dsn-pcb-to-circuit-json.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/convert-dsn-pcb-to-circuit-json.ts
@@ -30,8 +30,9 @@ export function convertDsnPcbToCircuitJson(
     material: "fr4",
     num_layers: 4,
   }
-  if (dsnPcb.structure.boundary.path) {
-    const boundaryPath = pairs(dsnPcb.structure.boundary.path.coordinates)
+  const boundaryCoordinates = getBoundaryCoordinates(dsnPcb.structure.boundary)
+  if (boundaryCoordinates.length >= 4) {
+    const boundaryPath = pairs(boundaryCoordinates)
     const maxX = Math.max(...boundaryPath.map(([x]) => x))
     const minX = Math.min(...boundaryPath.map(([x]) => x))
     const maxY = Math.max(...boundaryPath.map(([, y]) => y))
@@ -79,4 +80,23 @@ export function convertDsnPcbToCircuitJson(
   )
 
   return elements
+}
+
+function getBoundaryCoordinates(
+  boundary: DsnPcb["structure"]["boundary"],
+): number[] {
+  if (boundary.path) {
+    return boundary.path.coordinates
+  }
+  if (boundary.polygon) {
+    return boundary.polygon.coordinates
+  }
+  if (boundary.rect) {
+    if (boundary.rect.coordinates.length < 4) {
+      return []
+    }
+    const [x1, y1, x2, y2] = boundary.rect.coordinates
+    return [x1, y1, x2, y1, x2, y2, x1, y2]
+  }
+  return []
 }

--- a/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
@@ -296,14 +296,57 @@ function processBoundary(nodes: ASTNode[]): Boundary {
   const boundary: Partial<Boundary> = {}
   nodes.forEach((node) => {
     if (node.type === "List" && node.children![0].type === "Atom") {
-      boundary.path = processPath(node.children!)
+      switch (node.children![0].value) {
+        case "path":
+          boundary.path = processPath(node.children!)
+          break
+        case "rect":
+          boundary.rect = processBoundaryRect(node.children!)
+          break
+        case "polygon":
+          boundary.polygon = processBoundaryPolygon(node.children!)
+          break
+      }
     }
   })
-  // Ensure boundary.path is defined
-  if (!boundary.path) {
+  if (!boundary.path && !boundary.rect && !boundary.polygon) {
     boundary.path = { layer: "", width: 0, coordinates: [] }
   }
   return boundary as Boundary
+}
+
+function processBoundaryRect(nodes: ASTNode[]): NonNullable<Boundary["rect"]> {
+  if (nodes[1]?.type !== "Atom" || typeof nodes[1].value !== "string") {
+    throw new Error("Invalid boundary rect format")
+  }
+
+  return {
+    type: nodes[1].value,
+    coordinates: nodes
+      .slice(2)
+      .filter((node) => node.type === "Atom" && typeof node.value === "number")
+      .map((node) => node.value as number),
+  }
+}
+
+function processBoundaryPolygon(
+  nodes: ASTNode[],
+): NonNullable<Boundary["polygon"]> {
+  if (nodes[1]?.type !== "Atom" || typeof nodes[1].value !== "string") {
+    throw new Error("Invalid boundary polygon format")
+  }
+  if (nodes[2]?.type !== "Atom" || typeof nodes[2].value !== "number") {
+    throw new Error("Invalid boundary polygon width")
+  }
+
+  return {
+    type: nodes[1].value,
+    width: nodes[2].value,
+    coordinates: nodes
+      .slice(3)
+      .filter((node) => node.type === "Atom" && typeof node.value === "number")
+      .map((node) => node.value as number),
+  }
 }
 
 function processPath(nodes: ASTNode[]): Path {

--- a/lib/dsn-pcb/types.ts
+++ b/lib/dsn-pcb/types.ts
@@ -23,13 +23,7 @@ export interface DsnPcb {
         index: number
       }
     }>
-    boundary: {
-      path: {
-        layer: string
-        width: number
-        coordinates: number[]
-      }
-    }
+    boundary: Boundary
     via: string
     rule: {
       clearances: Array<{

--- a/tests/assets/repro/smoothieboard-boundary-shapes.dsn
+++ b/tests/assets/repro/smoothieboard-boundary-shapes.dsn
@@ -1,0 +1,37 @@
+(pcb "B:\depot\CAD\KiCad\test\Smoothieboard-master\smoothieboard-5driver\smoothieboard-5driver.dsn"
+  (parser
+    (string_quote ")
+    (space_in_quoted_tokens on)
+    (host_cad "KiCad's Pcbnew")
+    (host_version "(5.1.9)-1")
+  )
+  (resolution um 10)
+  (unit um)
+  (structure
+    (layer Top
+      (type signal)
+      (property
+        (index 0)
+      )
+    )
+    (layer Route2
+      (type power)
+      (property
+        (index 1)
+      )
+    )
+    (boundary
+      (rect pcb 82550 -159512 214376 -50673)
+      (polygon pcb 0 82550 -159512 214376 -159512 214376 -50673 82550 -50673)
+    )
+    (via "Via[0-3]_800:400_um")
+    (rule
+      (width 250)
+      (clearance 200.1)
+    )
+  )
+  (placement)
+  (library)
+  (network)
+  (wiring)
+)

--- a/tests/dsn-pcb/stringify-dsn-json.test.ts
+++ b/tests/dsn-pcb/stringify-dsn-json.test.ts
@@ -9,6 +9,10 @@ import {
 import testDsnFile from "../assets/testkicadproject/testkicadproject.dsn" with {
   type: "text",
 }
+// @ts-ignore
+import smoothieBoundaryShapesDsn from "../assets/repro/smoothieboard-boundary-shapes.dsn" with {
+  type: "text",
+}
 
 const getBoard = (dsnJson: DsnPcb) => {
   const board = convertDsnPcbToCircuitJson(dsnJson).find(
@@ -130,4 +134,27 @@ test("preserves polygon structure boundary shapes when stringifying", () => {
   const board = getBoard(reparsedJson)
   expect(board.width).toBeCloseTo(0.04)
   expect(board.height).toBeCloseTo(0.06)
+})
+
+test("round-trips Smoothieboard rect and polygon boundary shapes from fixture", () => {
+  const dsnJson = parseDsnToDsnJson(smoothieBoundaryShapesDsn) as DsnPcb
+
+  expect(dsnJson.structure.boundary).toEqual({
+    rect: {
+      type: "pcb",
+      coordinates: [82550, -159512, 214376, -50673],
+    },
+    polygon: {
+      type: "pcb",
+      width: 0,
+      coordinates: [
+        82550, -159512, 214376, -159512, 214376, -50673, 82550, -50673,
+      ],
+    },
+  })
+
+  const dsnString = stringifyDsnJson(dsnJson)
+  const reparsedJson = parseDsnToDsnJson(dsnString) as DsnPcb
+
+  expect(reparsedJson.structure.boundary).toEqual(dsnJson.structure.boundary)
 })

--- a/tests/dsn-pcb/stringify-dsn-json.test.ts
+++ b/tests/dsn-pcb/stringify-dsn-json.test.ts
@@ -1,8 +1,23 @@
 import { expect, test } from "bun:test"
-import { type DsnPcb, parseDsnToDsnJson, stringifyDsnJson } from "lib"
+import {
+  convertDsnPcbToCircuitJson,
+  type DsnPcb,
+  parseDsnToDsnJson,
+  stringifyDsnJson,
+} from "lib"
 // @ts-ignore
 import testDsnFile from "../assets/testkicadproject/testkicadproject.dsn" with {
   type: "text",
+}
+
+const getBoard = (dsnJson: DsnPcb) => {
+  const board = convertDsnPcbToCircuitJson(dsnJson).find(
+    (element) => element.type === "pcb_board",
+  )
+  if (!board || board.type !== "pcb_board") {
+    throw new Error("Expected a pcb_board element")
+  }
+  return board
 }
 
 test("stringify dsn json", () => {
@@ -16,4 +31,103 @@ test("stringify dsn json", () => {
 
   // Test that we can parse the generated string back to the same structure
   // expect(reparsedJson).toEqual(dsnJson)
+})
+
+test("preserves non-path structure boundary shapes when stringifying", () => {
+  const dsn = `(pcb boundary-shapes
+  (parser
+    (string_quote ")
+    (space_in_quoted_tokens on)
+    (host_cad "unit-test")
+    (host_version "1")
+  )
+  (resolution um 10)
+  (unit um)
+  (structure
+    (layer F.Cu
+      (type signal)
+      (property
+        (index 0)
+      )
+    )
+    (boundary
+      (rect pcb -10 -20 30 40)
+    )
+    (via "")
+    (rule
+      (width 100)
+    )
+  )
+  (placement)
+  (library)
+  (network)
+  (wiring)
+)`
+
+  const dsnJson = parseDsnToDsnJson(dsn) as DsnPcb
+
+  expect(dsnJson.structure.boundary.rect).toEqual({
+    type: "pcb",
+    coordinates: [-10, -20, 30, 40],
+  })
+
+  const dsnString = stringifyDsnJson(dsnJson)
+  const reparsedJson = parseDsnToDsnJson(dsnString) as DsnPcb
+
+  expect(dsnString).toContain("(rect pcb -10 -20 30 40)")
+  expect(reparsedJson.structure.boundary).toEqual(dsnJson.structure.boundary)
+
+  const board = getBoard(reparsedJson)
+  expect(board.width).toBeCloseTo(0.04)
+  expect(board.height).toBeCloseTo(0.06)
+})
+
+test("preserves polygon structure boundary shapes when stringifying", () => {
+  const dsn = `(pcb polygon-boundary
+  (parser
+    (string_quote ")
+    (space_in_quoted_tokens on)
+    (host_cad "unit-test")
+    (host_version "1")
+  )
+  (resolution um 10)
+  (unit um)
+  (structure
+    (layer F.Cu
+      (type signal)
+      (property
+        (index 0)
+      )
+    )
+    (boundary
+      (polygon pcb 0 -10 -20 30 -20 30 40 -10 40)
+    )
+    (via "")
+    (rule
+      (width 100)
+    )
+  )
+  (placement)
+  (library)
+  (network)
+  (wiring)
+)`
+
+  const dsnJson = parseDsnToDsnJson(dsn) as DsnPcb
+
+  expect(dsnJson.structure.boundary.polygon).toEqual({
+    type: "pcb",
+    width: 0,
+    coordinates: [-10, -20, 30, -20, 30, 40, -10, 40],
+  })
+
+  const dsnString = stringifyDsnJson(dsnJson)
+  const reparsedJson = parseDsnToDsnJson(dsnString) as DsnPcb
+
+  expect(dsnString).toContain("(polygon pcb 0 -10 -20 30 -20 30 40 -10 40)")
+  expect(reparsedJson.structure.boundary).toEqual(dsnJson.structure.boundary)
+
+  const board = getBoard(reparsedJson)
+  expect(board.width).toBeCloseTo(0.04)
+  expect(board.height).toBeCloseTo(0.06)
 })


### PR DESCRIPTION
# Preserve DSN structure boundary shapes

## Summary
- Parse structure boundary descriptors by shape type so `(rect ...)` and `(polygon ...)` are preserved instead of being coerced through the path parser.
- Stringify preserved structure boundary `path`, `rect`, and `polygon` descriptors from `DsnPcb`.
- Derive board extents from preserved rect/polygon boundaries so existing DSN-to-Circuit JSON conversion keeps working.

Fixes #54.
/claim #54

## Why this is low-risk
- Limits parser/stringifier changes to the structure boundary descriptor path.
- Keeps existing path boundary behavior unchanged.
- Adds only the board-boundary extent compatibility needed for preserved rect/polygon fixtures.

## Files changed
- `lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts` - modified: dispatches boundary shapes and parses rect/polygon descriptors
- `lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts` - modified: emits preserved boundary shape descriptors
- `lib/dsn-pcb/dsn-json-to-circuit-json/convert-dsn-pcb-to-circuit-json.ts` - modified: reads board extents from path, rect, or polygon boundaries
- `lib/dsn-pcb/types.ts` - modified: uses the existing Boundary type for DsnPcb.structure.boundary
- `tests/dsn-pcb/stringify-dsn-json.test.ts` - modified: adds rect/polygon parse -> stringify -> parse coverage plus board sizing assertions
- `tests/assets/repro/smoothieboard-boundary-shapes.dsn` - added: minimal Smoothieboard-shaped DSN fixture with rect and polygon structure boundaries

## Coverage
- Focused regression coverage for structure boundary `rect` and `polygon` descriptors.
- Round-trip assertions confirm stringified DSN reparses to the same boundary shape.
- Golden fixture coverage parses a minimal Smoothieboard-shaped DSN containing both rect and polygon boundaries, stringifies it, reparses it, and asserts the boundary shapes are identical.
- Board sizing assertions confirm preserved rect/polygon boundaries still feed DSN-to-Circuit JSON conversion.

## Verification
- `bun test tests/dsn-pcb/stringify-dsn-json.test.ts` - passed, 4 tests
- `bun run format:check` - passed
- `bunx tsc --noEmit` - passed
- `bun run build` - passed
- `bun test` - passed, 50 passed / 1 skipped / 0 failed
- `git diff --check` - passed

## Reviewer notes
- This intentionally does not touch placement, routing, padstack, plane, keepout, session, or Smoothieboard conversion logic beyond keeping board extents compatible with preserved boundary shapes.
- The focused tests reproduce the previous loss of `rect` and `polygon` boundary data before the parser change, and the Smoothieboard-shaped fixture proves both shapes survive a full parse -> stringify -> parse cycle together.

## Boundary note
No payment, account, secret, or private contact details are included in this PR.