### PR TITLE
Preserve DSN structure control metadata

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
@@ -63,6 +63,16 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
     result += `${indent}${indent}${indent}(clearance ${clearance.value}${clearance.type ? ` (type ${clearance.type})` : ""})\n`
   })
   result += `${indent}${indent})\n`
+  if (dsnJson.structure.snap_angle) {
+    result += `${indent}${indent}(snap_angle\n`
+    result += `${indent}${indent}${indent}${dsnJson.structure.snap_angle}\n`
+    result += `${indent}${indent})\n`
+  }
+  if (dsnJson.structure.control?.via_at_smd) {
+    result += `${indent}${indent}(control\n`
+    result += `${indent}${indent}${indent}(via_at_smd ${dsnJson.structure.control.via_at_smd})\n`
+    result += `${indent}${indent})\n`
+  }
   result += `${indent})\n`
 
   // Placement section

--- a/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
@@ -14,6 +14,7 @@ import type {
   Clearance,
   Component,
   ComponentPlacement,
+  Control,
   DsnJson,
   DsnPcb,
   DsnSession,
@@ -236,12 +237,45 @@ export function processStructure(nodes: ASTNode[]): Structure {
           case "rule":
             structure.rule = processRule(node.children!.slice(1))
             break
+          case "snap_angle":
+            structure.snap_angle = processSnapAngle(node.children!)
+            break
+          case "control":
+            structure.control = processControl(node.children!.slice(1))
+            break
         }
       }
     }
   })
 
   return structure as Structure
+}
+
+function processSnapAngle(nodes: ASTNode[]): string | undefined {
+  const valueNode = nodes[1]
+  if (valueNode?.type === "Atom" && typeof valueNode.value === "string") {
+    return valueNode.value
+  }
+}
+
+function processControl(nodes: ASTNode[]): Control {
+  const control: Control = {}
+
+  nodes.forEach((node) => {
+    if (node.type === "List") {
+      const [keyNode, valueNode] = node.children!
+      if (
+        keyNode.type === "Atom" &&
+        keyNode.value === "via_at_smd" &&
+        valueNode?.type === "Atom" &&
+        typeof valueNode.value === "string"
+      ) {
+        control.via_at_smd = valueNode.value
+      }
+    }
+  })
+
+  return control
 }
 
 function processLayer(nodes: ASTNode[]): Layer {

--- a/lib/dsn-pcb/types.ts
+++ b/lib/dsn-pcb/types.ts
@@ -38,6 +38,10 @@ export interface DsnPcb {
       }>
       width: number
     }
+    snap_angle?: string
+    control?: {
+      via_at_smd?: string
+    }
   }
   placement: {
     components: Array<ComponentPlacement>
@@ -112,6 +116,8 @@ export interface Structure {
   boundary: Boundary
   via: string
   rule: Rule
+  snap_angle?: string
+  control?: Control
 }
 
 export interface Layer {
@@ -148,6 +154,10 @@ export interface Path {
 export interface Rule {
   width: number
   clearances: Clearance[]
+}
+
+export interface Control {
+  via_at_smd?: string
 }
 
 export interface Clearance {

--- a/tests/dsn-pcb/structure-control-snap-angle.test.ts
+++ b/tests/dsn-pcb/structure-control-snap-angle.test.ts
@@ -1,0 +1,50 @@
+import { expect, test } from "bun:test"
+import { type DsnPcb, parseDsnToDsnJson, stringifyDsnJson } from "lib"
+
+test("preserves structure snap angle and control settings", () => {
+  const dsn = `(pcb "structure-control.dsn"
+    (parser
+      (host_version "freerouting-test")
+    )
+    (resolution um 10)
+    (unit um)
+    (structure
+      (layer F.Cu
+        (type signal)
+        (property
+          (index 0)
+        )
+      )
+      (boundary
+        (path pcb 0 0 0 1000 0 1000 1000 0 1000)
+      )
+      (via "Via[0-1]_600:300_um")
+      (rule
+        (width 200)
+        (clearance 200)
+      )
+      (snap_angle
+        fortyfive_degree
+      )
+      (control
+        (via_at_smd off)
+      )
+    )
+    (placement)
+    (library)
+    (network)
+    (wiring)
+  )`
+
+  const dsnJson = parseDsnToDsnJson(dsn) as DsnPcb
+
+  expect(dsnJson.structure.snap_angle).toBe("fortyfive_degree")
+  expect(dsnJson.structure.control?.via_at_smd).toBe("off")
+
+  const dsnString = stringifyDsnJson(dsnJson)
+
+  expect(dsnString).toContain("(snap_angle")
+  expect(dsnString).toContain("fortyfive_degree")
+  expect(dsnString).toContain("(control")
+  expect(dsnString).toContain("(via_at_smd off)")
+})


### PR DESCRIPTION
/claim #54

## Summary
- preserve structure-level `(snap_angle ...)` when parsing DSN PCB files
- preserve `(control (via_at_smd ...))` in the DSN JSON structure model
- emit both descriptors from `stringifyDsnJson` so parse -> stringify keeps the freerouting metadata
- add a focused round-trip test for the new structure metadata fields

## Scope
This is intentionally metadata-only. It does not change Circuit JSON conversion, Smoothie geometry, placement, routing, wiring, padstack, library, or session behavior.

## Validation
- `npx --yes bun test tests\dsn-pcb\structure-control-snap-angle.test.ts`
- `npx --yes bun x tsc --noEmit`
- `npx --yes bun run build`
- `git diff --check`

Transparency: AI-assisted with OpenAI Codex; I reviewed the diff and local verification before submitting.