### PR TITLE
Preserve DSN structure plane polygons

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
@@ -56,6 +56,9 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
     result += `${indent}${indent}${indent}${stringifyPath(dsnJson.structure.boundary.path, 0)}\n`
     result += `${indent}${indent})\n`
   }
+  dsnJson.structure.planes?.forEach((plane) => {
+    result += `${indent}${indent}(plane ${stringifyValue(plane.net)} (polygon ${plane.polygon.layer} ${plane.polygon.width} ${stringifyCoordinates(plane.polygon.coordinates)}))\n`
+  })
   result += `${indent}${indent}(via ${stringifyValue(dsnJson.structure.via)})\n`
   result += `${indent}${indent}(rule\n`
   result += `${indent}${indent}${indent}(width ${dsnJson.structure.rule.width})\n`

--- a/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
@@ -30,6 +30,7 @@ import type {
   Pin,
   Placement,
   Places,
+  Plane,
   PolygonShape,
   RectShape,
   Resolution,
@@ -211,6 +212,7 @@ export function processResolution(nodes: ASTNode[]): Resolution {
 export function processStructure(nodes: ASTNode[]): Structure {
   const structure: Partial<Structure> = {
     layers: [],
+    planes: [],
   }
 
   nodes.forEach((node) => {
@@ -224,6 +226,9 @@ export function processStructure(nodes: ASTNode[]): Structure {
             break
           case "boundary":
             structure.boundary = processBoundary(node.children!.slice(1))
+            break
+          case "plane":
+            structure.planes!.push(processPlane(node.children!))
             break
           case "via":
             if (
@@ -242,6 +247,47 @@ export function processStructure(nodes: ASTNode[]): Structure {
   })
 
   return structure as Structure
+}
+
+function processPlane(nodes: ASTNode[]): Plane {
+  const plane: Partial<Plane> = {}
+  if (nodes[1].type === "Atom") {
+    plane.net = String(nodes[1].value)
+  }
+
+  const polygonNode = nodes.find(
+    (node) =>
+      node.type === "List" &&
+      node.children?.[0]?.type === "Atom" &&
+      node.children[0].value === "polygon",
+  )
+
+  if (polygonNode?.children) {
+    const polygonNodes = polygonNode.children
+    if (
+      polygonNodes[1]?.type === "Atom" &&
+      typeof polygonNodes[1].value === "string" &&
+      polygonNodes[2]?.type === "Atom" &&
+      typeof polygonNodes[2].value === "number"
+    ) {
+      plane.polygon = {
+        layer: polygonNodes[1].value,
+        width: polygonNodes[2].value,
+        coordinates: polygonNodes
+          .slice(3)
+          .filter(
+            (node) => node.type === "Atom" && typeof node.value === "number",
+          )
+          .map((node) => node.value as number),
+      }
+    }
+  }
+
+  if (!plane.net || !plane.polygon) {
+    throw new Error("Invalid plane format")
+  }
+
+  return plane as Plane
 }
 
 function processLayer(nodes: ASTNode[]): Layer {

--- a/lib/dsn-pcb/types.ts
+++ b/lib/dsn-pcb/types.ts
@@ -30,6 +30,7 @@ export interface DsnPcb {
         coordinates: number[]
       }
     }
+    planes?: Plane[]
     via: string
     rule: {
       clearances: Array<{
@@ -110,6 +111,7 @@ export interface Resolution {
 export interface Structure {
   layers: Layer[]
   boundary: Boundary
+  planes?: Plane[]
   via: string
   rule: Rule
 }
@@ -143,6 +145,15 @@ export interface Path {
   layer: string
   width: number
   coordinates: number[]
+}
+
+export interface Plane {
+  net: string
+  polygon: {
+    layer: string
+    width: number
+    coordinates: number[]
+  }
 }
 
 export interface Rule {

--- a/tests/dsn-pcb/stringify-dsn-json.test.ts
+++ b/tests/dsn-pcb/stringify-dsn-json.test.ts
@@ -1,6 +1,10 @@
 import { expect, test } from "bun:test"
 import { type DsnPcb, parseDsnToDsnJson, stringifyDsnJson } from "lib"
 // @ts-ignore
+import smoothieDsnFile from "../assets/repro/smoothieboard-repro.dsn" with {
+  type: "text",
+}
+// @ts-ignore
 import testDsnFile from "../assets/testkicadproject/testkicadproject.dsn" with {
   type: "text",
 }
@@ -16,4 +20,25 @@ test("stringify dsn json", () => {
 
   // Test that we can parse the generated string back to the same structure
   // expect(reparsedJson).toEqual(dsnJson)
+})
+
+test("preserves structure plane polygons from Smoothieboard DSN", () => {
+  const dsnJson = parseDsnToDsnJson(smoothieDsnFile) as DsnPcb
+
+  expect(dsnJson.structure.planes).toHaveLength(1)
+  expect(dsnJson.structure.planes?.[0]).toEqual({
+    net: "AGND",
+    polygon: {
+      layer: "Route2",
+      width: 0,
+      coordinates: [
+        214249, -158877, 82677, -159512, 82550, -50673, 214376, -50673, 214249,
+        -158877,
+      ],
+    },
+  })
+
+  const reparsedJson = parseDsnToDsnJson(stringifyDsnJson(dsnJson)) as DsnPcb
+
+  expect(reparsedJson.structure.planes).toEqual(dsnJson.structure.planes)
 })


### PR DESCRIPTION
﻿## Summary
- Preserve DSN `structure`-level `(plane ...)` descriptors in the parsed `DsnPcb` model.
- Emit preserved plane polygons from `stringifyDsnJson` so Smoothieboard's `AGND` copper pour survives parse -> stringify -> parse.
- Add focused Smoothieboard regression coverage for the existing `(plane AGND (polygon Route2 ...))` fixture.

This is a scoped incremental slice for #54, not a claim that the entire Smoothieboard conversion is finished.

@algora-pbc /claim #54

## Verification
- `npx bun test tests\\dsn-pcb\\stringify-dsn-json.test.ts -t "preserves structure plane polygons"`
- `npx bun run build`
- `npx biome check lib\\dsn-pcb\\types.ts lib\\dsn-pcb\\dsn-json-to-circuit-json\\parse-dsn-to-dsn-json.ts lib\\dsn-pcb\\circuit-json-to-dsn-json\\stringify-dsn-json.ts tests\\dsn-pcb\\stringify-dsn-json.test.ts`
- `git diff --check`

Note: `npx bun test tests\\dsn-pcb\\stringify-dsn-json.test.ts` still hits the pre-existing unfiltered `stringify dsn json` parser/string_quote round-trip failure on current main, so the new regression was run by name.
