### PR TITLE
Preserve rectangular padstack shapes when stringifying DSN

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
@@ -97,6 +97,8 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
         result += `${indent}${indent}${indent}(shape (polygon ${shape.layer} ${shape.width} ${stringifyCoordinates(shape.coordinates)}))\n`
       } else if (shape.shapeType === "circle") {
         result += `${indent}${indent}${indent}(shape (circle ${shape.layer} ${shape.diameter}))\n`
+      } else if (shape.shapeType === "rect") {
+        result += `${indent}${indent}${indent}(shape (rect ${shape.layer} ${stringifyCoordinates(shape.coordinates)}))\n`
       } else if (shape.shapeType === "path") {
         result += `${indent}${indent}${indent}(shape (path ${shape.layer} ${shape.width} ${stringifyCoordinates(shape.coordinates)}))\n`
       }

--- a/tests/dsn-pcb/stringify-dsn-json.test.ts
+++ b/tests/dsn-pcb/stringify-dsn-json.test.ts
@@ -4,6 +4,18 @@ import { type DsnPcb, parseDsnToDsnJson, stringifyDsnJson } from "lib"
 import testDsnFile from "../assets/testkicadproject/testkicadproject.dsn" with {
   type: "text",
 }
+// @ts-ignore
+import smoothieboardDsnFile from "../assets/repro/smoothieboard-repro.dsn" with {
+  type: "text",
+}
+
+const countRectPadstackShapes = (dsnJson: DsnPcb) =>
+  dsnJson.library.padstacks.reduce(
+    (count, padstack) =>
+      count +
+      padstack.shapes.filter((shape) => shape.shapeType === "rect").length,
+    0,
+  )
 
 test("stringify dsn json", () => {
   const dsnJson = parseDsnToDsnJson(testDsnFile) as DsnPcb
@@ -16,4 +28,55 @@ test("stringify dsn json", () => {
 
   // Test that we can parse the generated string back to the same structure
   // expect(reparsedJson).toEqual(dsnJson)
+})
+
+test("stringify dsn json preserves rectangular padstack shapes", () => {
+  const dsnJson = parseDsnToDsnJson(`
+    (pcb "rect-padstack.dsn"
+      (parser
+        (string_quote ")
+        (space_in_quoted_tokens on)
+        (host_cad "KiCad")
+        (host_version "8.0")
+      )
+      (resolution um 10)
+      (unit um)
+      (structure
+        (layer Top (type signal) (property (index 0)))
+        (boundary (path pcb 0 0 0 1000 0 1000 1000 0 1000 0 0))
+        (via "Via[0-1]_600:300_um")
+        (rule (width 150) (clearance 150))
+      )
+      (placement)
+      (library
+        (image "R_0603" (pin Rect[T]Pad_1000x500_um 1 0 0))
+        (padstack Rect[T]Pad_1000x500_um
+          (shape (rect Top -500 -250 500 250))
+          (attach off)
+        )
+      )
+      (network)
+      (wiring)
+    )
+  `) as DsnPcb
+
+  const dsnString = stringifyDsnJson(dsnJson)
+  const reparsedJson = parseDsnToDsnJson(dsnString) as DsnPcb
+
+  expect(reparsedJson.library.padstacks[0]!.shapes).toContainEqual({
+    shapeType: "rect",
+    layer: "Top",
+    coordinates: [-500, -250, 500, 250],
+  })
+})
+
+test("stringify dsn json keeps Smoothieboard rectangular padstack count", () => {
+  const dsnJson = parseDsnToDsnJson(smoothieboardDsnFile) as DsnPcb
+  const originalRectShapeCount = countRectPadstackShapes(dsnJson)
+
+  const dsnString = stringifyDsnJson(dsnJson)
+  const reparsedJson = parseDsnToDsnJson(dsnString) as DsnPcb
+
+  expect(originalRectShapeCount).toBeGreaterThan(0)
+  expect(countRectPadstackShapes(reparsedJson)).toBe(originalRectShapeCount)
 })


### PR DESCRIPTION
## Summary
- emit parsed `rect` padstack shapes from `stringifyDsnJson`
- add focused round-trip coverage for a rectangular padstack shape
- add a Smoothieboard fixture guard that preserves the parsed rectangular padstack shape count

## Why this helps #54
The Smoothieboard DSN fixture includes rectangular SMD padstack shapes. Current main parses those `rect` shapes into DSN JSON but drops them when stringifying, so parse -> stringify loses pad geometry. This keeps the parsed geometry round-trippable without changing Circuit JSON conversion behaviour.

## Tests
- `bun test tests/dsn-pcb/stringify-dsn-json.test.ts`
- `bun run build`
- `bun test`
- `git diff --check`

Note: `bun run format:check` currently reports pre-existing generated debug-file formatting differences under `debug-files/`; touched files were formatted directly with Biome.

/claim #54