### PR TITLE
Preserve placement pin clearance classes

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
@@ -26,6 +26,23 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
     return `${padding}(path ${path.layer} ${path.width}  ${stringifyCoordinates(path.coordinates)})`
   }
 
+  const stringifyPlace = (place: any, level: number): string => {
+    const padding = indent.repeat(level)
+    const pn = place.PN ? ` (PN ${stringifyValue(place.PN)})` : ""
+    const pinMetadata = place.pins ?? []
+
+    if (pinMetadata.length === 0) {
+      return `${padding}(place ${place.refdes} ${place.x} ${place.y} ${place.side} ${place.rotation}${pn})`
+    }
+
+    let placeString = `${padding}(place ${place.refdes} ${place.x} ${place.y} ${place.side} ${place.rotation}${pn}\n`
+    pinMetadata.forEach((pin: any) => {
+      placeString += `${padding}${indent}(pin ${pin.pin_number}${pin.clearance_class ? ` (clearance_class ${stringifyValue(pin.clearance_class)})` : ""})\n`
+    })
+    placeString += `${padding})`
+    return placeString
+  }
+
   // Start with pcb
   result += `(pcb ${dsnJson.filename ? dsnJson.filename : "./converted_dsn.dsn"}\n`
 
@@ -71,7 +88,7 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
     result += `${indent}${indent}(component ${stringifyValue(component.name)}\n`
     if (component.places) {
       component.places.forEach((place) => {
-        result += `${indent}${indent}${indent}(place ${place.refdes} ${place.x} ${place.y} ${place.side} ${place.rotation}${place.PN ? ` (PN ${stringifyValue(place.PN)})` : ""})\n`
+        result += `${stringifyPlace(place, 3)}\n`
       })
     }
     result += `${indent}${indent})\n`

--- a/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
@@ -477,7 +477,7 @@ function processPlace(nodes: ASTNode[]): Places {
     }
   }
 
-  // Process optional PN (part number) if present
+  // Process optional PN (part number) and per-place pin metadata if present
   for (let i = coordIndex + 4; i < nodes.length; i++) {
     const node = nodes[i]
     if (
@@ -489,7 +489,33 @@ function processPlace(nodes: ASTNode[]): Places {
       node.children[1].type === "Atom"
     ) {
       places.PN = String(node.children[1].value)
-      break
+    } else if (
+      node.type === "List" &&
+      node.children &&
+      node.children[0].type === "Atom" &&
+      node.children[0].value === "pin" &&
+      node.children[1] &&
+      node.children[1].type === "Atom"
+    ) {
+      const pin: NonNullable<Places["pins"]>[number] = {
+        pin_number: node.children[1].value as string | number,
+      }
+
+      for (const pinChild of node.children.slice(2)) {
+        if (
+          pinChild.type === "List" &&
+          pinChild.children &&
+          pinChild.children[0].type === "Atom" &&
+          pinChild.children[0].value === "clearance_class" &&
+          pinChild.children[1] &&
+          pinChild.children[1].type === "Atom"
+        ) {
+          pin.clearance_class = String(pinChild.children[1].value)
+        }
+      }
+
+      places.pins ??= []
+      places.pins.push(pin)
     }
   }
 

--- a/lib/dsn-pcb/types.ts
+++ b/lib/dsn-pcb/types.ts
@@ -88,6 +88,10 @@ export interface ComponentPlacement {
   places: Array<{
     refdes: string
     PN?: string
+    pins?: Array<{
+      pin_number: string | number
+      clearance_class?: string
+    }>
     x: number
     y: number
     side: "front" | "back"
@@ -171,6 +175,10 @@ export interface Places {
   side: string
   rotation: number
   PN: string
+  pins?: Array<{
+    pin_number: string | number
+    clearance_class?: string
+  }>
 }
 
 export interface Library {

--- a/tests/dsn-pcb/stringify-dsn-json.test.ts
+++ b/tests/dsn-pcb/stringify-dsn-json.test.ts
@@ -1,6 +1,10 @@
 import { expect, test } from "bun:test"
 import { type DsnPcb, parseDsnToDsnJson, stringifyDsnJson } from "lib"
 // @ts-ignore
+import freeroutingTraceAddedDsnFile from "../assets/testkicadproject/freeroutingTraceAdded.dsn" with {
+  type: "text",
+}
+// @ts-ignore
 import testDsnFile from "../assets/testkicadproject/testkicadproject.dsn" with {
   type: "text",
 }
@@ -16,4 +20,35 @@ test("stringify dsn json", () => {
 
   // Test that we can parse the generated string back to the same structure
   // expect(reparsedJson).toEqual(dsnJson)
+})
+
+test("preserves placement pin clearance classes", () => {
+  const dsnJson = parseDsnToDsnJson(freeroutingTraceAddedDsnFile) as DsnPcb
+  const resistor = dsnJson.placement.components.find(
+    (component) => component.name === "Resistor_SMD:R_0402_1005Metric",
+  )
+  const r1 = resistor?.places.find((place) => place.refdes === "R1")
+
+  expect(r1?.pins).toEqual([
+    { pin_number: 1, clearance_class: "kicad_default" },
+    { pin_number: 2, clearance_class: "kicad_default" },
+  ])
+
+  const stringifierSafeDsnJson = parseDsnToDsnJson(testDsnFile) as DsnPcb
+  const placeToRoundTrip =
+    stringifierSafeDsnJson.placement.components[0].places[0]
+  placeToRoundTrip.pins = r1?.pins
+
+  const reparsedJson = parseDsnToDsnJson(
+    stringifyDsnJson(stringifierSafeDsnJson),
+  ) as DsnPcb
+  const reparsedResistor = reparsedJson.placement.components.find(
+    (component) =>
+      component.name === stringifierSafeDsnJson.placement.components[0].name,
+  )
+  const reparsedR1 = reparsedResistor?.places.find(
+    (place) => place.refdes === placeToRoundTrip.refdes,
+  )
+
+  expect(reparsedR1?.pins).toEqual(r1?.pins)
 })


### PR DESCRIPTION
## Summary
- parse per-placement DSN `(pin ... (clearance_class ...))` metadata under `(place ...)` records
- emit preserved placement pin clearance classes from `stringifyDsnJson`
- add focused coverage proving the freerouting fixture metadata is parsed and survives parse -> stringify -> parse

## Scope
This is a narrow DSN round-trip slice for #54. It does not change Circuit JSON conversion, Smoothieboard geometry, padstack, boundary, plane, wiring, session, tokenizer, or component-level placement property behavior.

## Validation
- `npx -y bun@1.2.21 test tests/dsn-pcb/stringify-dsn-json.test.ts -t "preserves placement pin clearance classes"`
- `npx -y bun@1.2.21 test tests/dsn-pcb/stringify-dsn-json.test.ts`
- `npx -y bun@1.2.21 test`
- `npx -y bun@1.2.21 x tsc --noEmit`
- `npx -y bun@1.2.21 run build`
- `npx -y bun@1.2.21 x biome check lib/dsn-pcb/types.ts lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts tests/dsn-pcb/stringify-dsn-json.test.ts`
- `git diff --check`

/claim #54

Worked on by GPT-5.5 with Codex, with Tom's human review before delivery.