### PR TITLE
Preserve image property metadata

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
@@ -82,6 +82,13 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
   result += `${indent}(library\n`
   dsnJson.library.images.forEach((image) => {
     result += `${indent}${indent}(image ${stringifyValue(image.name)}\n`
+    if (image.properties?.length) {
+      result += `${indent}${indent}${indent}(property\n`
+      image.properties.forEach((property) => {
+        result += `${indent}${indent}${indent}${indent}(${property.key} ${stringifyValue(property.value)})\n`
+      })
+      result += `${indent}${indent}${indent})\n`
+    }
     image.outlines.forEach((outline) => {
       result += `${indent}${indent}${indent}(outline ${stringifyPath(outline.path, 4)})\n`
     })

--- a/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
@@ -16,6 +16,7 @@ import type {
   ComponentPlacement,
   DsnJson,
   DsnPcb,
+  DsnProperty,
   DsnSession,
   Image,
   Layer,
@@ -292,6 +293,28 @@ function processProperty(nodes: ASTNode[]): { index: number } {
   return property
 }
 
+function processGenericProperties(nodes: ASTNode[]): DsnProperty[] {
+  const properties: DsnProperty[] = []
+  nodes.forEach((node) => {
+    if (node.type !== "List") return
+
+    const [keyNode, valueNode] = node.children!
+    if (
+      keyNode?.type === "Atom" &&
+      typeof keyNode.value === "string" &&
+      valueNode?.type === "Atom" &&
+      (typeof valueNode.value === "string" ||
+        typeof valueNode.value === "number")
+    ) {
+      properties.push({
+        key: keyNode.value,
+        value: valueNode.value,
+      })
+    }
+  })
+  return properties
+}
+
 function processBoundary(nodes: ASTNode[]): Boundary {
   const boundary: Partial<Boundary> = {}
   nodes.forEach((node) => {
@@ -534,6 +557,7 @@ function processImage(nodes: ASTNode[]): Image {
   }
   image.outlines = []
   image.pins = []
+  image.properties = []
 
   nodes.slice(2).forEach((node) => {
     if (node.type === "List") {
@@ -545,6 +569,10 @@ function processImage(nodes: ASTNode[]): Image {
         } else if (key === "pin") {
           const pin = processPin(node.children!)
           if (pin) image.pins!.push(pin)
+        } else if (key === "property") {
+          image.properties!.push(
+            ...processGenericProperties(node.children!.slice(1)),
+          )
         }
       }
     }

--- a/lib/dsn-pcb/types.ts
+++ b/lib/dsn-pcb/types.ts
@@ -182,6 +182,12 @@ export interface Image {
   name: string
   outlines: Outline[]
   pins: Pin[]
+  properties?: DsnProperty[]
+}
+
+export interface DsnProperty {
+  key: string
+  value: string | number
 }
 
 export interface Outline {

--- a/tests/dsn-pcb/stringify-dsn-image-properties.test.ts
+++ b/tests/dsn-pcb/stringify-dsn-image-properties.test.ts
@@ -1,0 +1,63 @@
+import { expect, test } from "bun:test"
+import { type DsnPcb, parseDsnToDsnJson, stringifyDsnJson } from "lib"
+
+test("preserves DSN library image property metadata", () => {
+  const dsn = `(pcb "image-properties.dsn"
+  (parser
+    (string_quote ")
+    (space_in_quoted_tokens on)
+    (host_cad "KiCad")
+    (host_version "9.0")
+  )
+  (resolution um 10)
+  (unit um)
+  (structure
+    (layer F.Cu
+      (type signal)
+      (property
+        (index 0)
+      )
+    )
+    (boundary
+      (path pcb 0 0 0 1000 0 1000 1000 0 1000 0 0)
+    )
+    (via "Via[0-1]_600:300_um")
+    (rule
+      (width 200)
+      (clearance 150)
+    )
+  )
+  (placement)
+  (library
+    (image "Connector:Demo"
+      (property
+        (reference_prefix "J")
+        (rotation 90)
+      )
+      (outline (path signal 50 0 0 1000 0))
+      (pin "Rect[T]Pad_1000x500_um" "A1" 0 0)
+    )
+    (padstack "Rect[T]Pad_1000x500_um"
+      (shape (rect F.Cu -500 -250 500 250))
+      (attach off)
+    )
+  )
+  (network)
+  (wiring)
+)`
+
+  const dsnJson = parseDsnToDsnJson(dsn) as DsnPcb
+  expect(dsnJson.library.images[0].properties).toEqual([
+    { key: "reference_prefix", value: "J" },
+    { key: "rotation", value: 90 },
+  ])
+
+  const dsnString = stringifyDsnJson(dsnJson)
+  expect(dsnString).toContain('(reference_prefix "J")')
+  expect(dsnString).toContain("(rotation 90)")
+
+  const reparsedJson = parseDsnToDsnJson(dsnString) as DsnPcb
+  expect(reparsedJson.library.images[0].properties).toEqual(
+    dsnJson.library.images[0].properties,
+  )
+})


### PR DESCRIPTION
Summary
- Preserve DSN library image `(property ...)` metadata while parsing image records.
- Emit image property metadata from `stringifyDsnJson` so DSN JSON round trips keep image-level descriptors.
- Add focused regression coverage for string and numeric image property entries.

/claim #54

Verification
- bun test tests/dsn-pcb/stringify-dsn-image-properties.test.ts
- bun test
- bunx tsc --noEmit
- bunx biome check lib/dsn-pcb/types.ts lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts tests/dsn-pcb/stringify-dsn-image-properties.test.ts
- bun run build
- git diff --check

Transparency note: AI-assisted with Codex; I reviewed the diff and verified it locally before submission.