### PR TITLE
fix: compute polygon pad bbox and pin positions for DSN export

### DIFF
--- a/lib/utils/create-and-add-padstack-for-pcb-smtpad.ts
+++ b/lib/utils/create-and-add-padstack-for-pcb-smtpad.ts
@@ -7,18 +7,50 @@ import {
 } from "./create-padstack"
 import { type PadstackNameArgs, getPadstackName } from "./get-padstack-name"
 
+function getPolygonBoundingBox(points: Array<{ x: number; y: number }>): {
+  width: number
+  height: number
+} {
+  let minX = Infinity
+  let maxX = -Infinity
+  let minY = Infinity
+  let maxY = -Infinity
+  for (const pt of points) {
+    if (pt.x < minX) minX = pt.x
+    if (pt.x > maxX) maxX = pt.x
+    if (pt.y < minY) minY = pt.y
+    if (pt.y > maxY) maxY = pt.y
+  }
+  return { width: maxX - minX, height: maxY - minY }
+}
+
 export function createAndAddPadstackFromPcbSmtPad(
   pcb: DsnPcb,
   pad: PcbSmtPad,
   processedPadstacks: Set<string>,
 ): string {
   const isCircle = pad.shape === "circle"
+
+  let widthUm: number | undefined
+  let heightUm: number | undefined
+
+  if (!isCircle) {
+    if (pad.shape === "polygon") {
+      const bbox = getPolygonBoundingBox(pad.points)
+      widthUm = bbox.width * 1000
+      heightUm = bbox.height * 1000
+    } else {
+      widthUm = (pad as { width: number }).width * 1000
+      heightUm = (pad as { height: number }).height * 1000
+    }
+  }
+
   const padstackParams: PadstackNameArgs = {
     shape: isCircle ? "circle" : "rect",
-    outerDiameter: isCircle ? pad.radius * 1000 * 2 : undefined, // Radius to diameter
-    holeDiameter: isCircle ? pad.radius * 1000 * 2 : undefined, // Radius to diameter
-    width: isCircle ? undefined : (pad as { width: number }).width * 1000,
-    height: isCircle ? undefined : (pad as { height: number }).height * 1000,
+    outerDiameter: isCircle ? pad.radius * 1000 * 2 : undefined,
+    holeDiameter: isCircle ? pad.radius * 1000 * 2 : undefined,
+    width: widthUm,
+    height: heightUm,
     layer: pad.layer as PcbSmtPad["layer"],
   }
 

--- a/lib/utils/create-pin-for-image.ts
+++ b/lib/utils/create-pin-for-image.ts
@@ -4,6 +4,30 @@ import type { PcbComponent, SourcePort } from "circuit-json"
 import type { Pin } from "lib"
 import { type PadstackNameArgs, getPadstackName } from "./get-padstack-name"
 
+function getPolygonBbox(points: Array<{ x: number; y: number }>): {
+  width: number
+  height: number
+  centerX: number
+  centerY: number
+} {
+  let minX = Infinity
+  let maxX = -Infinity
+  let minY = Infinity
+  let maxY = -Infinity
+  for (const pt of points) {
+    if (pt.x < minX) minX = pt.x
+    if (pt.x > maxX) maxX = pt.x
+    if (pt.y < minY) minY = pt.y
+    if (pt.y > maxY) maxY = pt.y
+  }
+  return {
+    width: maxX - minX,
+    height: maxY - minY,
+    centerX: (minX + maxX) / 2,
+    centerY: (minY + maxY) / 2,
+  }
+}
+
 export function createPinForImage(
   pad: any,
   pcbComponent: PcbComponent,
@@ -12,12 +36,35 @@ export function createPinForImage(
   if (!sourcePort) return undefined
 
   const isCircle = pad.shape === "circle"
+  const isPolygon = pad.shape === "polygon"
+
+  let widthUm: number | undefined
+  let heightUm: number | undefined
+  let padX: number
+  let padY: number
+
+  if (isCircle) {
+    padX = pad.x
+    padY = pad.y
+  } else if (isPolygon) {
+    const bbox = getPolygonBbox(pad.points)
+    widthUm = bbox.width * 1000
+    heightUm = bbox.height * 1000
+    padX = bbox.centerX
+    padY = bbox.centerY
+  } else {
+    widthUm = pad.width * 1000
+    heightUm = pad.height * 1000
+    padX = pad.x
+    padY = pad.y
+  }
+
   const padstackParams: PadstackNameArgs = {
     shape: isCircle ? "circle" : "rect",
-    outerDiameter: isCircle ? pad.radius * 1000 * 2 : undefined, // Radius to diameter
-    holeDiameter: isCircle ? pad.radius * 1000 * 2 : undefined, // Radius to diameter
-    width: isCircle ? undefined : pad.width * 1000,
-    height: isCircle ? undefined : pad.height * 1000,
+    outerDiameter: isCircle ? pad.radius * 1000 * 2 : undefined,
+    holeDiameter: isCircle ? pad.radius * 1000 * 2 : undefined,
+    width: widthUm,
+    height: heightUm,
     layer: pad.layer as PcbSmtPad["layer"],
   }
 
@@ -25,7 +72,7 @@ export function createPinForImage(
     padstack_name: getPadstackName(padstackParams),
     pin_number:
       sourcePort.port_hints?.find((hint) => !Number.isNaN(Number(hint))) || 1,
-    x: (pad.x - pcbComponent.center.x) * 1000,
-    y: (pad.y - pcbComponent.center.y) * 1000,
+    x: (padX - pcbComponent.center.x) * 1000,
+    y: (padY - pcbComponent.center.y) * 1000,
   }
 }


### PR DESCRIPTION
## Summary

Fixes NaN dimensions and zeroed pin positions when exporting polygon-shaped SMT pads to Specctra DSN format.

**Changes:**

- **`create-and-add-padstack-for-pcb-smtpad.ts`**: When a pad has `shape === "polygon"`, compute the bounding box (width/height) from the `points` array instead of accessing non-existent `width`/`height` properties (which produced `NaN`).
- **`create-pin-for-image.ts`**: For polygon pads, derive the pin position from the polygon's bounding box center relative to the component center, instead of using `pad.x`/`pad.y` (which don't exist on polygon pads and produced `0 0`).

## Problem

When circuit-json contains `pcb_smtpad` elements with `shape: "polygon"`, the DSN export produced:
1. `NaN` padstack dimensions (because polygon pads have `points[]` not `width`/`height`)
2. `0 0` pin positions in images (because polygon pads don't have `x`/`y` center coords)
3. Undefined padstack references in routed-wiring (consequence of NaN in padstack names)

## Test Results

All 41 existing tests pass. The 6 pre-existing failures are unrelated (Windows path issues in debug utils, `@tscircuit/core` internal errors in newer test files, and a stringify round-trip issue).

Fixes tscircuit/tscircuit#3301
