### PR TITLE
fix: preserve DSN pin identifiers during Smoothieboard conversion

### DIFF
--- a/lib/common/parse-sexpr.ts
+++ b/lib/common/parse-sexpr.ts
@@ -44,18 +44,23 @@ export function tokenizeDsn(input: string): Token[] {
       }
       i++ // Skip the closing quote
       tokens.push({ type: "String", value })
-    } else if (char === "-" || /\d/.test(char)) {
-      // Parse number (integer or float)
-      let numStr = ""
-      if (char === "-") {
-        numStr += "-"
+    } else if (
+      /\d/.test(char) ||
+      (char === "-" && i + 1 < length && /[\d.]/.test(input[i + 1]))
+    ) {
+      // Parse a complete token first. DSN pin names can start with digits,
+      // e.g. "2@1", so only treat the token as a number if the whole token
+      // matches a numeric format.
+      let token = ""
+      while (i < length && !/\s|\(|\)/.test(input[i])) {
+        token += input[i]
         i++
       }
-      while (i < length && /[\d.]/.test(input[i])) {
-        numStr += input[i]
-        i++
+      if (/^-?(?:\d+\.?\d*|\.\d+)(?:e-?\d+)?$/i.test(token)) {
+        tokens.push({ type: "Number", value: Number(token) })
+      } else {
+        tokens.push({ type: "Symbol", value: token })
       }
-      tokens.push({ type: "Number", value: parseFloat(numStr) })
     } else {
       // Parse symbol
       let sym = ""

--- a/lib/dsn-pcb/dsn-json-to-circuit-json/dsn-component-converters/convert-dsn-pcb-components-to-source-components-and-ports.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/dsn-component-converters/convert-dsn-pcb-components-to-source-components-and-ports.ts
@@ -2,6 +2,19 @@ import type { AnySourceComponent, PcbPort, SourcePort } from "circuit-json"
 import type { DsnPcb, Image, Pin } from "lib/dsn-pcb/types"
 import { type Matrix, applyToPoint } from "transformation-matrix"
 
+const getPinIdFragment = (pinNumber: number | string) => {
+  if (typeof pinNumber === "number") return String(pinNumber)
+  return pinNumber.replace(
+    /[^a-zA-Z0-9_-]/g,
+    (char) => `_${char.charCodeAt(0).toString(16)}_`,
+  )
+}
+
+const getSourcePortPinNumber = (pinNumber: number | string) => {
+  if (typeof pinNumber === "number") return pinNumber
+  return undefined
+}
+
 export const convertDsnPcbComponentsToSourceComponentsAndPorts = ({
   dsnPcb,
   transformDsnUnitToMm,
@@ -33,13 +46,18 @@ export const convertDsnPcbComponentsToSourceComponentsAndPorts = ({
       // Create ports for each pin in the image
       if (image.pins) {
         for (const pin of image.pins) {
+          const pinLabel = String(pin.pin_number)
+          const pinIdFragment = getPinIdFragment(pin.pin_number)
           const port: SourcePort = {
             type: "source_port",
-            source_port_id: `source_port_${component.name}-Pad${pin.pin_number}_${place.refdes}`,
+            source_port_id: `source_port_${component.name}-Pad${pinIdFragment}_${place.refdes}`,
             source_component_id: sourceComponent.source_component_id,
-            name: `${place.refdes}-${pin.pin_number}`,
-            pin_number: Number(pin.pin_number),
-            port_hints: [],
+            name: `${place.refdes}-${pinLabel}`,
+            port_hints: [pinLabel],
+          }
+          const sourcePortPinNumber = getSourcePortPinNumber(pin.pin_number)
+          if (sourcePortPinNumber !== undefined) {
+            port.pin_number = sourcePortPinNumber
           }
           // Handle case where place coordinates might be null/undefined
           const placeX = place.x || 0
@@ -49,7 +67,7 @@ export const convertDsnPcbComponentsToSourceComponentsAndPorts = ({
             y: placeY + pin.y,
           })
           const pcb_port: PcbPort = {
-            pcb_port_id: `pcb_port_${component.name}-Pad${pin.pin_number}_${place.refdes}`,
+            pcb_port_id: `pcb_port_${component.name}-Pad${pinIdFragment}_${place.refdes}`,
             type: "pcb_port",
             source_port_id: port.source_port_id,
             pcb_component_id: component.name,

--- a/lib/dsn-pcb/dsn-json-to-circuit-json/dsn-component-converters/convert-padstacks-to-smtpads.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/dsn-component-converters/convert-padstacks-to-smtpads.ts
@@ -5,6 +5,22 @@ import { applyToPoint } from "transformation-matrix"
 
 const debug = Debug("dsn-converter:convertPadstacksToSmtpads")
 
+const getPcbSmtPadIdFragment = (pinNumber: number | string) => {
+  if (typeof pinNumber === "number") return String(pinNumber - 1)
+  return pinNumber.replace(
+    /[^a-zA-Z0-9_-]/g,
+    (char) => `_${char.charCodeAt(0).toString(16)}_`,
+  )
+}
+
+const getPortIdFragment = (pinNumber: number | string) => {
+  if (typeof pinNumber === "number") return String(pinNumber)
+  return pinNumber.replace(
+    /[^a-zA-Z0-9_-]/g,
+    (char) => `_${char.charCodeAt(0).toString(16)}_`,
+  )
+}
+
 export function convertPadstacksToSmtPads(
   pcb: DsnPcb,
   transform: any,
@@ -116,6 +132,9 @@ export function convertPadstacksToSmtPads(
         })
 
         let pcbPad: PcbSmtPad
+        const pinLabel = String(pin.pin_number)
+        const smtPadIdFragment = getPcbSmtPadIdFragment(pin.pin_number)
+        const portIdFragment = getPortIdFragment(pin.pin_number)
         if (rectShape || polygonShape || pathShape) {
           const layer = padstack.shapes[0].layer.includes("B.")
             ? "bottom"
@@ -126,29 +145,29 @@ export function convertPadstacksToSmtPads(
           })
           pcbPad = {
             type: "pcb_smtpad",
-            pcb_smtpad_id: `pcb_smtpad_${componentId}_${place.refdes}_${Number(pin.pin_number) - 1}`,
+            pcb_smtpad_id: `pcb_smtpad_${componentId}_${place.refdes}_${smtPadIdFragment}`,
             pcb_component_id: `${componentId}_${place.refdes}`,
-            pcb_port_id: `pcb_port_${componentId}-Pad${pin.pin_number}_${place.refdes}`,
+            pcb_port_id: `pcb_port_${componentId}-Pad${portIdFragment}_${place.refdes}`,
             shape: "rect",
             x: circuitX,
             y: circuitY,
             width,
             height,
             layer,
-            port_hints: [pin.pin_number.toString()],
+            port_hints: [pinLabel],
           }
         } else {
           pcbPad = {
             type: "pcb_smtpad",
-            pcb_smtpad_id: `pcb_smtpad_${componentId}_${place.refdes}_${Number(pin.pin_number) - 1}`,
+            pcb_smtpad_id: `pcb_smtpad_${componentId}_${place.refdes}_${smtPadIdFragment}`,
             pcb_component_id: `${componentId}_${place.refdes}`,
-            pcb_port_id: `pcb_port_${componentId}-Pad${pin.pin_number}_${place.refdes}`,
+            pcb_port_id: `pcb_port_${componentId}-Pad${portIdFragment}_${place.refdes}`,
             shape: "circle",
             x: circuitX,
             y: circuitY,
             radius: circleShape!.diameter / 2 / 1000,
             layer: side === "front" ? "top" : "bottom",
-            port_hints: [pin.pin_number.toString()],
+            port_hints: [pinLabel],
           }
         }
 

--- a/lib/dsn-pcb/dsn-json-to-circuit-json/dsn-component-converters/convert-wiring-via-to-pcb-vias.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/dsn-component-converters/convert-wiring-via-to-pcb-vias.ts
@@ -21,13 +21,15 @@ export const convertWiringViaToPcbVias = ({
 
   const [x, y] = wire.path.coordinates
   const circuitPoint = applyToPoint(transformUmToMm, { x, y })
+  const viaX = Number(circuitPoint.x.toFixed(4))
+  const viaY = Number(circuitPoint.y.toFixed(4))
 
   const via: PcbVia = {
     type: "pcb_via",
     layers: ["top", "bottom"],
-    pcb_via_id: `pcb_via_${netName}`,
-    x: Number(circuitPoint.x.toFixed(4)),
-    y: Number(circuitPoint.y.toFixed(4)),
+    pcb_via_id: `pcb_via_${netName}_${viaX}_${viaY}`,
+    x: viaX,
+    y: viaY,
     // TODO look up via size
     outer_diameter: 0.6, // Standard via diameter in mm
     hole_diameter: 0.3, // Standard drill diameter in mm

--- a/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
@@ -832,7 +832,7 @@ function processNet(nodes: ASTNode[]): Net {
     ) {
       net.pins = node.children!.slice(1).map((pinNode) => {
         if (pinNode.type === "Atom" && typeof pinNode.value === "string") {
-          return pinNode.value
+          return pinNode.value.replaceAll('"', "")
         } else {
           throw new Error("Invalid pin in net")
         }

--- a/lib/utils/get-pin-number.ts
+++ b/lib/utils/get-pin-number.ts
@@ -9,14 +9,31 @@ const debug = Debug("dsn-converter:getPinNum")
  */
 export function getPinNum(nodes: ASTNode[]): number | string | null {
   // Extract pin number from AST nodes
-  let pinNumber
+  let pinNumber: number | string | undefined
 
-  if (nodes[2]?.type === "List" && nodes[2].children) {
+  const pinNumberNodeIndex = (() => {
+    for (let i = 2; i < nodes.length; i++) {
+      const node = nodes[i]
+      if (
+        node?.type === "List" &&
+        node.children?.[0]?.type === "Atom" &&
+        ["rotate", "mirror"].includes(String(node.children[0].value))
+      ) {
+        continue
+      }
+      return i
+    }
+    return -1
+  })()
+
+  const pinNumberNode = nodes[pinNumberNodeIndex]
+
+  if (pinNumberNode?.type === "List" && pinNumberNode.children) {
     // Pin number is in a List structure
-    pinNumber = nodes[2].children[0]?.value
-  } else if (nodes[2]?.type === "Atom") {
+    pinNumber = pinNumberNode.children[0]?.value
+  } else if (pinNumberNode?.type === "Atom") {
     // Pin number is direct value
-    pinNumber = nodes[2].value
+    pinNumber = pinNumberNode.value
   } else {
     debug("Unsupported pin number format:", nodes)
     return null
@@ -26,7 +43,9 @@ export function getPinNum(nodes: ASTNode[]): number | string | null {
   if (typeof pinNumber === "number") {
     return pinNumber
   }
-  // Try parsing as number first
-  const parsed = parseInt(String(pinNumber), 10)
-  return Number.isNaN(parsed) ? String(pinNumber) : parsed
+  const pinNumberString = String(pinNumber)
+  if (/^-?\d+$/.test(pinNumberString)) {
+    return Number.parseInt(pinNumberString, 10)
+  }
+  return pinNumberString
 }

--- a/tests/dsn-pcb/parse-dsn-pin-identifiers.test.ts
+++ b/tests/dsn-pcb/parse-dsn-pin-identifiers.test.ts
@@ -1,0 +1,30 @@
+import { expect, test } from "bun:test"
+import { type DsnPcb, parseDsnToDsnJson } from "lib"
+
+test("parses DSN pin identifiers with transforms, dashes, and quoted suffixes", () => {
+  const dsn = `
+    (pcb test-board
+      (library
+        (image TESTPKG
+          (pin Rect[T]Pad_1600x1400_um (rotate 90) A 1400 0)
+          (pin Rect[T]Pad_3800x1400_um - -3000 0)
+          (pin RoundRect[T]Pad_2200x3700_1104.19_um 2@1 0 940)
+        )
+      )
+      (network
+        (net AGND
+          (pins C1-- IC11-2@1 RJ1-"RD-")
+        )
+      )
+    )
+  `
+
+  const dsnJson = parseDsnToDsnJson(dsn) as DsnPcb
+
+  expect(dsnJson.library.images[0].pins.map((pin) => pin.pin_number)).toEqual([
+    "A",
+    "-",
+    "2@1",
+  ])
+  expect(dsnJson.network.nets[0].pins).toEqual(["C1--", "IC11-2@1", "RJ1-RD-"])
+})


### PR DESCRIPTION
## Summary

- preserve DSN pin identifiers such as `A`, `-`, `2@1`, and quoted suffixes after transform lists like `(rotate 90)`
- normalize net pin references such as `RJ1-"RD-"` so they can match generated source ports
- avoid forcing string pin labels into numeric `pin_number` fields
- generate unique string-based pad/port IDs instead of `NaN` IDs
- include coordinates in wiring via IDs to avoid duplicate via IDs on the same net
- add a focused parser regression test for rotated, dashed, alphanumeric, and quoted pin identifiers

## Verification

- `node_modules\.bin\biome.cmd check lib\common\parse-sexpr.ts lib\utils\get-pin-number.ts lib\dsn-pcb\dsn-json-to-circuit-json\parse-dsn-to-dsn-json.ts lib\dsn-pcb\dsn-json-to-circuit-json\dsn-component-converters\convert-dsn-pcb-components-to-source-components-and-ports.ts lib\dsn-pcb\dsn-json-to-circuit-json\dsn-component-converters\convert-padstacks-to-smtpads.ts lib\dsn-pcb\dsn-json-to-circuit-json\dsn-component-converters\convert-wiring-via-to-pcb-vias.ts tests\dsn-pcb\parse-dsn-pin-identifiers.test.ts`
- `npm.cmd run build`
- `bun test tests\dsn-pcb\parse-dsn-pin-identifiers.test.ts tests\repros\repro3-fix-hover-trace.test.ts tests\repros\repro7-smoothie-board.test.ts`
- manual Smoothieboard conversion check:
  - unmatched net pins: 266 before, 0 after
  - invalid source-port numeric pin numbers: 0 after
  - duplicate ID samples: 0 after
  - SVG output contains no `NaN` or `undefined`
- manual conversion smoke check across 9 existing `.dsn` fixtures:
  - all 9 parse and convert successfully
  - duplicate ID count: 0 for every fixture
  - invalid source-port numeric pin numbers: 0 for every fixture
- local patch backup checked with `git apply --check` against a clean temporary checkout

## Note

I also ran the full Bun suite on Windows. It reports 45 pass / 1 skip / 3 fail. The remaining failures are outside this change:

- two debug helper path failures from `testPath.split("/")` receiving a Windows path
- existing `stringify-dsn-json` roundtrip mismatch around `(string_quote ")`

Addresses part of #54

/claim #54
