### PR TITLE
Preserve net fromto length constraints

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
@@ -1,4 +1,4 @@
-import type { DsnPcb } from "../types"
+import type { DsnPcb, NetFromToEndpoint } from "../types"
 
 export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
   const indent = "  "
@@ -18,6 +18,13 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
   // Helper function to stringify an array of coordinates
   const stringifyCoordinates = (coordinates: number[]): string => {
     return coordinates.join(" ")
+  }
+
+  const stringifyNetFromToEndpoint = (endpoint: NetFromToEndpoint): string => {
+    if (typeof endpoint === "string") {
+      return endpoint
+    }
+    return `(virtual_pin ${endpoint.virtual_pin})`
   }
 
   // Helper function to stringify a path
@@ -113,6 +120,14 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
     if (net.pins.length > 0) {
       result += `${indent}${indent}${indent}(pins ${net.pins.join(" ")})\n`
     }
+    net.fromtos?.forEach((fromto) => {
+      const circuitLength = fromto.circuit?.length
+      const circuit =
+        circuitLength && circuitLength.length > 0
+          ? ` (circuit (length ${circuitLength.join(" ")}))`
+          : ""
+      result += `${indent}${indent}${indent}(fromto ${stringifyNetFromToEndpoint(fromto.from)} ${stringifyNetFromToEndpoint(fromto.to)}${circuit})\n`
+    })
     result += `${indent}${indent})\n`
   })
   dsnJson.network.classes.forEach((cls) => {

--- a/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
@@ -21,6 +21,8 @@ import type {
   Layer,
   Library,
   Net,
+  NetFromTo,
+  NetFromToEndpoint,
   Network,
   Outline,
   Padstack,
@@ -837,9 +839,64 @@ function processNet(nodes: ASTNode[]): Net {
           throw new Error("Invalid pin in net")
         }
       })
+    } else if (
+      node.type === "List" &&
+      node.children![0].type === "Atom" &&
+      node.children![0].value === "fromto"
+    ) {
+      net.fromtos ??= []
+      net.fromtos.push(processNetFromTo(node.children!))
     }
   })
   return net as Net
+}
+
+function processNetFromTo(nodes: ASTNode[]): NetFromTo {
+  const from = processNetFromToEndpoint(nodes[1])
+  const to = processNetFromToEndpoint(nodes[2])
+  const fromto: NetFromTo = { from, to }
+
+  const circuitNode = nodes.find(
+    (node) =>
+      node.type === "List" &&
+      node.children?.[0]?.type === "Atom" &&
+      node.children[0].value === "circuit",
+  )
+
+  const lengthNode = circuitNode?.children?.find(
+    (node) =>
+      node.type === "List" &&
+      node.children?.[0]?.type === "Atom" &&
+      node.children[0].value === "length",
+  )
+
+  const length = lengthNode?.children
+    ?.slice(1)
+    .filter((node) => node.type === "Atom" && typeof node.value === "number")
+    .map((node) => node.value as number)
+
+  if (length?.length) {
+    fromto.circuit = { length }
+  }
+
+  return fromto
+}
+
+function processNetFromToEndpoint(node: ASTNode): NetFromToEndpoint {
+  if (node.type === "Atom") {
+    return String(node.value)
+  }
+
+  if (
+    node.type === "List" &&
+    node.children?.[0]?.type === "Atom" &&
+    node.children[0].value === "virtual_pin" &&
+    node.children[1]?.type === "Atom"
+  ) {
+    return { virtual_pin: String(node.children[1].value) }
+  }
+
+  throw new Error(`Invalid fromto endpoint: ${JSON.stringify(node)}`)
 }
 
 function processClass(nodes: ASTNode[]): Class {

--- a/lib/dsn-pcb/types.ts
+++ b/lib/dsn-pcb/types.ts
@@ -47,10 +47,7 @@ export interface DsnPcb {
     padstacks: Padstack[]
   }
   network: {
-    nets: Array<{
-      name: string
-      pins: string[]
-    }>
+    nets: Net[]
     classes: Array<{
       name: string
       description: string
@@ -250,6 +247,17 @@ export interface Network {
 export interface Net {
   name: string
   pins: string[]
+  fromtos?: NetFromTo[]
+}
+
+export type NetFromToEndpoint = string | { virtual_pin: string }
+
+export interface NetFromTo {
+  from: NetFromToEndpoint
+  to: NetFromToEndpoint
+  circuit?: {
+    length?: number[]
+  }
 }
 
 export interface Class {

--- a/tests/dsn-pcb/stringify-dsn-json.test.ts
+++ b/tests/dsn-pcb/stringify-dsn-json.test.ts
@@ -17,3 +17,79 @@ test("stringify dsn json", () => {
   // Test that we can parse the generated string back to the same structure
   // expect(reparsedJson).toEqual(dsnJson)
 })
+
+test("preserves net fromto circuit length constraints", () => {
+  const dsn = `(pcb test.dsn
+  (parser
+    (string_quote ")
+    (space_in_quoted_tokens on)
+    (host_cad "KiCad's Pcbnew")
+    (host_version "8.0.0")
+  )
+  (resolution um 10)
+  (unit um)
+  (structure
+    (layer F.Cu
+      (type signal)
+      (property
+        (index 0)
+      )
+    )
+    (layer B.Cu
+      (type signal)
+      (property
+        (index 1)
+      )
+    )
+    (boundary
+      (path pcb 0 0 0 10000 0 10000 10000 0 10000 0 0)
+    )
+    (via "Via[0-1]_600:300_um")
+    (rule
+      (width 250)
+      (clearance 200)
+    )
+  )
+  (placement)
+  (library)
+  (network
+    (net CLK1
+      (pins U1-1 U2-1 U3-1)
+      (fromto U1-1 (virtual_pin FP1)
+        (circuit (length 350 300)))
+      (fromto (virtual_pin FP1) U2-1)
+    )
+    (class kicad_default "" CLK1
+      (circuit
+        (use_via "Via[0-1]_600:300_um")
+      )
+      (rule
+        (width 250)
+        (clearance 200)
+      )
+    )
+  )
+  (wiring)
+)`
+
+  const dsnJson = parseDsnToDsnJson(dsn) as DsnPcb
+
+  expect(dsnJson.network.nets[0].fromtos).toEqual([
+    {
+      from: "U1-1",
+      to: { virtual_pin: "FP1" },
+      circuit: { length: [350, 300] },
+    },
+    {
+      from: { virtual_pin: "FP1" },
+      to: "U2-1",
+    },
+  ])
+
+  const dsnString = stringifyDsnJson(dsnJson)
+  const reparsedJson = parseDsnToDsnJson(dsnString) as DsnPcb
+
+  expect(reparsedJson.network.nets[0].fromtos).toEqual(
+    dsnJson.network.nets[0].fromtos,
+  )
+})


### PR DESCRIPTION
## Summary
- Preserve DSN network `(fromto ...)` records in the parsed `Net` model.
- Support atom endpoints plus `(virtual_pin ...)` endpoints.
- Round-trip optional `(circuit (length ...))` constraints through `stringifyDsnJson`.
- Add a focused parse -> stringify -> parse regression test.

Scope is metadata preservation only; this does not change Smoothie geometry, tokenizer, padstack, via, placement, boundary, or Circuit JSON conversion behavior.

## Validation
- `bun test`
- `bun run build`
- `bun x biome format lib/dsn-pcb/types.ts lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts tests/dsn-pcb/stringify-dsn-json.test.ts`
- `git diff --check`

/claim #54