### PR TITLE
fix: treat standalone minus sign as symbol in DSN tokenizer

### DIFF
--- a/lib/common/parse-sexpr.ts
+++ b/lib/common/parse-sexpr.ts
@@ -44,8 +44,12 @@ export function tokenizeDsn(input: string): Token[] {
       }
       i++ // Skip the closing quote
       tokens.push({ type: "String", value })
-    } else if (char === "-" || /\d/.test(char)) {
+    } else if (
+      /\d/.test(char) ||
+      (char === "-" && i + 1 < length && /\d/.test(input[i + 1]))
+    ) {
       // Parse number (integer or float)
+      // Only treat - as number start if followed by a digit (not standalone - symbol)
       let numStr = ""
       if (char === "-") {
         numStr += "-"

--- a/tests/parse-sexpr-lone-minus.test.ts
+++ b/tests/parse-sexpr-lone-minus.test.ts
@@ -2,13 +2,17 @@ import { expect, test } from "bun:test"
 import { tokenizeDsn, parseSexprToAst } from "lib/common/parse-sexpr"
 
 test("standalone minus sign is tokenized as Symbol, not Number", () => {
-  const tokens = tokenizeDsn('(test -)')
-  expect(tokens.find((t) => t.type === "Symbol" && t.value === "-")).toBeDefined()
-  expect(tokens.find((t) => t.type === "Number" && t.value === "-")).toBeUndefined()
+  const tokens = tokenizeDsn("(test -)")
+  expect(
+    tokens.find((t) => t.type === "Symbol" && t.value === "-"),
+  ).toBeDefined()
+  expect(
+    tokens.find((t) => t.type === "Number" && t.value === "-"),
+  ).toBeUndefined()
 })
 
 test("negative numbers still parse correctly", () => {
-  const tokens = tokenizeDsn('(test -1.5)')
+  const tokens = tokenizeDsn("(test -1.5)")
   const numToken = tokens.find((t) => t.type === "Number")
   expect(numToken).toBeDefined()
   expect(numToken!.value).toBe(-1.5)

--- a/tests/parse-sexpr-lone-minus.test.ts
+++ b/tests/parse-sexpr-lone-minus.test.ts
@@ -1,0 +1,15 @@
+import { expect, test } from "bun:test"
+import { tokenizeDsn, parseSexprToAst } from "lib/common/parse-sexpr"
+
+test("standalone minus sign is tokenized as Symbol, not Number", () => {
+  const tokens = tokenizeDsn('(test -)')
+  expect(tokens.find((t) => t.type === "Symbol" && t.value === "-")).toBeDefined()
+  expect(tokens.find((t) => t.type === "Number" && t.value === "-")).toBeUndefined()
+})
+
+test("negative numbers still parse correctly", () => {
+  const tokens = tokenizeDsn('(test -1.5)')
+  const numToken = tokens.find((t) => t.type === "Number")
+  expect(numToken).toBeDefined()
+  expect(numToken!.value).toBe(-1.5)
+})


### PR DESCRIPTION
## Summary

A standalone `-` (not followed by a digit) was incorrectly tokenized as a `Number` with value `NaN`. This broke DSN files that use `-` as a pin/component name (e.g. smoothie-board fixtures).

**Fix:** `-` is only treated as a number prefix when the next character is a digit. Otherwise it falls through to the symbol branch.

## Changes
- `lib/common/parse-sexpr.ts` — 1 conditional change (5 lines)
- `tests/parse-sexpr-lone-minus.test.ts` — 2 tests: standalone `-` → Symbol, negative numbers still work

Minimal patch as discussed in #130. All 51 existing tests pass.