### PR TITLE
Preserve DSN padstack hole descriptors

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
@@ -26,6 +26,17 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
     return `${padding}(path ${path.layer} ${path.width}  ${stringifyCoordinates(path.coordinates)})`
   }
 
+  const stringifyPadstackHole = (hole: any): string | null => {
+    if (!hole) return null
+    if (hole.shape === "circle") {
+      return `(hole (circle ${hole.diameter}))`
+    }
+    if (hole.shape === "oval" || hole.shape === "square") {
+      return `(hole (${hole.shape} ${hole.width} ${hole.height}))`
+    }
+    return null
+  }
+
   // Start with pcb
   result += `(pcb ${dsnJson.filename ? dsnJson.filename : "./converted_dsn.dsn"}\n`
 
@@ -101,6 +112,10 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
         result += `${indent}${indent}${indent}(shape (path ${shape.layer} ${shape.width} ${stringifyCoordinates(shape.coordinates)}))\n`
       }
     })
+    const hole = stringifyPadstackHole(padstack.hole)
+    if (hole) {
+      result += `${indent}${indent}${indent}${hole}\n`
+    }
     result += `${indent}${indent}${indent}(attach ${padstack.attach})\n`
     result += `${indent}${indent})\n`
   })

--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-session.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-session.ts
@@ -4,6 +4,17 @@ export const stringifyDsnSession = (session: DsnSession): string => {
   const indent = "  "
   let result = ""
 
+  const stringifyPadstackHole = (hole: any): string | null => {
+    if (!hole) return null
+    if (hole.shape === "circle") {
+      return `(hole (circle ${hole.diameter}))`
+    }
+    if (hole.shape === "oval" || hole.shape === "square") {
+      return `(hole (${hole.shape} ${hole.width} ${hole.height}))`
+    }
+    return null
+  }
+
   // Start with session
   result += `(session ${session.filename}\n`
 
@@ -47,6 +58,10 @@ export const stringifyDsnSession = (session: DsnSession): string => {
           result += `${indent}${indent}${indent}${indent})\n`
         }
       })
+      const hole = stringifyPadstackHole(padstack.hole)
+      if (hole) {
+        result += `${indent}${indent}${indent}${indent}${hole}\n`
+      }
       result += `${indent}${indent}${indent}${indent}(attach ${padstack.attach})\n`
       result += `${indent}${indent}${indent})\n`
     })

--- a/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
@@ -655,6 +655,8 @@ function processPadstack(nodes: ASTNode[]): Padstack {
         const key = keyNode.value
         if (key === "shape") {
           padstack.shapes!.push(processShape(node.children!))
+        } else if (key === "hole") {
+          padstack.hole = processPadstackHole(node.children!)
         } else if (key === "attach") {
           if (rest[0].type === "Atom" && typeof rest[0].value === "string") {
             padstack.attach = rest[0].value
@@ -665,6 +667,46 @@ function processPadstack(nodes: ASTNode[]): Padstack {
   })
 
   return padstack as Padstack
+}
+
+function processPadstackHole(nodes: ASTNode[]): Padstack["hole"] {
+  const holeNode = nodes[1]
+  if (holeNode?.type !== "List") {
+    throw new Error("Invalid padstack hole format")
+  }
+
+  const [shapeNode, ...rest] = holeNode.children!
+  if (shapeNode.type !== "Atom" || typeof shapeNode.value !== "string") {
+    throw new Error("Invalid padstack hole shape")
+  }
+
+  switch (shapeNode.value) {
+    case "circle":
+      if (rest[0]?.type === "Atom" && typeof rest[0].value === "number") {
+        return {
+          shape: "circle",
+          diameter: rest[0].value,
+        }
+      }
+      break
+    case "oval":
+    case "square":
+      if (
+        rest[0]?.type === "Atom" &&
+        typeof rest[0].value === "number" &&
+        rest[1]?.type === "Atom" &&
+        typeof rest[1].value === "number"
+      ) {
+        return {
+          shape: shapeNode.value,
+          width: rest[0].value,
+          height: rest[1].value,
+        }
+      }
+      break
+  }
+
+  throw new Error("Invalid padstack hole dimensions")
 }
 
 function processShape(nodes: ASTNode[]): Shape {

--- a/tests/dsn-pcb/stringify-dsn-json.test.ts
+++ b/tests/dsn-pcb/stringify-dsn-json.test.ts
@@ -17,3 +17,53 @@ test("stringify dsn json", () => {
   // Test that we can parse the generated string back to the same structure
   // expect(reparsedJson).toEqual(dsnJson)
 })
+
+test("preserves padstack hole descriptors when stringifying dsn json", () => {
+  const dsnJson = parseDsnToDsnJson(`(pcb hole-test
+  (parser
+    (string_quote ")
+    (space_in_quoted_tokens on)
+    (host_cad "KiCad's Pcbnew")
+    (host_version "9.0")
+  )
+  (resolution um 10)
+  (unit um)
+  (structure
+    (layer F.Cu (type signal) (property (index 0)))
+    (layer B.Cu (type signal) (property (index 1)))
+    (boundary (path pcb 0 0 0 1000 0 1000 1000 0 1000 0 0))
+    (via "Via[0-1]_600:300_um")
+    (rule (width 100) (clearance 100))
+  )
+  (placement)
+  (library
+    (padstack "RoundHole"
+      (shape (circle F.Cu 600))
+      (hole (circle 300))
+      (attach off)
+    )
+    (padstack "OvalHole"
+      (shape (circle F.Cu 900))
+      (hole (oval 300 500))
+      (attach off)
+    )
+    (padstack "SquareHole"
+      (shape (circle F.Cu 700))
+      (hole (square 250 250))
+      (attach off)
+    )
+  )
+  (network)
+  (wiring)
+)`) as DsnPcb
+
+  const reparsedJson = parseDsnToDsnJson(stringifyDsnJson(dsnJson)) as DsnPcb
+
+  expect(
+    reparsedJson.library.padstacks.map((padstack) => padstack.hole),
+  ).toEqual([
+    { shape: "circle", diameter: 300 },
+    { shape: "oval", width: 300, height: 500 },
+    { shape: "square", width: 250, height: 250 },
+  ])
+})


### PR DESCRIPTION
﻿## Summary
- Preserve padstack `(hole ...)` descriptors when parsing DSN padstacks.
- Emit circular, oval, and square padstack hole descriptors from PCB and session DSN stringifiers.
- Add focused parse -> stringify -> parse coverage so plated-hole padstack metadata is not silently dropped.

## Scope
This is metadata preservation only. It does not change Circuit JSON conversion, geometry placement, routing, or Smoothie Board pad/pin transforms.

## Verification
- `bun test tests/dsn-pcb/stringify-dsn-json.test.ts -t "preserves padstack hole descriptors"`
- `bunx tsc --noEmit`
- `bun run build`
- `git diff --check`

Note: the full `stringify-dsn-json.test.ts` file still hits the existing `string_quote` round-trip assertion on current main; this PR's new regression passes in isolation.

/claim #54
