### PR TITLE
Preserve DSN session padstack shape geometry

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-session.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-session.ts
@@ -45,6 +45,18 @@ export const stringifyDsnSession = (session: DsnSession): string => {
           result += `${indent}${indent}${indent}${indent}(shape\n`
           result += `${indent}${indent}${indent}${indent}${indent}(circle ${shape.layer} ${shape.diameter} 0 0)\n`
           result += `${indent}${indent}${indent}${indent})\n`
+        } else if (shape.shapeType === "polygon") {
+          result += `${indent}${indent}${indent}${indent}(shape\n`
+          result += `${indent}${indent}${indent}${indent}${indent}(polygon ${shape.layer} ${shape.width} ${shape.coordinates.join(" ")})\n`
+          result += `${indent}${indent}${indent}${indent})\n`
+        } else if (shape.shapeType === "rect") {
+          result += `${indent}${indent}${indent}${indent}(shape\n`
+          result += `${indent}${indent}${indent}${indent}${indent}(rect ${shape.layer} ${shape.coordinates.join(" ")})\n`
+          result += `${indent}${indent}${indent}${indent})\n`
+        } else if (shape.shapeType === "path") {
+          result += `${indent}${indent}${indent}${indent}(shape\n`
+          result += `${indent}${indent}${indent}${indent}${indent}(path ${shape.layer} ${shape.width} ${shape.coordinates.join(" ")})\n`
+          result += `${indent}${indent}${indent}${indent})\n`
         }
       })
       result += `${indent}${indent}${indent}${indent}(attach ${padstack.attach})\n`

--- a/tests/dsn-pcb/stringify-dsn-session.test.ts
+++ b/tests/dsn-pcb/stringify-dsn-session.test.ts
@@ -25,3 +25,37 @@ test("stringify session file", () => {
   expect(reparsedNet.name).toBe(originalNet.name)
   expect(reparsedNet.wires).toHaveLength(originalNet.wires.length)
 })
+
+test("preserves non-circle session library_out padstack shapes", () => {
+  const sessionJson = parseDsnToDsnJson(`(session shape-test
+  (base_design shape-test)
+  (placement
+    (resolution um 10)
+  )
+  (was_is)
+  (routes
+    (resolution um 10)
+    (parser
+      (host_cad "KiCad's Pcbnew")
+      (host_version "9.0")
+    )
+    (library_out
+      (padstack "MixedPad"
+        (shape (polygon F.Cu 0 0 0 100 0 100 100 0 100))
+        (shape (rect B.Cu -50 -25 50 25))
+        (shape (path Inner1.Cu 20 0 0 100 0))
+        (attach off)
+      )
+    )
+    (network_out)
+  )
+)`) as DsnSession
+
+  const reparsed = parseDsnToDsnJson(
+    stringifyDsnSession(sessionJson),
+  ) as DsnSession
+
+  expect(reparsed.routes.library_out?.padstacks[0].shapes).toEqual(
+    sessionJson.routes.library_out?.padstacks[0].shapes,
+  )
+})


### PR DESCRIPTION
﻿## Summary
- Preserve polygon, rect, and path padstack shapes when stringifying session `library_out` data.
- Keep existing circle output unchanged.
- Add focused parse -> stringify -> parse coverage for non-circle session padstack geometry.

## Scope
Session serialization only. This does not alter PCB DSN stringification, Circuit JSON conversion, placement, routing, or Smoothie Board transform behavior.

## Verification
- `bun test tests/dsn-pcb/stringify-dsn-session.test.ts -t "preserves non-circle"`
- `bunx tsc --noEmit`
- `bun run build`
- `git diff --check`

/claim #54
