### PR TITLE
Preserve DSN session library image descriptors

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-session.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-session.ts
@@ -38,6 +38,18 @@ export const stringifyDsnSession = (session: DsnSession): string => {
   // Library_out subsection
   if (session.routes.library_out) {
     result += `${indent}${indent}(library_out \n`
+    session.routes.library_out.images.forEach((image) => {
+      result += `${indent}${indent}${indent}(image ${JSON.stringify(image.name)}\n`
+      image.outlines.forEach((outline) => {
+        result += `${indent}${indent}${indent}${indent}(outline\n`
+        result += `${indent}${indent}${indent}${indent}${indent}(path ${outline.path.layer} ${outline.path.width} ${outline.path.coordinates.join(" ")})\n`
+        result += `${indent}${indent}${indent}${indent})\n`
+      })
+      image.pins.forEach((pin) => {
+        result += `${indent}${indent}${indent}${indent}(pin ${pin.padstack_name} ${pin.pin_number} ${pin.x} ${pin.y})\n`
+      })
+      result += `${indent}${indent}${indent})\n`
+    })
     session.routes.library_out.padstacks.forEach((padstack) => {
       result += `${indent}${indent}${indent}(padstack ${JSON.stringify(padstack.name)}\n`
       padstack.shapes.forEach((shape) => {

--- a/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
@@ -1081,17 +1081,9 @@ function processSessionNode(ast: ASTNode): DsnSession {
         child.children[0].value === "library_out",
     )
     if (libraryNode) {
-      session.routes.library_out = {
-        images: [],
-        padstacks: libraryNode
-          .children!.filter(
-            (child) =>
-              child.type === "List" &&
-              child.children?.[0].type === "Atom" &&
-              child.children[0].value === "padstack",
-          )
-          .map((padstackNode) => processPadstack(padstackNode.children!)),
-      }
+      session.routes.library_out = processLibrary(
+        libraryNode.children!.slice(1),
+      )
     }
 
     // Extract network_out section

--- a/tests/dsn-pcb/stringify-dsn-session.test.ts
+++ b/tests/dsn-pcb/stringify-dsn-session.test.ts
@@ -25,3 +25,40 @@ test("stringify session file", () => {
   expect(reparsedNet.name).toBe(originalNet.name)
   expect(reparsedNet.wires).toHaveLength(originalNet.wires.length)
 })
+
+test("preserves session library_out image descriptors", () => {
+  const sessionJson = parseDsnToDsnJson(`(session image-test
+  (base_design image-test)
+  (placement
+    (resolution um 10)
+  )
+  (was_is)
+  (routes
+    (resolution um 10)
+    (parser
+      (host_cad "KiCad's Pcbnew")
+      (host_version "9.0")
+    )
+    (library_out
+      (image "Connector"
+        (outline (path F.Cu 0 0 0 100 0 100 100))
+        (pin ViaPad 1 10 20)
+        (pin ViaPad 2 30 40)
+      )
+      (padstack "ViaPad"
+        (shape (circle F.Cu 600))
+        (attach off)
+      )
+    )
+    (network_out)
+  )
+)`) as DsnSession
+
+  const reparsed = parseDsnToDsnJson(
+    stringifyDsnSession(sessionJson),
+  ) as DsnSession
+
+  expect(reparsed.routes.library_out?.images).toEqual(
+    sessionJson.routes.library_out?.images,
+  )
+})


### PR DESCRIPTION
﻿## Summary
- Preserve session `library_out` image descriptors instead of dropping them during parse.
- Emit session library images, outlines, and pins from `stringifyDsnSession`.
- Add focused parse -> stringify -> parse coverage for session image metadata.

## Scope
Session `library_out` metadata only. This does not change PCB DSN stringification, routing geometry, placement, or Circuit JSON conversion behavior.

## Verification
- `bun test tests/dsn-pcb/stringify-dsn-session.test.ts -t "preserves session library_out image"`
- `bunx tsc --noEmit`
- `bun run build`
- `git diff --check`

/claim #54
