### PR TITLE
Preserve DSN session placement PN descriptors

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-session.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-session.ts
@@ -16,7 +16,8 @@ export const stringifyDsnSession = (session: DsnSession): string => {
   session.placement.components.forEach((component) => {
     result += `${indent}${indent}(component ${component.name}\n`
     component.places.forEach((place) => {
-      result += `${indent}${indent}${indent}(place ${place.refdes} ${place.x} ${place.y} ${place.side} ${place.rotation})\n`
+      const pn = place.PN ? ` (PN ${JSON.stringify(place.PN)})` : ""
+      result += `${indent}${indent}${indent}(place ${place.refdes} ${place.x} ${place.y} ${place.side} ${place.rotation}${pn})\n`
     })
     result += `${indent}${indent})\n`
   })

--- a/tests/dsn-pcb/stringify-dsn-session.test.ts
+++ b/tests/dsn-pcb/stringify-dsn-session.test.ts
@@ -25,3 +25,25 @@ test("stringify session file", () => {
   expect(reparsedNet.name).toBe(originalNet.name)
   expect(reparsedNet.wires).toHaveLength(originalNet.wires.length)
 })
+
+test("stringify session preserves placement PN descriptors", () => {
+  const session = parseDsnToDsnJson(`
+    (session test.ses
+      (placement
+        (resolution um 10)
+        (component R_0603
+          (place R1 100 200 front 90 (PN "RES 10K"))
+        )
+      )
+      (routes
+        (resolution um 10)
+        (network_out)
+      )
+    )
+  `) as DsnSession
+
+  const stringified = stringifyDsnSession(session)
+  const reparsed = parseDsnToDsnJson(stringified) as DsnSession
+
+  expect(reparsed.placement.components[0].places[0].PN).toBe("RES 10K")
+})


### PR DESCRIPTION
﻿## Summary
- preserve optional `(PN ...)` placement descriptors when stringifying DSN session files
- add a regression test that parses, stringifies, and reparses a placement with a quoted PN value

## Verification
- `bun test tests\dsn-pcb\stringify-dsn-session.test.ts -t "placement PN"`
- `bunx tsc --noEmit`
- `bun run build`
- `git diff --check`

/claim #54
