### PR TITLE
Preserve DSN session route parser metadata

### DIFF
--- a/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
@@ -1073,6 +1073,16 @@ function processSessionNode(ast: ASTNode): DsnSession {
       child.children[0].value === "routes",
   )
   if (routesNode) {
+    const parserNode = routesNode.children!.find(
+      (child) =>
+        child.type === "List" &&
+        child.children?.[0].type === "Atom" &&
+        child.children[0].value === "parser",
+    )
+    if (parserNode) {
+      session.routes.parser = processParser(parserNode.children!.slice(1))
+    }
+
     // Extract library_out section
     const libraryNode = routesNode.children!.find(
       (child) =>

--- a/tests/dsn-pcb/stringify-dsn-session.test.ts
+++ b/tests/dsn-pcb/stringify-dsn-session.test.ts
@@ -25,3 +25,27 @@ test("stringify session file", () => {
   expect(reparsedNet.name).toBe(originalNet.name)
   expect(reparsedNet.wires).toHaveLength(originalNet.wires.length)
 })
+
+test("stringify session preserves routes parser metadata", () => {
+  const session = parseDsnToDsnJson(`
+    (session test.ses
+      (placement
+        (resolution um 10)
+      )
+      (routes
+        (resolution um 10)
+        (parser
+          (host_cad "KiCad")
+          (host_version "9.0.2")
+        )
+        (network_out)
+      )
+    )
+  `) as DsnSession
+
+  const stringified = stringifyDsnSession(session)
+  const reparsed = parseDsnToDsnJson(stringified) as DsnSession
+
+  expect(reparsed.routes.parser.host_cad).toBe("KiCad")
+  expect(reparsed.routes.parser.host_version).toBe("9.0.2")
+})


### PR DESCRIPTION
﻿## Summary
- parse the DSN session `routes` `(parser ...)` block instead of leaving parser metadata blank
- add a round-trip regression test for `host_cad` and `host_version`

## Verification
- `bun test tests\dsn-pcb\stringify-dsn-session.test.ts -t "routes parser"`
- `bunx tsc --noEmit`
- `bun run build`
- `git diff --check`

/claim #54
