### PR TITLE
Preserve DSN session network wire metadata

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-session.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-session.ts
@@ -58,11 +58,19 @@ export const stringifyDsnSession = (session: DsnSession): string => {
   session.routes.network_out.nets.forEach((net) => {
     result += `${indent}${indent}${indent}(net ${JSON.stringify(net.name)}\n`
     net.wires.forEach((wire) => {
-      if (wire.path) {
+      const path = wire.path ?? wire.polyline_path
+      if (path) {
+        const pathType = wire.path ? "path" : "polyline_path"
         result += `${indent}${indent}${indent}${indent}(wire\n`
-        result += `${indent}${indent}${indent}${indent}${indent}(path ${wire.path.layer} ${wire.path.width}\n`
-        result += `${indent}${indent}${indent}${indent}${indent}${indent}${wire.path.coordinates.join(" ")}\n`
+        result += `${indent}${indent}${indent}${indent}${indent}(${pathType} ${path.layer} ${path.width}\n`
+        result += `${indent}${indent}${indent}${indent}${indent}${indent}${path.coordinates.join(" ")}\n`
         result += `${indent}${indent}${indent}${indent}${indent})\n`
+        if (wire.clearance_class) {
+          result += `${indent}${indent}${indent}${indent}${indent}(clearance_class ${wire.clearance_class})\n`
+        }
+        if (wire.type) {
+          result += `${indent}${indent}${indent}${indent}${indent}(type ${wire.type})\n`
+        }
         result += `${indent}${indent}${indent}${indent})\n`
       }
     })

--- a/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
@@ -1128,9 +1128,8 @@ function processSessionNode(ast: ASTNode): DsnSession {
         const net = {
           name: netName,
           wires: wireNodes.map((wireNode) => ({
-            path: processPath(wireNode.children!.slice(1)),
+            ...processWire(wireNode.children!.slice(1)),
             net: netName,
-            type: "route",
           })),
           vias: viaNodes.map((viaNode) => ({
             x: viaNode.children![2].value as number,

--- a/tests/dsn-pcb/stringify-dsn-session.test.ts
+++ b/tests/dsn-pcb/stringify-dsn-session.test.ts
@@ -25,3 +25,32 @@ test("stringify session file", () => {
   expect(reparsedNet.name).toBe(originalNet.name)
   expect(reparsedNet.wires).toHaveLength(originalNet.wires.length)
 })
+
+test("stringify session preserves network wire metadata", () => {
+  const session = parseDsnToDsnJson(`
+    (session test.ses
+      (placement
+        (resolution um 10)
+      )
+      (routes
+        (resolution um 10)
+        (network_out
+          (net "N1"
+            (wire
+              (path F.Cu 120 0 0 100 0)
+              (clearance_class tight)
+              (type protect)
+            )
+          )
+        )
+      )
+    )
+  `) as DsnSession
+
+  const stringified = stringifyDsnSession(session)
+  const reparsed = parseDsnToDsnJson(stringified) as DsnSession
+  const wire = reparsed.routes.network_out.nets[0].wires[0]
+
+  expect(wire.clearance_class).toBe("tight")
+  expect(wire.type).toBe("protect")
+})


### PR DESCRIPTION
﻿## Summary
- parse DSN session `network_out` wires through the existing `processWire` helper
- stringify `path`/`polyline_path`, `clearance_class`, and `type` for session wires
- add a round-trip regression test for wire metadata

## Verification
- `bun test tests\dsn-pcb\stringify-dsn-session.test.ts -t "network wire metadata"`
- `bunx tsc --noEmit`
- `bun run build`
- `git diff --check`

/claim #54
