### PR TITLE
Preserve DSN session network vias

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-session.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-session.ts
@@ -66,6 +66,10 @@ export const stringifyDsnSession = (session: DsnSession): string => {
         result += `${indent}${indent}${indent}${indent})\n`
       }
     })
+    net.vias?.forEach((via) => {
+      const padstackName = via.padstack_name ?? "via"
+      result += `${indent}${indent}${indent}${indent}(via ${JSON.stringify(padstackName)} ${via.x} ${via.y})\n`
+    })
     result += `${indent}${indent}${indent})\n`
   })
   result += `${indent}${indent})\n`

--- a/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
@@ -1133,6 +1133,7 @@ function processSessionNode(ast: ASTNode): DsnSession {
             type: "route",
           })),
           vias: viaNodes.map((viaNode) => ({
+            padstack_name: viaNode.children![1].value as string,
             x: viaNode.children![2].value as number,
             y: viaNode.children![3].value as number,
           })),

--- a/lib/dsn-pcb/types.ts
+++ b/lib/dsn-pcb/types.ts
@@ -285,6 +285,7 @@ export interface Wire {
 }
 
 export interface Via {
+  padstack_name?: string
   x: number
   y: number
 }

--- a/tests/dsn-pcb/stringify-dsn-session.test.ts
+++ b/tests/dsn-pcb/stringify-dsn-session.test.ts
@@ -25,3 +25,29 @@ test("stringify session file", () => {
   expect(reparsedNet.name).toBe(originalNet.name)
   expect(reparsedNet.wires).toHaveLength(originalNet.wires.length)
 })
+
+test("stringify session preserves network vias", () => {
+  const session = parseDsnToDsnJson(`
+    (session test.ses
+      (placement
+        (resolution um 10)
+      )
+      (routes
+        (resolution um 10)
+        (network_out
+          (net "N1"
+            (via "Via[0-1]_800:400_um" 25 50)
+          )
+        )
+      )
+    )
+  `) as DsnSession
+
+  const stringified = stringifyDsnSession(session)
+  const reparsed = parseDsnToDsnJson(stringified) as DsnSession
+  const via = reparsed.routes.network_out.nets[0].vias?.[0]
+
+  expect(via?.padstack_name).toBe("Via[0-1]_800:400_um")
+  expect(via?.x).toBe(25)
+  expect(via?.y).toBe(50)
+})


### PR DESCRIPTION
﻿## Summary
- preserve DSN session `network_out` via padstack names with via coordinates
- stringify session `via` entries under their nets
- add a round-trip regression test for session vias

## Verification
- `bun test tests\dsn-pcb\stringify-dsn-session.test.ts -t "network vias"`
- `bunx tsc --noEmit`
- `bun run build`
- `git diff --check`

/claim #54
