### PR TITLE
Emit DSN session parser options

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-session.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-session.ts
@@ -31,6 +31,12 @@ export const stringifyDsnSession = (session: DsnSession): string => {
 
   // Parser subsection
   result += `${indent}${indent}(parser\n`
+  if (session.routes.parser.string_quote) {
+    result += `${indent}${indent}${indent}(string_quote ${JSON.stringify(session.routes.parser.string_quote)})\n`
+  }
+  if (session.routes.parser.space_in_quoted_tokens) {
+    result += `${indent}${indent}${indent}(space_in_quoted_tokens ${JSON.stringify(session.routes.parser.space_in_quoted_tokens)})\n`
+  }
   result += `${indent}${indent}${indent}(host_cad ${JSON.stringify(session.routes.parser.host_cad)})\n`
   result += `${indent}${indent}${indent}(host_version ${JSON.stringify(session.routes.parser.host_version)})\n`
   result += `${indent}${indent})\n`

--- a/tests/dsn-pcb/stringify-dsn-session.test.ts
+++ b/tests/dsn-pcb/stringify-dsn-session.test.ts
@@ -50,6 +50,6 @@ test("stringify session preserves parser options", () => {
 
   const stringified = stringifyDsnSession(session)
 
-  expect(stringified).toContain("(string_quote \"'\")")
+  expect(stringified).toContain('(string_quote "\'")')
   expect(stringified).toContain('(space_in_quoted_tokens "on")')
 })

--- a/tests/dsn-pcb/stringify-dsn-session.test.ts
+++ b/tests/dsn-pcb/stringify-dsn-session.test.ts
@@ -25,3 +25,31 @@ test("stringify session file", () => {
   expect(reparsedNet.name).toBe(originalNet.name)
   expect(reparsedNet.wires).toHaveLength(originalNet.wires.length)
 })
+
+test("stringify session preserves parser options", () => {
+  const session = {
+    is_dsn_session: true,
+    filename: "test.ses",
+    placement: {
+      resolution: { unit: "um", value: 10 },
+      components: [],
+    },
+    routes: {
+      resolution: { unit: "um", value: 10 },
+      parser: {
+        string_quote: "'",
+        space_in_quoted_tokens: "on",
+        host_cad: "KiCad",
+        host_version: "9.0.2",
+      },
+      network_out: {
+        nets: [],
+      },
+    },
+  } as DsnSession
+
+  const stringified = stringifyDsnSession(session)
+
+  expect(stringified).toContain("(string_quote \"'\")")
+  expect(stringified).toContain('(space_in_quoted_tokens "on")')
+})


### PR DESCRIPTION
﻿## Summary
- emit `string_quote` and `space_in_quoted_tokens` from the DSN session parser block when present
- keep existing `host_cad` and `host_version` output unchanged
- add a regression test for the generated parser option output

## Verification
- `bun test tests\dsn-pcb\stringify-dsn-session.test.ts -t "parser options"`
- `bunx tsc --noEmit`
- `bun run build`
- `git diff --check`

/claim #54
