### PR TITLE
fix: resolve non-numeric DSN pin names to finite pin_numbers (#54)

### DIFF
--- a/lib/dsn-pcb/dsn-json-to-circuit-json/dsn-component-converters/convert-dsn-pcb-components-to-source-components-and-ports.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/dsn-component-converters/convert-dsn-pcb-components-to-source-components-and-ports.ts
@@ -1,6 +1,7 @@
 import type { AnySourceComponent, PcbPort, SourcePort } from "circuit-json"
-import type { DsnPcb, Image, Pin } from "lib/dsn-pcb/types"
+import type { DsnPcb } from "lib/dsn-pcb/types"
 import { type Matrix, applyToPoint } from "transformation-matrix"
+import { createDsnPinNumberResolver } from "./get-dsn-pin-number"
 
 export const convertDsnPcbComponentsToSourceComponentsAndPorts = ({
   dsnPcb,
@@ -32,13 +33,15 @@ export const convertDsnPcbComponentsToSourceComponentsAndPorts = ({
 
       // Create ports for each pin in the image
       if (image.pins) {
+        const getPinNumber = createDsnPinNumberResolver(image.pins)
         for (const pin of image.pins) {
+          const pinNumber = getPinNumber(pin)
           const port: SourcePort = {
             type: "source_port",
             source_port_id: `source_port_${component.name}-Pad${pin.pin_number}_${place.refdes}`,
             source_component_id: sourceComponent.source_component_id,
             name: `${place.refdes}-${pin.pin_number}`,
-            pin_number: Number(pin.pin_number),
+            pin_number: pinNumber,
             port_hints: [],
           }
           // Handle case where place coordinates might be null/undefined

--- a/lib/dsn-pcb/dsn-json-to-circuit-json/dsn-component-converters/convert-padstacks-to-smtpads.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/dsn-component-converters/convert-padstacks-to-smtpads.ts
@@ -2,6 +2,7 @@ import type { AnyCircuitElement, PcbSmtPad } from "circuit-json"
 import Debug from "debug"
 import type { DsnPcb } from "lib/dsn-pcb/types"
 import { applyToPoint } from "transformation-matrix"
+import { createDsnPinNumberResolver } from "./get-dsn-pin-number"
 
 const debug = Debug("dsn-converter:convertPadstacksToSmtpads")
 
@@ -89,8 +90,10 @@ export function convertPadstacksToSmtPads(
     placementComponent.places.forEach((place) => {
       debug("processing place...", { place })
       const { x: compX, y: compY, side } = place
+      const getPinNumber = createDsnPinNumberResolver(image.pins)
 
       image.pins.forEach((pin) => {
+        const pinNumber = getPinNumber(pin)
         // Find the corresponding padstack
         const padstack = padstacks.find((p) => p.name === pin.padstack_name)
         debug("found padstack", { padstack })
@@ -194,7 +197,7 @@ export function convertPadstacksToSmtPads(
           })
           pcbPad = {
             type: "pcb_smtpad",
-            pcb_smtpad_id: `pcb_smtpad_${componentId}_${place.refdes}_${Number(pin.pin_number) - 1}`,
+            pcb_smtpad_id: `pcb_smtpad_${componentId}_${place.refdes}_${pinNumber - 1}`,
             pcb_component_id: `${componentId}_${place.refdes}`,
             pcb_port_id: `pcb_port_${componentId}-Pad${pin.pin_number}_${place.refdes}`,
             shape: "polygon",
@@ -213,7 +216,7 @@ export function convertPadstacksToSmtPads(
           })
           pcbPad = {
             type: "pcb_smtpad",
-            pcb_smtpad_id: `pcb_smtpad_${componentId}_${place.refdes}_${Number(pin.pin_number) - 1}`,
+            pcb_smtpad_id: `pcb_smtpad_${componentId}_${place.refdes}_${pinNumber - 1}`,
             pcb_component_id: `${componentId}_${place.refdes}`,
             pcb_port_id: `pcb_port_${componentId}-Pad${pin.pin_number}_${place.refdes}`,
             shape: "rect",
@@ -227,7 +230,7 @@ export function convertPadstacksToSmtPads(
         } else {
           pcbPad = {
             type: "pcb_smtpad",
-            pcb_smtpad_id: `pcb_smtpad_${componentId}_${place.refdes}_${Number(pin.pin_number) - 1}`,
+            pcb_smtpad_id: `pcb_smtpad_${componentId}_${place.refdes}_${pinNumber - 1}`,
             pcb_component_id: `${componentId}_${place.refdes}`,
             pcb_port_id: `pcb_port_${componentId}-Pad${pin.pin_number}_${place.refdes}`,
             shape: "circle",

--- a/lib/dsn-pcb/dsn-json-to-circuit-json/dsn-component-converters/get-dsn-pin-number.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/dsn-component-converters/get-dsn-pin-number.ts
@@ -1,0 +1,31 @@
+import type { Pin } from "lib/dsn-pcb/types"
+
+function parseDsnPinNumber(pinNumber: Pin["pin_number"]): number | undefined {
+  const normalized =
+    typeof pinNumber === "string"
+      ? pinNumber.trim().replace(/^pin/i, "")
+      : pinNumber
+  const parsed = Number(normalized)
+  return Number.isFinite(parsed) ? parsed : undefined
+}
+
+export function createDsnPinNumberResolver(pins: Pin[]) {
+  const pinNumbers = new Map<Pin, number>()
+  let maxPinNumber = 0
+
+  for (const pin of pins) {
+    const pinNumber = parseDsnPinNumber(pin.pin_number)
+    if (pinNumber === undefined) continue
+    pinNumbers.set(pin, pinNumber)
+    maxPinNumber = Math.max(maxPinNumber, pinNumber)
+  }
+
+  let nextPinNumber = Math.floor(maxPinNumber) + 1
+  for (const pin of pins) {
+    if (pinNumbers.has(pin)) continue
+    pinNumbers.set(pin, nextPinNumber)
+    nextPinNumber++
+  }
+
+  return (pin: Pin) => pinNumbers.get(pin) ?? nextPinNumber++
+}

--- a/tests/repros/smoothie-no-nan.test.ts
+++ b/tests/repros/smoothie-no-nan.test.ts
@@ -1,0 +1,49 @@
+import { expect, test } from "bun:test"
+import { type DsnPcb, convertDsnPcbToCircuitJson, parseDsnToDsnJson } from "lib"
+
+// @ts-ignore
+import smoothieDsn from "../assets/repro/smoothieboard-repro.dsn" with {
+  type: "text",
+}
+
+/**
+ * Regression guard for the Smoothie Board conversion (#54).
+ *
+ * The DSN component pins on this board carry non-numeric pad names, and the
+ * converter coerced them with `Number(pin.pin_number)`, yielding `NaN` on every
+ * such source_port.pin_number (456 non-finite values). NaN pin numbers break
+ * downstream consumers and serialization.
+ *
+ * This test asserts the conversion output contains no non-finite numbers and
+ * drops no ports.
+ */
+function findNonFinite(value: unknown, path: string, out: string[]): void {
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) out.push(`${path} = ${value}`)
+    return
+  }
+  if (value && typeof value === "object") {
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      findNonFinite(v, `${path}.${k}`, out)
+    }
+  }
+}
+
+test("smoothie board conversion has no NaN/Infinity values", () => {
+  const dsnJson = parseDsnToDsnJson(smoothieDsn) as DsnPcb
+  const circuitJson = convertDsnPcbToCircuitJson(dsnJson)
+
+  const ports = (circuitJson as Array<{ type: string }>).filter(
+    (e) => e.type === "source_port",
+  )
+  // The conversion must not silently drop ports to "fix" the NaNs.
+  expect(ports.length).toBeGreaterThanOrEqual(1055)
+
+  const bad: string[] = []
+  ;(circuitJson as Array<{ type: string }>).forEach((e, i) =>
+    findNonFinite(e, `${e.type}[${i}]`, bad),
+  )
+
+  expect(bad.slice(0, 10)).toEqual([])
+  expect(bad.length).toBe(0)
+})


### PR DESCRIPTION
An incremental step toward converting the Smoothie Board (#54).

### Problem
The Smoothie Board DSN uses pad/pin names that aren't purely numeric. In the DSN to Circuit JSON path, `pin_number: Number(pin.pin_number)` coerces those to `NaN` — **456 `source_port.pin_number = NaN`** in the converted output for `smoothieboard-repro.dsn`, plus `NaN` leaking into derived `pcb_smtpad` ids. NaN pin numbers break downstream consumers and serialization.

### Fix
New helper `createDsnPinNumberResolver(pins)` (per component image):
- parses a numeric pin number from each pad name, stripping a leading `pin` prefix (matching the existing plated-hole convention in `process-plated-holes.ts`), and
- deterministically assigns any remaining non-numeric pins a unique number continuing **after** the max parsed number — so no ports are dropped and numbers never collide.

Applied at both conversion sites (`convert-dsn-pcb-components-to-source-components-and-ports.ts` and `convert-padstacks-to-smtpads.ts`) so source_port / pcb_port / pcb_smtpad ids stay consistent. Already-numeric pads are unchanged.

### Test
Adds `tests/repros/smoothie-no-nan.test.ts` — asserts the Smoothie Board conversion contains **no** non-finite numbers and drops no ports (≥1055 source_ports). It fails on `main` (456 NaNs) and passes with this change.

### Verification
- `bun test tests/repros/smoothie-no-nan.test.ts` → pass (was failing on main)
- `bunx tsc --noEmit` → clean
- `bun run build` → success
- `bunx biome format .` → clean
- No new test regressions introduced by this change.

This is scoped to the NaN pin-number issue per your note about landing #54 in incremental steps. Happy to follow up with the next conversion gaps.

/claim #54