### PR TITLE
Scale merged session padstacks

### DIFF
--- a/lib/dsn-pcb/dsn-json-to-circuit-json/merge-dsn-session-into-dsn-pcb.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/merge-dsn-session-into-dsn-pcb.ts
@@ -1,7 +1,76 @@
 import Debug from "debug"
-import type { DsnPcb, DsnSession } from "../types"
+import type { DsnPcb, DsnSession, Padstack, Shape } from "../types"
 
 const debug = Debug("dsn-converter:mergeDsnSessionIntoDsnPcb")
+const DEFAULT_SESSION_TO_PCB_SCALE = 10
+
+function getSessionToPcbScale(resolution?: { value: number }): number {
+  if (resolution?.value && Number.isFinite(resolution.value)) {
+    return resolution.value
+  }
+
+  return DEFAULT_SESSION_TO_PCB_SCALE
+}
+
+function scaleCoordinates(coordinates: number[], scale: number): number[] {
+  return coordinates.map((coordinate) => coordinate / scale)
+}
+
+function getNormalizedSessionShape(shape: Shape, scale: number): Shape {
+  switch (shape.shapeType) {
+    case "circle":
+      return {
+        ...shape,
+        diameter: shape.diameter / scale,
+      }
+    case "rect":
+      return {
+        ...shape,
+        coordinates: scaleCoordinates(shape.coordinates, scale),
+      }
+    case "path":
+      return {
+        ...shape,
+        width: shape.width / scale,
+        coordinates: scaleCoordinates(shape.coordinates, scale),
+      }
+    case "polygon":
+      return {
+        ...shape,
+        width: shape.width / scale,
+        coordinates: scaleCoordinates(shape.coordinates, scale),
+      }
+  }
+}
+
+function getNormalizedSessionPadstack(
+  padstack: Padstack,
+  scale: number,
+): Padstack {
+  return {
+    ...padstack,
+    shapes: padstack.shapes.map((shape) =>
+      getNormalizedSessionShape(shape, scale),
+    ),
+    hole: padstack.hole
+      ? {
+          ...padstack.hole,
+          width:
+            padstack.hole.width === undefined
+              ? undefined
+              : padstack.hole.width / scale,
+          height:
+            padstack.hole.height === undefined
+              ? undefined
+              : padstack.hole.height / scale,
+          diameter:
+            padstack.hole.diameter === undefined
+              ? undefined
+              : padstack.hole.diameter / scale,
+        }
+      : undefined,
+  }
+}
 
 export function mergeDsnSessionIntoDsnPcb(
   dsnPcb: DsnPcb,
@@ -43,13 +112,16 @@ export function mergeDsnSessionIntoDsnPcb(
 
   // Add any padstacks from session's library_out to PCB's library
   if (dsnSession.routes?.library_out?.padstacks) {
+    const sessionToPcbScale = getSessionToPcbScale(dsnSession.routes.resolution)
     const existingPadstackNames = new Set(
       mergedPcb.library.padstacks.map((p) => p.name),
     )
 
     dsnSession.routes.library_out.padstacks.forEach((padstack) => {
       if (!existingPadstackNames.has(padstack.name)) {
-        mergedPcb.library.padstacks.push(padstack)
+        mergedPcb.library.padstacks.push(
+          getNormalizedSessionPadstack(padstack, sessionToPcbScale),
+        )
       }
     })
   }

--- a/tests/dsn-pcb/merge-dsn-session-scale.test.ts
+++ b/tests/dsn-pcb/merge-dsn-session-scale.test.ts
@@ -1,0 +1,198 @@
+import { expect, test } from "bun:test"
+import { type DsnPcb, type DsnSession, mergeDsnSessionIntoDsnPcb } from "lib"
+
+const baseDsnPcb: DsnPcb = {
+  is_dsn_pcb: true,
+  filename: "merge-scale.dsn",
+  parser: {
+    string_quote: '"',
+    space_in_quoted_tokens: "on",
+    host_cad: "test",
+    host_version: "1",
+  },
+  resolution: {
+    unit: "um",
+    value: 10,
+  },
+  unit: "um",
+  structure: {
+    layers: [
+      { name: "F.Cu", type: "signal", property: { index: 0 } },
+      { name: "B.Cu", type: "signal", property: { index: 1 } },
+    ],
+    boundary: {
+      path: {
+        layer: "pcb",
+        width: 0,
+        coordinates: [0, 0, 2000, 0, 2000, 1000, 0, 1000, 0, 0],
+      },
+    },
+    via: "ExistingVia[0-1]_600:300_um",
+    rule: {
+      width: 200,
+      clearances: [{ value: 200 }],
+    },
+  },
+  placement: {
+    components: [],
+  },
+  library: {
+    images: [],
+    padstacks: [
+      {
+        name: "ExistingVia[0-1]_600:300_um",
+        attach: "off",
+        shapes: [
+          {
+            shapeType: "circle",
+            layer: "F.Cu",
+            diameter: 600,
+          },
+        ],
+        hole: {
+          shape: "circle",
+          diameter: 300,
+        },
+      },
+    ],
+  },
+  network: {
+    nets: [{ name: "NET1", pins: [] }],
+    classes: [
+      {
+        name: "kicad_default",
+        description: "",
+        net_names: ["NET1"],
+        circuit: { use_via: "ExistingVia[0-1]_600:300_um" },
+        rule: {
+          width: 200,
+          clearances: [{ value: 200 }],
+        },
+      },
+    ],
+  },
+  wiring: {
+    wires: [],
+  },
+}
+
+test("mergeDsnSessionIntoDsnPcb scales new session library_out padstacks", () => {
+  const session: DsnSession = {
+    is_dsn_session: true,
+    filename: "merge-scale.ses",
+    placement: {
+      resolution: baseDsnPcb.resolution,
+      components: [],
+    },
+    routes: {
+      resolution: baseDsnPcb.resolution,
+      parser: baseDsnPcb.parser,
+      library_out: {
+        images: [],
+        padstacks: [
+          {
+            name: "ExistingVia[0-1]_600:300_um",
+            attach: "off",
+            shapes: [
+              {
+                shapeType: "circle",
+                layer: "F.Cu",
+                diameter: 6000,
+              },
+            ],
+            hole: {
+              shape: "circle",
+              diameter: 3000,
+            },
+          },
+          {
+            name: "SessionVia[0-1]_600:300_um",
+            attach: "off",
+            shapes: [
+              {
+                shapeType: "circle",
+                layer: "F.Cu",
+                diameter: 6000,
+              },
+              {
+                shapeType: "rect",
+                layer: "B.Cu",
+                coordinates: [-3000, -2000, 3000, 2000],
+              },
+              {
+                shapeType: "path",
+                layer: "F.Cu",
+                width: 2000,
+                coordinates: [0, 0, 10000, 0],
+              },
+              {
+                shapeType: "polygon",
+                layer: "B.Cu",
+                width: 1000,
+                coordinates: [0, 0, 10000, 0, 10000, 5000],
+              },
+            ],
+            hole: {
+              shape: "oval",
+              width: 3000,
+              height: 5000,
+            },
+          },
+        ],
+      },
+      network_out: {
+        nets: [],
+      },
+    },
+  }
+
+  const mergedPcb = mergeDsnSessionIntoDsnPcb(baseDsnPcb, session)
+  const existingPadstack = mergedPcb.library.padstacks.find(
+    (padstack) => padstack.name === "ExistingVia[0-1]_600:300_um",
+  )
+  const mergedPadstack = mergedPcb.library.padstacks.find(
+    (padstack) => padstack.name === "SessionVia[0-1]_600:300_um",
+  )
+
+  expect(mergedPcb.library.padstacks).toHaveLength(2)
+  expect(existingPadstack?.shapes).toEqual([
+    {
+      shapeType: "circle",
+      layer: "F.Cu",
+      diameter: 600,
+    },
+  ])
+  expect(existingPadstack?.hole).toEqual({
+    shape: "circle",
+    diameter: 300,
+  })
+  expect(mergedPadstack?.shapes).toEqual([
+    {
+      shapeType: "circle",
+      layer: "F.Cu",
+      diameter: 600,
+    },
+    {
+      shapeType: "rect",
+      layer: "B.Cu",
+      coordinates: [-300, -200, 300, 200],
+    },
+    {
+      shapeType: "path",
+      layer: "F.Cu",
+      width: 200,
+      coordinates: [0, 0, 1000, 0],
+    },
+    {
+      shapeType: "polygon",
+      layer: "B.Cu",
+      width: 100,
+      coordinates: [0, 0, 1000, 0, 1000, 500],
+    },
+  ])
+  expect(mergedPadstack?.hole).toEqual({
+    shape: "oval",
+    width: 300,
+    height: 500,
+  })
+})


### PR DESCRIPTION
## Summary
- scale new `routes.library_out.padstacks` copied during `mergeDsnSessionIntoDsnPcb` from session-resolution units back into DSN PCB units
- normalize circle diameters, rect/path/polygon coordinates, path/polygon widths, and optional hole dimensions
- leave existing PCB padstacks unchanged when the session repeats a padstack name

## Scope
Fixes #81. This is intentionally separate from the open PRs that scale merged session wire widths (#303) and session placements (#273/#406); this PR only handles copied session `library_out` padstack geometry.

## Verification
- `bun test tests/dsn-pcb/merge-dsn-session-scale.test.ts`
- `bunx biome check lib/dsn-pcb/dsn-json-to-circuit-json/merge-dsn-session-into-dsn-pcb.ts tests/dsn-pcb/merge-dsn-session-scale.test.ts`
- `bunx tsc --noEmit`
- `bun run build`
- `git diff --check`

Full `bun test` still fails on existing Windows/pre-existing failures:
- `basic-via-pcb-layer-change` debug path ENOENT
- `merge-dsn-session-with-conversion` debug path ENOENT
- `stringify dsn json` parser metadata round-trip mismatch