### PR TITLE
Fix subcircuit source trace partitioning

### DIFF
--- a/lib/dsn-pcb/dsn-json-to-circuit-json/dsn-component-converters/convert-nets-to-source-nets-and-traces.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/dsn-component-converters/convert-nets-to-source-nets-and-traces.ts
@@ -1,12 +1,90 @@
 import type { SourceNet, SourcePort, SourceTrace } from "circuit-json"
 import type { DsnPcb } from "lib/dsn-pcb/types"
 
+const getSourcePortIdFromWirePortToken = (
+  token: string,
+  source_ports: SourcePort[],
+) =>
+  source_ports.find((sp) => sp.source_port_id.includes(token))?.source_port_id
+
+const getRoutedPortSets = (dsnPcb: DsnPcb, source_ports: SourcePort[]) => {
+  return dsnPcb.wiring.wires
+    .map((wire) => {
+      if (!wire.net?.includes("--")) return []
+
+      return wire.net
+        .split("--")
+        .slice(1)
+        .map((token) => getSourcePortIdFromWirePortToken(token, source_ports))
+        .filter((source_port_id): source_port_id is string =>
+          Boolean(source_port_id),
+        )
+    })
+    .filter((source_port_ids) => source_port_ids.length >= 2)
+}
+
+const getNetAnchorSourcePortId = (
+  netName: string,
+  source_ports: SourcePort[],
+) => {
+  const match = /^Net-\((.+)-Pad(.+)\)$/.exec(netName)
+  if (!match) return undefined
+
+  const [, componentName, pinNumber] = match
+  return source_ports.find(
+    (sp) =>
+      sp.name === `${componentName}-${pinNumber}` ||
+      sp.name === `${componentName}-pin${pinNumber}` ||
+      sp.source_port_id.includes(`Pad${pinNumber}_${componentName}`),
+  )?.source_port_id
+}
+
+const trimRoutedSiblingPortsFromNetTrace = ({
+  connected_source_port_ids,
+  netName,
+  routedPortSets,
+  source_ports,
+}: {
+  connected_source_port_ids: string[]
+  netName: string
+  routedPortSets: string[][]
+  source_ports: SourcePort[]
+}) => {
+  const anchorSourcePortId = getNetAnchorSourcePortId(netName, source_ports)
+  if (!anchorSourcePortId) return connected_source_port_ids
+
+  // The DSN net is the electrical union, but routed wire net names still carry
+  // source_trace boundaries. Drop routed-only siblings when reconstructing a
+  // net-derived source_trace; the caller skips it if only the anchor remains.
+  const routedSiblingPortIds = new Set<string>()
+  for (const routedPortSet of routedPortSets) {
+    if (!routedPortSet.includes(anchorSourcePortId)) continue
+
+    for (const sourcePortId of routedPortSet) {
+      if (sourcePortId !== anchorSourcePortId) {
+        routedSiblingPortIds.add(sourcePortId)
+      }
+    }
+  }
+
+  if (routedSiblingPortIds.size === 0) return connected_source_port_ids
+
+  const trimmed_source_port_ids = connected_source_port_ids.filter(
+    (sourcePortId) =>
+      sourcePortId === anchorSourcePortId ||
+      !routedSiblingPortIds.has(sourcePortId),
+  )
+
+  return trimmed_source_port_ids
+}
+
 export const convertNetsToSourceNetsAndTraces = ({
   dsnPcb,
   source_ports,
 }: { dsnPcb: DsnPcb; source_ports: SourcePort[] }) => {
   const result: Array<SourceNet | SourceTrace> = []
   const { nets } = dsnPcb.network
+  const routedPortSets = getRoutedPortSets(dsnPcb, source_ports)
 
   let source_trace_id = dsnPcb.wiring.wires.length
   for (const net of nets) {
@@ -30,14 +108,23 @@ export const convertNetsToSourceNetsAndTraces = ({
         }
       }
     }
+    const net_connected_source_port_ids = trimRoutedSiblingPortsFromNetTrace({
+      connected_source_port_ids,
+      netName: name,
+      routedPortSets,
+      source_ports,
+    })
 
     const source_trace: SourceTrace = {
       type: "source_trace",
       connected_source_net_ids: [source_net.source_net_id],
-      connected_source_port_ids,
+      connected_source_port_ids: net_connected_source_port_ids,
       source_trace_id: `source_trace_${source_trace_id}`,
     }
-    result.push(source_net, source_trace)
+    result.push(source_net)
+    if (net_connected_source_port_ids.length >= 2) {
+      result.push(source_trace)
+    }
     source_trace_id++
   }
 

--- a/tests/repros/repro8-multiple-traces-in-one-net.test.ts
+++ b/tests/repros/repro8-multiple-traces-in-one-net.test.ts
@@ -3,7 +3,13 @@ import { su } from "@tscircuit/soup-util"
 import { convertCircuitJsonToDsnString, parseDsnToCircuitJson } from "lib"
 import threeSubcircuitCircuitConnectedToSamePorts from "../assets/repro/three-subcircuit-connected-to-same-ports.json"
 
-test("circuit json -> dsn -> circuit json", async () => {
+const hasPort = (ports: string[], portName: string) =>
+  ports.some((portId) => portId.includes(portName))
+
+const hasPorts = (ports: string[], portNames: string[]) =>
+  portNames.every((portName) => hasPort(ports, portName))
+
+test("circuit json -> dsn -> circuit json preserves subcircuit trace boundaries", async () => {
   const dsnFile = convertCircuitJsonToDsnString(
     threeSubcircuitCircuitConnectedToSamePorts as any,
   )
@@ -16,6 +22,68 @@ test("circuit json -> dsn -> circuit json", async () => {
   expect(pcb_trace.length).toBe(1)
   expect(pcb_trace[0].source_trace_id).toBe(source_trace[0].source_trace_id)
 
-  // The other source_trace is having multiple connected_source_port_ids
-  expect(source_trace[1].connected_source_port_ids.length).toBe(3)
+  expect(hasPort(source_trace[0].connected_source_port_ids, "R1")).toBe(true)
+  expect(hasPort(source_trace[0].connected_source_port_ids, "R2")).toBe(true)
+  expect(hasPort(source_trace[0].connected_source_port_ids, "C1")).toBe(false)
+
+  const outerSubcircuitTrace = source_trace.find((trace) =>
+    hasPort(trace.connected_source_port_ids, "C1"),
+  )
+
+  expect(outerSubcircuitTrace).toBeDefined()
+  expect(outerSubcircuitTrace!.connected_source_port_ids).toHaveLength(2)
+  expect(hasPort(outerSubcircuitTrace!.connected_source_port_ids, "R1")).toBe(
+    true,
+  )
+  expect(hasPort(outerSubcircuitTrace!.connected_source_port_ids, "R2")).toBe(
+    false,
+  )
+})
+
+test("circuit json -> dsn -> circuit json does not add a merged trace when shared-anchor branches are routed", async () => {
+  const circuitWithOuterRoute = JSON.parse(
+    JSON.stringify(threeSubcircuitCircuitConnectedToSamePorts),
+  )
+  circuitWithOuterRoute.push({
+    type: "pcb_trace",
+    pcb_trace_id: "pcb_trace_source_trace_1",
+    source_trace_id: "source_trace_1",
+    route: [
+      {
+        x: 2.5,
+        y: 0,
+        layer: "top",
+        width: 0.16,
+        route_type: "wire",
+      },
+      {
+        x: -3.85,
+        y: 0,
+        layer: "top",
+        width: 0.16,
+        route_type: "wire",
+      },
+    ],
+  })
+
+  const dsnFile = convertCircuitJsonToDsnString(circuitWithOuterRoute as any)
+  const circuitJson = parseDsnToCircuitJson(dsnFile)
+  const source_trace = su(circuitJson).source_trace.list()
+
+  expect(source_trace.length).toBe(2)
+  expect(
+    source_trace.some((trace) =>
+      hasPorts(trace.connected_source_port_ids, ["R1", "R2", "C1"]),
+    ),
+  ).toBe(false)
+  expect(
+    source_trace.some((trace) =>
+      hasPorts(trace.connected_source_port_ids, ["R1", "R2"]),
+    ),
+  ).toBe(true)
+  expect(
+    source_trace.some((trace) =>
+      hasPorts(trace.connected_source_port_ids, ["R1", "C1"]),
+    ),
+  ).toBe(true)
 })


### PR DESCRIPTION
## Summary

Fixes #82.

This prevents DSN import from reconstructing a single merged `source_trace` for a multi-pin DSN net when routed wire names still preserve the original `source_trace` boundaries. The DSN `source_net` remains as the electrical union, but net-derived source traces drop routed-only sibling ports and are skipped when the routed traces already cover all branches.

## Changes

- Track source-port sets encoded in routed wire net names.
- Use `Net-(...-Pad...)` anchor names to trim routed sibling ports from net-derived source traces.
- Preserve the existing unrouted outer-branch behavior for the issue #82 fixture.
- Add coverage for the all-routed shared-anchor variant so no extra merged R1/R2/C1 trace is emitted.

## Verification

- `bun test tests/repros/repro8-multiple-traces-in-one-net.test.ts`
- `bun test tests/repros/repro8-multiple-traces-in-one-net.test.ts tests/repros/repro3-fix-hover-trace.test.ts tests/dsn-pcb/convert-circuit-json-to-dsn-session.unit.test.ts tests/dsn-pcb/circuit-json-to-dsn-session.test.ts tests/dsn-pcb/subcircuits-having-same-component.test.ts tests/repros/repro-6-subcircuit-group.test.ts`
- `bunx biome check lib/dsn-pcb/dsn-json-to-circuit-json/dsn-component-converters/convert-nets-to-source-nets-and-traces.ts tests/repros/repro8-multiple-traces-in-one-net.test.ts`
- `bunx tsc --noEmit`
- `bun run build`
- `git diff --check`

Full `bun test` still has the existing unrelated Windows/parser failures:

- `tests/dsn-pcb/basic-via-pcb-layer-change.test.tsx` debug path `ENOENT`
- `tests/dsn-pcb/merge-dsn-session-with-conversion.test.tsx` debug path `ENOENT`
- `tests/dsn-pcb/stringify-dsn-json.test.ts` parser metadata mismatch