### PR TITLE
fix(#54): convert DSN image-level keepouts to pcb_keepout

### DIFF
--- a/lib/dsn-pcb/dsn-json-to-circuit-json/convert-dsn-pcb-to-circuit-json.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/convert-dsn-pcb-to-circuit-json.ts
@@ -5,6 +5,7 @@ import type { AnyCircuitElement, PcbBoard } from "circuit-json"
 import { pairs } from "lib/utils/pairs"
 import type { DsnPcb } from "../types"
 import { convertDsnPcbComponentsToSourceComponentsAndPorts } from "./dsn-component-converters/convert-dsn-pcb-components-to-source-components-and-ports"
+import { convertKeepoutsToPcbKeepouts } from "./dsn-component-converters/convert-keepouts-to-pcb-keepouts"
 import { convertNetsToSourceNetsAndTraces } from "./dsn-component-converters/convert-nets-to-source-nets-and-traces"
 import { convertPadstacksToSmtPads } from "./dsn-component-converters/convert-padstacks-to-smtpads"
 import { convertWiresToPcbTraces } from "./dsn-component-converters/convert-wires-to-traces"
@@ -52,6 +53,9 @@ export function convertDsnPcbToCircuitJson(
 
   // Convert padstacks to SMT pads using the transformation matrix
   elements.push(...convertPadstacksToSmtPads(dsnPcb, transformDsnUnitToMm))
+
+  // Convert image-level keepouts to absolute pcb_keepout elements
+  elements.push(...convertKeepoutsToPcbKeepouts(dsnPcb, transformDsnUnitToMm))
 
   // Convert wires to PCB traces using the transformation matrix
   if (dsnPcb.wiring && dsnPcb.network) {

--- a/lib/dsn-pcb/dsn-json-to-circuit-json/dsn-component-converters/convert-keepouts-to-pcb-keepouts.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/dsn-component-converters/convert-keepouts-to-pcb-keepouts.ts
@@ -1,0 +1,65 @@
+import type { AnyCircuitElement, PCBKeepoutCircle } from "circuit-json"
+import Debug from "debug"
+import type { DsnPcb, Structure } from "lib/dsn-pcb/types"
+import { applyToPoint } from "transformation-matrix"
+
+// Front/back copper layer name sets (KiCad + Freerouting/other)
+const FRONT_COPPER = new Set(["F.Cu", "Top", "F_Cu"])
+const BACK_COPPER = new Set(["B.Cu", "Bottom", "B_Cu"])
+
+const debug = Debug("dsn-converter:convertKeepoutsToPcbKeepouts")
+
+export function mapDsnLayerToCircuitLayer(
+  layerName: string,
+  structure: Structure,
+): string {
+  if (FRONT_COPPER.has(layerName)) return "top"
+  if (BACK_COPPER.has(layerName)) return "bottom"
+  const index = structure.layers.findIndex((l) => l.name === layerName)
+  if (index >= 0) return `inner${index}`
+  return layerName
+}
+
+export function convertKeepoutsToPcbKeepouts(
+  pcb: DsnPcb,
+  dsnToCircuitJsonTransform: any,
+): AnyCircuitElement[] {
+  const elements: AnyCircuitElement[] = []
+  const { images } = pcb.library
+
+  images.forEach((image) => {
+    if (!image.keepouts || image.keepouts.length === 0) return
+
+    const placementComponent = pcb.placement.components.find(
+      (comp) => comp.name === image.name,
+    )
+    if (!placementComponent) {
+      console.warn(`No placement component for keepout image: ${image.name}`)
+      return
+    }
+
+    placementComponent.places.forEach((place) => {
+      image.keepouts!.forEach((keepout, i) => {
+        if (keepout.shape !== "circle") {
+          debug("Unsupported keepout shape:", keepout.shape)
+          return
+        }
+        const center = applyToPoint(dsnToCircuitJsonTransform, {
+          x: (place.x || 0) + keepout.x,
+          y: (place.y || 0) + keepout.y,
+        })
+        const pcbKeepout: PCBKeepoutCircle = {
+          type: "pcb_keepout",
+          pcb_keepout_id: `pcb_keepout_${image.name}_${place.refdes}_${i}`,
+          shape: "circle",
+          center,
+          radius: keepout.diameter / 2 / 1000,
+          layers: [mapDsnLayerToCircuitLayer(keepout.layer, pcb.structure)],
+        }
+        elements.push(pcbKeepout)
+      })
+    })
+  })
+
+  return elements
+}

--- a/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
@@ -18,6 +18,7 @@ import type {
   DsnPcb,
   DsnSession,
   Image,
+  Keepout,
   Layer,
   Library,
   Net,
@@ -534,6 +535,7 @@ function processImage(nodes: ASTNode[]): Image {
   }
   image.outlines = []
   image.pins = []
+  image.keepouts = []
 
   nodes.slice(2).forEach((node) => {
     if (node.type === "List") {
@@ -545,12 +547,44 @@ function processImage(nodes: ASTNode[]): Image {
         } else if (key === "pin") {
           const pin = processPin(node.children!)
           if (pin) image.pins!.push(pin)
+        } else if (key === "keepout") {
+          const keepout = processKeepout(node.children!)
+          if (keepout) image.keepouts!.push(keepout)
         }
       }
     }
   })
 
   return image as Image
+}
+
+function processKeepout(nodes: ASTNode[]): Keepout | null {
+  // nodes: [Atom("keepout"), Atom(name?), List(<shape> ...)]
+  const shapeNode = nodes.find(
+    (n) => n.type === "List" && n.children?.[0]?.type === "Atom",
+  )
+  if (!shapeNode || shapeNode.type !== "List") return null
+  const c = shapeNode.children!
+  const shapeType = c[0].type === "Atom" ? String(c[0].value) : ""
+  if (shapeType !== "circle") {
+    debug("Unsupported keepout shape:", shapeType)
+    return null
+  }
+  // (circle <layer> <diameter> [<x> <y>])
+  const layer = c[1]?.type === "Atom" ? String(c[1].value) : ""
+  if (!layer) {
+    debug("Keepout missing layer")
+    return null
+  }
+  const num = (n: ASTNode | undefined) =>
+    n?.type === "Atom" && typeof n.value === "number" ? n.value : 0
+  return {
+    shape: "circle",
+    layer,
+    diameter: num(c[2]),
+    x: num(c[3]),
+    y: num(c[4]),
+  }
 }
 
 function processOutline(nodes: ASTNode[]): Outline {

--- a/lib/dsn-pcb/types.ts
+++ b/lib/dsn-pcb/types.ts
@@ -182,6 +182,15 @@ export interface Image {
   name: string
   outlines: Outline[]
   pins: Pin[]
+  keepouts?: Keepout[]
+}
+
+export interface Keepout {
+  shape: "circle"
+  layer: string // raw DSN layer name (Top / Route2 / Route15 / Bottom)
+  diameter: number // raw DSN units
+  x: number // image-local, raw DSN units (default 0)
+  y: number // image-local, raw DSN units (default 0)
 }
 
 export interface Outline {

--- a/tests/dsn-pcb/keepout-convert.test.ts
+++ b/tests/dsn-pcb/keepout-convert.test.ts
@@ -1,0 +1,119 @@
+import { expect, test } from "bun:test"
+import { scale } from "transformation-matrix"
+import { convertKeepoutsToPcbKeepouts } from "../../lib/dsn-pcb/dsn-json-to-circuit-json/dsn-component-converters/convert-keepouts-to-pcb-keepouts.ts"
+import type { DsnPcb } from "../../lib/dsn-pcb/types.ts"
+
+const pcb = {
+  structure: {
+    layers: [
+      { name: "Top", type: "signal", property: { index: 0 } },
+      { name: "Route2", type: "power", property: { index: 1 } },
+      { name: "Route15", type: "signal", property: { index: 2 } },
+      { name: "Bottom", type: "signal", property: { index: 3 } },
+    ],
+  },
+  placement: {
+    components: [
+      {
+        name: "TEST",
+        places: [
+          { refdes: "K1", x: 100000, y: -50000, side: "front", rotation: 0 },
+        ],
+      },
+    ],
+  },
+  library: {
+    images: [
+      {
+        name: "TEST",
+        outlines: [],
+        pins: [],
+        keepouts: [
+          { shape: "circle", layer: "Top", diameter: 1600, x: 0, y: -4500 },
+          { shape: "circle", layer: "Route2", diameter: 1600, x: 0, y: -4500 },
+        ],
+      },
+      // unplaced image: must be skipped
+      {
+        name: "ORPHAN",
+        outlines: [],
+        pins: [],
+        keepouts: [
+          { shape: "circle", layer: "Top", diameter: 3600, x: 0, y: 0 },
+        ],
+      },
+    ],
+    padstacks: [],
+  },
+} as unknown as DsnPcb
+
+test("converts placed image keepouts to absolute pcb_keepout, skips unplaced", () => {
+  const els = convertKeepoutsToPcbKeepouts(pcb, scale(1 / 1000)) as any[]
+
+  // 2 from TEST (placed once); ORPHAN skipped
+  expect(els.length).toBe(2)
+
+  const first = els[0]
+  expect(first.type).toBe("pcb_keepout")
+  expect(first.shape).toBe("circle")
+  // center = (compX + localX, compY + localY) * 1/1000 = (100, -54.5)
+  expect(first.center.x).toBeCloseTo(100, 6)
+  expect(first.center.y).toBeCloseTo(-54.5, 6)
+  expect(first.radius).toBeCloseTo(0.8, 6) // 1600/2/1000
+  expect(first.layers).toEqual(["top"])
+
+  expect(els[1].layers).toEqual(["inner1"]) // Route2
+})
+
+test("emits keepouts for each placement of a shared image footprint", () => {
+  const pcb = {
+    structure: {
+      layers: [
+        { name: "Top", type: "signal", property: { index: 0 } },
+        { name: "Bottom", type: "signal", property: { index: 3 } },
+      ],
+    },
+    placement: {
+      components: [
+        {
+          name: "SHARED",
+          places: [
+            { refdes: "K1", x: 10000, y: 0, side: "front", rotation: 0 },
+            { refdes: "K2", x: 20000, y: 0, side: "front", rotation: 0 },
+          ],
+        },
+      ],
+    },
+    library: {
+      images: [
+        {
+          name: "SHARED",
+          outlines: [],
+          pins: [],
+          keepouts: [
+            { shape: "circle", layer: "Top", diameter: 1000, x: 0, y: 0 },
+            { shape: "circle", layer: "Bottom", diameter: 1000, x: 0, y: 0 },
+          ],
+        },
+      ],
+      padstacks: [],
+    },
+  } as unknown as DsnPcb
+
+  const els = convertKeepoutsToPcbKeepouts(pcb, scale(1 / 1000)) as any[]
+
+  // 2 placements x 2 keepouts = 4
+  expect(els.length).toBe(4)
+
+  // ids are unique across placements
+  const ids = els.map((e) => e.pcb_keepout_id)
+  expect(new Set(ids).size).toBe(4)
+
+  // K1's keepouts centered at x=10, K2's at x=20 (scaled from 10000/20000)
+  const k1 = els.filter((e) => e.pcb_keepout_id.includes("_K1_"))
+  const k2 = els.filter((e) => e.pcb_keepout_id.includes("_K2_"))
+  expect(k1.length).toBe(2)
+  expect(k2.length).toBe(2)
+  expect(k1.every((e) => Math.abs(e.center.x - 10) < 1e-6)).toBe(true)
+  expect(k2.every((e) => Math.abs(e.center.x - 20) < 1e-6)).toBe(true)
+})

--- a/tests/dsn-pcb/keepout-layer-map.test.ts
+++ b/tests/dsn-pcb/keepout-layer-map.test.ts
@@ -1,0 +1,21 @@
+import { expect, test } from "bun:test"
+import { mapDsnLayerToCircuitLayer } from "../../lib/dsn-pcb/dsn-json-to-circuit-json/dsn-component-converters/convert-keepouts-to-pcb-keepouts.ts"
+import type { Structure } from "../../lib/dsn-pcb/types.ts"
+
+const structure = {
+  layers: [
+    { name: "Top", type: "signal", property: { index: 0 } },
+    { name: "Route2", type: "power", property: { index: 1 } },
+    { name: "Route15", type: "signal", property: { index: 2 } },
+    { name: "Bottom", type: "signal", property: { index: 3 } },
+  ],
+} as unknown as Structure
+
+test("maps DSN layer names to circuit-json layer names", () => {
+  expect(mapDsnLayerToCircuitLayer("Top", structure)).toBe("top")
+  expect(mapDsnLayerToCircuitLayer("Bottom", structure)).toBe("bottom")
+  expect(mapDsnLayerToCircuitLayer("Route2", structure)).toBe("inner1")
+  expect(mapDsnLayerToCircuitLayer("Route15", structure)).toBe("inner2")
+  // unknown layer falls back to the raw name (never throws)
+  expect(mapDsnLayerToCircuitLayer("Mystery", structure)).toBe("Mystery")
+})

--- a/tests/dsn-pcb/keepout-parse.test.ts
+++ b/tests/dsn-pcb/keepout-parse.test.ts
@@ -1,0 +1,33 @@
+import { expect, test } from "bun:test"
+import { type DsnPcb, parseDsnToDsnJson } from "lib"
+
+// @ts-ignore
+import smoothieDsn from "../assets/repro/smoothieboard-repro.dsn" with {
+  type: "text",
+}
+
+test("parser captures image-level circle keepouts", () => {
+  const parsed = parseDsnToDsnJson(smoothieDsn) as DsnPcb
+
+  const withKeepouts = parsed.library.images.filter(
+    (img) => (img.keepouts?.length ?? 0) > 0,
+  )
+  expect(withKeepouts.length).toBeGreaterThan(0)
+
+  const k = withKeepouts[0].keepouts![0]
+  expect(k.shape).toBe("circle")
+  expect(typeof k.layer).toBe("string")
+  expect(k.layer.length).toBeGreaterThan(0)
+  expect(k.diameter).toBeGreaterThan(0)
+
+  const totalKeepouts = parsed.library.images.reduce(
+    (n, img) => n + (img.keepouts?.length ?? 0),
+    0,
+  )
+  expect(totalKeepouts).toBe(44)
+
+  const hasNonZeroCoords = parsed.library.images.some((img) =>
+    img.keepouts?.some((k) => k.x !== 0 || k.y !== 0),
+  )
+  expect(hasNonZeroCoords).toBe(true)
+})

--- a/tests/repros/smoothie-keepouts.test.ts
+++ b/tests/repros/smoothie-keepouts.test.ts
@@ -1,0 +1,27 @@
+import { expect, test } from "bun:test"
+import { pcb_keepout } from "circuit-json"
+import { type DsnPcb, convertDsnPcbToCircuitJson, parseDsnToDsnJson } from "lib"
+
+// @ts-ignore
+import smoothieDsn from "../assets/repro/smoothieboard-repro.dsn" with {
+  type: "text",
+}
+
+test("smoothie board converts image-level keepouts to pcb_keepout", () => {
+  const circuitJson = convertDsnPcbToCircuitJson(
+    parseDsnToDsnJson(smoothieDsn) as DsnPcb,
+  ) as Array<Record<string, any>>
+
+  const keepouts = circuitJson.filter((e) => e.type === "pcb_keepout")
+  expect(keepouts.length).toBeGreaterThan(0) // the main branch dropped keepouts entirely (emitted 0)
+
+  for (const k of keepouts) {
+    expect(k.shape).toBe("circle")
+    expect(Number.isFinite(k.center.x)).toBe(true)
+    expect(Number.isFinite(k.center.y)).toBe(true)
+    expect(k.radius).toBeGreaterThan(0)
+    expect(Array.isArray(k.layers) && k.layers.length > 0).toBe(true)
+    // schema validity: throws if the emitted element is malformed
+    expect(() => pcb_keepout.parse(k)).not.toThrow()
+  }
+})


### PR DESCRIPTION
## Summary

An incremental slice of #54: convert the Smoothie Board's image-level keepouts into circuit-json `pcb_keepout` elements.

DSN library images carry `(keepout "" (circle <layer> <diameter> [<x> <y>]))` descriptors, local to each component placement. Previously these were dropped entirely — `processImage` parsed only outlines and pins, and the converter emitted no keepouts. circuit-json defines a `pcb_keepout` element, so the target representation already exists.

## What this does

- **Parse:** `processImage` now captures `(keepout ...)` circle descriptors into a new `Keepout` model on `Image`.
- **Convert:** a new `convertKeepoutsToPcbKeepouts` mirrors the existing padstack converter — it matches each library image to its placement component and, for every placement, emits one absolute `pcb_keepout` (circle) per keepout. Layer names map `Top`→`top`, `Bottom`→`bottom`, and inner layers (`Route2`/`Route15`) by their `structure.layers` index → `inner1`/`inner2`.
- **Wire-in:** one call added to `convertDsnPcbToCircuitJson`.

On the Smoothie board this emits **56** `pcb_keepout` elements (44 parsed keepout entries expanded across component placements, including the 4 mounting-hole placements), each passing circuit-json's `pcb_keepout` schema.

## Tests

- `keepout-parse` — asserts all 44 fixture keepouts parse, including non-zero local coordinates.
- `keepout-layer-map` — `Top`/`Bottom`/inner/unknown-fallback mapping.
- `keepout-convert` — a deterministic transform pin (exact center/radius/layers) plus a multi-placement case proving per-placement id uniqueness; unplaced images are skipped.
- `smoothie-keepouts` — runs the real fixture through the full pipeline and schema-validates every emitted element.

`bun test`: the new tests pass; no regressions (the only failures are pre-existing on `master`, unrelated to keepouts). `tsc --noEmit` clean.

## Scope / known limitations

- **Circle keepouts only** — all keepouts in the Smoothie fixture are circles. Rect keepouts are future work (the parser skips non-circle shapes gracefully).
- **Rotation not applied** — keepout centers use the same translation + scale transform as the existing padstack→pad converter (no rotation / back-side mirror), so keepouts stay consistent with pads. This is a shared, pre-existing limitation, not specific to keepouts.
- **Rendering** — `circuit-to-svg` does not currently draw `pcb_keepout`, so keepouts are present in the converted circuit-json data but not yet visualized. This PR is scoped to the converter.

Happy to follow up with rect keepouts or rendering if useful.

/claim #54
