### PR TITLE
fix: preserve Smoothie DSN pin labels

### DIFF
--- a/lib/common/parse-sexpr.ts
+++ b/lib/common/parse-sexpr.ts
@@ -15,6 +15,11 @@ export function tokenizeDsn(input: string): Token[] {
 
   while (i < length) {
     const char = input[i]
+    const startsNumber =
+      /\d/.test(char) ||
+      (char === "-" &&
+        (/\d/.test(input[i + 1]) ||
+          (input[i + 1] === "." && /\d/.test(input[i + 2]))))
 
     if (char === "(") {
       tokens.push({ type: "LParen" })
@@ -44,7 +49,7 @@ export function tokenizeDsn(input: string): Token[] {
       }
       i++ // Skip the closing quote
       tokens.push({ type: "String", value })
-    } else if (char === "-" || /\d/.test(char)) {
+    } else if (startsNumber) {
       // Parse number (integer or float)
       let numStr = ""
       if (char === "-") {

--- a/lib/dsn-pcb/dsn-json-to-circuit-json/dsn-component-converters/convert-dsn-pcb-components-to-source-components-and-ports.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/dsn-component-converters/convert-dsn-pcb-components-to-source-components-and-ports.ts
@@ -2,6 +2,12 @@ import type { AnySourceComponent, PcbPort, SourcePort } from "circuit-json"
 import type { DsnPcb, Image, Pin } from "lib/dsn-pcb/types"
 import { type Matrix, applyToPoint } from "transformation-matrix"
 
+function getNumericPinNumber(pinNumber: Pin["pin_number"]): number | undefined {
+  const numericPinNumber = Number(pinNumber)
+
+  return Number.isFinite(numericPinNumber) ? numericPinNumber : undefined
+}
+
 export const convertDsnPcbComponentsToSourceComponentsAndPorts = ({
   dsnPcb,
   transformDsnUnitToMm,
@@ -33,13 +39,15 @@ export const convertDsnPcbComponentsToSourceComponentsAndPorts = ({
       // Create ports for each pin in the image
       if (image.pins) {
         for (const pin of image.pins) {
+          const numericPinNumber = getNumericPinNumber(pin.pin_number)
           const port: SourcePort = {
             type: "source_port",
             source_port_id: `source_port_${component.name}-Pad${pin.pin_number}_${place.refdes}`,
             source_component_id: sourceComponent.source_component_id,
             name: `${place.refdes}-${pin.pin_number}`,
-            pin_number: Number(pin.pin_number),
-            port_hints: [],
+            ...(numericPinNumber === undefined
+              ? { port_hints: [pin.pin_number.toString()] }
+              : { pin_number: numericPinNumber, port_hints: [] }),
           }
           // Handle case where place coordinates might be null/undefined
           const placeX = place.x || 0

--- a/lib/dsn-pcb/dsn-json-to-circuit-json/dsn-component-converters/convert-padstacks-to-smtpads.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/dsn-component-converters/convert-padstacks-to-smtpads.ts
@@ -87,6 +87,17 @@ function isApproximatelyEqual(a: number, b: number) {
   return Math.abs(a - b) < 1e-6
 }
 
+function getPinIdSuffix(pinNumber: string | number): string {
+  if (typeof pinNumber === "number") {
+    return String(pinNumber - 1)
+  }
+
+  if (pinNumber === "+") return "plus"
+  if (pinNumber === "-") return "minus"
+
+  return pinNumber.replace(/[^a-zA-Z0-9_-]/g, "_")
+}
+
 export function convertPadstacksToSmtPads(
   pcb: DsnPcb,
   dsnToCircuitJsonTransform: any,
@@ -286,7 +297,7 @@ export function convertPadstacksToSmtPads(
           const layer = getLayerFromPadstack(padstack)
           pcbPad = {
             type: "pcb_smtpad",
-            pcb_smtpad_id: `pcb_smtpad_${componentId}_${place.refdes}_${Number(pin.pin_number) - 1}`,
+            pcb_smtpad_id: `pcb_smtpad_${componentId}_${place.refdes}_${getPinIdSuffix(pin.pin_number)}`,
             ...commonIds,
             shape: "polygon",
             points: getPolygonPoints(polygonShape.coordinates, {
@@ -299,7 +310,7 @@ export function convertPadstacksToSmtPads(
           const layer = getLayerFromPadstack(padstack)
           pcbPad = {
             type: "pcb_smtpad",
-            pcb_smtpad_id: `pcb_smtpad_${componentId}_${place.refdes}_${Number(pin.pin_number) - 1}`,
+            pcb_smtpad_id: `pcb_smtpad_${componentId}_${place.refdes}_${getPinIdSuffix(pin.pin_number)}`,
             ...commonIds,
             shape: "rect",
             x: circuitX,
@@ -311,7 +322,7 @@ export function convertPadstacksToSmtPads(
         } else {
           pcbPad = {
             type: "pcb_smtpad",
-            pcb_smtpad_id: `pcb_smtpad_${componentId}_${place.refdes}_${Number(pin.pin_number) - 1}`,
+            pcb_smtpad_id: `pcb_smtpad_${componentId}_${place.refdes}_${getPinIdSuffix(pin.pin_number)}`,
             ...commonIds,
             shape: "circle",
             x: circuitX,

--- a/lib/utils/get-pin-number.ts
+++ b/lib/utils/get-pin-number.ts
@@ -11,13 +11,26 @@ export function getPinNum(nodes: ASTNode[]): number | string | null {
   // Extract pin number from AST nodes
   let pinNumber
 
-  if (nodes[2]?.type === "List" && nodes[2].children) {
-    // Pin number is in a List structure
-    pinNumber = nodes[2].children[0]?.value
-  } else if (nodes[2]?.type === "Atom") {
-    // Pin number is direct value
-    pinNumber = nodes[2].value
-  } else {
+  for (const node of nodes.slice(2)) {
+    if (node.type === "List") {
+      if (
+        node.children?.[0]?.type === "Atom" &&
+        node.children[0].value === "rotate"
+      ) {
+        continue
+      }
+
+      pinNumber = node.children?.[0]?.value
+      break
+    }
+
+    if (node.type === "Atom") {
+      pinNumber = node.value
+      break
+    }
+  }
+
+  if (pinNumber === undefined) {
     debug("Unsupported pin number format:", nodes)
     return null
   }

--- a/tests/repros/repro7-smoothie-board.test.ts
+++ b/tests/repros/repro7-smoothie-board.test.ts
@@ -16,3 +16,51 @@ test("smoothieboard repro", async () => {
     import.meta.path,
   )
 })
+
+test("smoothieboard rotated string pins keep their pin identifiers", () => {
+  const dsnJson = parseDsnToDsnJson(dsnFileWithFreeroutingTrace) as DsnPcb
+  const eia3216Image = dsnJson.library.images.find(
+    (image) => image.name === "smoothieboard-5driver:EIA3216",
+  )
+
+  expect(eia3216Image?.pins.map((pin) => pin.pin_number)).toContain("A")
+  expect(eia3216Image?.pins.map((pin) => pin.pin_number)).toContain("C")
+
+  const panasonicEImage = dsnJson.library.images.find(
+    (image) => image.name === "smoothieboard-5driver:PANASONIC_E",
+  )
+
+  expect(panasonicEImage?.pins.map((pin) => pin.pin_number)).toContain("+")
+  expect(panasonicEImage?.pins.map((pin) => pin.pin_number)).toContain("-")
+
+  const circuitJson = convertDsnPcbToCircuitJson(dsnJson)
+  const serializedElements = circuitJson.map((element) =>
+    JSON.stringify(element),
+  )
+
+  expect(serializedElements.some((element) => element.includes("NaN"))).toBe(
+    false,
+  )
+  expect(
+    serializedElements.some((element) =>
+      element.includes("pcb_smtpad_smoothieboard-5driver:EIA3216_C7_A"),
+    ),
+  ).toBe(true)
+  expect(
+    serializedElements.some((element) =>
+      element.includes("pcb_smtpad_smoothieboard-5driver:EIA3216_C7_C"),
+    ),
+  ).toBe(true)
+  expect(
+    serializedElements.some((element) =>
+      element.includes("pcb_smtpad_smoothieboard-5driver:PANASONIC_E_C60_plus"),
+    ),
+  ).toBe(true)
+  expect(
+    serializedElements.some((element) =>
+      element.includes(
+        "pcb_smtpad_smoothieboard-5driver:PANASONIC_E_C60_minus",
+      ),
+    ),
+  ).toBe(true)
+})


### PR DESCRIPTION
Part of #54.

/claim #54

## Summary
- tokenize a bare `-` as a pin label instead of `NaN`, while keeping real negative coordinates numeric
- skip DSN `(rotate ...)` metadata when reading image pin identifiers like `A` and `C`
- keep named DSN pins out of numeric-only `source_port.pin_number` fields and use stable SMT pad ID suffixes for labels such as `+`, `-`, `A`, and `C`
- add a Smoothieboard regression that checks those labels and prevents `NaN` in converted Circuit JSON

## Testing
- `bun test`
- `bun run build`
- `git diff --check`

Algora payout: GitHub user `@jamilahmadzai`.
