### PR TITLE
feat: preserve DSN padstack hole descriptors and shapes during JSON round-tripping

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/process-plated-holes.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/process-plated-holes.ts
@@ -40,8 +40,9 @@ export function processPlatedHoles(
         })
         if (!processedPadstacks.has(name)) {
           const d = Math.round(hole.outer_diameter * 1000)
+          const h = Math.round(hole.hole_diameter * 1000)
           pcb.library.padstacks.push(
-            createCircularPadstack(name, d, d, numLayers),
+            createCircularPadstack(name, d, h, numLayers),
           )
           processedPadstacks.add(name)
         }

--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
@@ -102,6 +102,15 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
       }
     })
     result += `${indent}${indent}${indent}(attach ${padstack.attach})\n`
+    if (padstack.hole) {
+      if (padstack.hole.shape === "circle") {
+        result += `${indent}${indent}${indent}(hole (circle ${padstack.hole.diameter}))\n`
+      } else if (padstack.hole.shape === "oval") {
+        result += `${indent}${indent}${indent}(hole (oval ${padstack.hole.width} ${padstack.hole.height}))\n`
+      } else if (padstack.hole.shape === "square") {
+        result += `${indent}${indent}${indent}(hole (square ${padstack.hole.width}))\n`
+      }
+    }
     result += `${indent}${indent})\n`
   })
   result += `${indent})\n`

--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-session.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-session.ts
@@ -38,16 +38,47 @@ export const stringifyDsnSession = (session: DsnSession): string => {
   // Library_out subsection
   if (session.routes.library_out) {
     result += `${indent}${indent}(library_out \n`
-    session.routes.library_out.padstacks.forEach((padstack) => {
+    session.routes.library_out.images?.forEach((image) => {
+      result += `${indent}${indent}${indent}(image ${JSON.stringify(image.name)}\n`
+      image.outlines.forEach((outline) => {
+        result += `${indent}${indent}${indent}${indent}(outline (path ${outline.path.layer} ${outline.path.width} ${outline.path.coordinates.join(" ")}))\n`
+      })
+      image.pins.forEach((pin) => {
+        result += `${indent}${indent}${indent}${indent}(pin ${pin.padstack_name} ${pin.pin_number} ${pin.x} ${pin.y})\n`
+      })
+      result += `${indent}${indent}${indent})\n`
+    })
+    session.routes.library_out.padstacks?.forEach((padstack) => {
       result += `${indent}${indent}${indent}(padstack ${JSON.stringify(padstack.name)}\n`
       padstack.shapes.forEach((shape) => {
-        if (shape.shapeType === "circle") {
+        if (shape.shapeType === "polygon") {
+          result += `${indent}${indent}${indent}${indent}(shape\n`
+          result += `${indent}${indent}${indent}${indent}${indent}(polygon ${shape.layer} ${shape.width} ${shape.coordinates.join(" ")})\n`
+          result += `${indent}${indent}${indent}${indent})\n`
+        } else if (shape.shapeType === "circle") {
           result += `${indent}${indent}${indent}${indent}(shape\n`
           result += `${indent}${indent}${indent}${indent}${indent}(circle ${shape.layer} ${shape.diameter} 0 0)\n`
+          result += `${indent}${indent}${indent}${indent})\n`
+        } else if (shape.shapeType === "path") {
+          result += `${indent}${indent}${indent}${indent}(shape\n`
+          result += `${indent}${indent}${indent}${indent}${indent}(path ${shape.layer} ${shape.width} ${shape.coordinates.join(" ")})\n`
+          result += `${indent}${indent}${indent}${indent})\n`
+        } else if (shape.shapeType === "rect") {
+          result += `${indent}${indent}${indent}${indent}(shape\n`
+          result += `${indent}${indent}${indent}${indent}${indent}(rect ${shape.layer} ${shape.coordinates.join(" ")})\n`
           result += `${indent}${indent}${indent}${indent})\n`
         }
       })
       result += `${indent}${indent}${indent}${indent}(attach ${padstack.attach})\n`
+      if (padstack.hole) {
+        if (padstack.hole.shape === "circle") {
+          result += `${indent}${indent}${indent}${indent}(hole (circle ${padstack.hole.diameter}))\n`
+        } else if (padstack.hole.shape === "oval") {
+          result += `${indent}${indent}${indent}${indent}(hole (oval ${padstack.hole.width} ${padstack.hole.height}))\n`
+        } else if (padstack.hole.shape === "square") {
+          result += `${indent}${indent}${indent}${indent}(hole (square ${padstack.hole.width}))\n`
+        }
+      }
       result += `${indent}${indent}${indent})\n`
     })
     result += `${indent}${indent})\n`

--- a/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
@@ -674,6 +674,27 @@ function processPadstack(nodes: ASTNode[]): Padstack {
                 height: rest[2].value as number,
               }
             }
+          } else if (rest[0]?.type === "List") {
+            const shapeNode = rest[0].children?.[0]
+            if (shapeNode?.type === "Atom") {
+              if (shapeNode.value === "circle") {
+                padstack.hole = {
+                  shape: "circle",
+                  diameter: rest[0].children?.[1]?.value as number,
+                }
+              } else if (shapeNode.value === "oval") {
+                padstack.hole = {
+                  shape: "oval",
+                  width: rest[0].children?.[1]?.value as number,
+                  height: rest[0].children?.[2]?.value as number,
+                }
+              } else if (shapeNode.value === "square") {
+                padstack.hole = {
+                  shape: "square",
+                  width: rest[0].children?.[1]?.value as number,
+                }
+              }
+            }
           }
         }
       }
@@ -1097,17 +1118,9 @@ function processSessionNode(ast: ASTNode): DsnSession {
         child.children[0].value === "library_out",
     )
     if (libraryNode) {
-      session.routes.library_out = {
-        images: [],
-        padstacks: libraryNode
-          .children!.filter(
-            (child) =>
-              child.type === "List" &&
-              child.children?.[0].type === "Atom" &&
-              child.children[0].value === "padstack",
-          )
-          .map((padstackNode) => processPadstack(padstackNode.children!)),
-      }
+      session.routes.library_out = processLibrary(
+        libraryNode.children!.slice(1),
+      )
     }
 
     // Extract network_out section

--- a/tests/dsn-pcb/stringify-dsn-json-holes.test.ts
+++ b/tests/dsn-pcb/stringify-dsn-json-holes.test.ts
@@ -1,0 +1,105 @@
+import { expect, test } from "bun:test"
+import { parseDsnToDsnJson, stringifyDsnJson, type DsnPcb } from "lib"
+
+const dsnWithHoles = `(pcb test.dsn
+  (parser
+    (string_quote ")
+    (space_in_quoted_tokens on)
+    (host_cad "KiCad's Pcbnew")
+    (host_version "1.0")
+  )
+  (resolution um 10)
+  (unit um)
+  (structure
+    (layer F.Cu
+      (type signal)
+      (property
+        (index 0)
+      )
+    )
+    (layer B.Cu
+      (type signal)
+      (property
+        (index 1)
+      )
+    )
+    (via via)
+    (rule
+      (width 10)
+      (clearance 10)
+    )
+  )
+  (placement
+  )
+  (library
+    (padstack "circ-hole"
+      (shape (circle F.Cu 1000))
+      (shape (circle B.Cu 1000))
+      (attach off)
+      (hole (circle 500))
+    )
+    (padstack "oval-hole"
+      (shape (circle F.Cu 1200))
+      (shape (circle B.Cu 1200))
+      (attach off)
+      (hole (oval 400 800))
+    )
+    (padstack "square-hole"
+      (shape (circle F.Cu 800))
+      (shape (circle B.Cu 800))
+      (attach off)
+      (hole (square 600))
+    )
+    (padstack "no-hole"
+      (shape (circle F.Cu 600))
+      (attach off)
+    )
+  )
+  (network
+  )
+  (wiring
+  )
+)
+`
+
+test("stringify-dsn-json with holes", () => {
+  const dsnJson = parseDsnToDsnJson(dsnWithHoles) as DsnPcb
+  const stringified = stringifyDsnJson(dsnJson)
+  const reparsed = parseDsnToDsnJson(stringified) as DsnPcb
+
+  const padstacks = reparsed.library.padstacks
+
+  expect(padstacks).toHaveLength(4)
+
+  // Circle hole
+  const ps1 = padstacks.find((p) => p.name === "circ-hole")!
+  expect(ps1).toBeDefined()
+  expect(ps1.hole?.shape).toBe("circle")
+  expect(ps1.hole?.diameter).toBe(500)
+  expect(ps1.hole?.width).toBeUndefined()
+  expect(ps1.hole?.height).toBeUndefined()
+
+  // Oval hole
+  const ps2 = padstacks.find((p) => p.name === "oval-hole")!
+  expect(ps2).toBeDefined()
+  expect(ps2.hole?.shape).toBe("oval")
+  expect(ps2.hole?.width).toBe(400)
+  expect(ps2.hole?.height).toBe(800)
+  expect(ps2.hole?.diameter).toBeUndefined()
+
+  // Square hole
+  const ps3 = padstacks.find((p) => p.name === "square-hole")!
+  expect(ps3).toBeDefined()
+  expect(ps3.hole?.shape).toBe("square")
+  expect(ps3.hole?.width).toBe(600)
+  expect(ps3.hole?.diameter).toBeUndefined()
+  expect(ps3.hole?.height).toBeUndefined()
+
+  // No hole
+  const ps4 = padstacks.find((p) => p.name === "no-hole")!
+  expect(ps4).toBeDefined()
+  expect(ps4.hole).toBeUndefined()
+
+  // Full structural equality
+  expect(dsnJson.library.padstacks).toEqual(reparsed.library.padstacks)
+})

--- a/tests/dsn-pcb/stringify-dsn-session-shapes-and-holes.test.ts
+++ b/tests/dsn-pcb/stringify-dsn-session-shapes-and-holes.test.ts
@@ -50,10 +50,88 @@ test("stringify-dsn-session-shapes-and-holes", () => {
   const stringified = stringifyDsnSession(sessionJson)
   const reparsed = parseDsnToDsnJson(stringified) as DsnSession
 
-  expect(reparsed.routes.library_out?.images?.length).toBe(1)
-  expect(reparsed.routes.library_out?.images?.[0].name).toBe("test_image")
-  expect(reparsed.routes.library_out?.padstacks?.length).toBe(4)
-  expect(reparsed.routes.library_out?.padstacks?.[0].hole?.shape).toBe("circle")
-  expect(reparsed.routes.library_out?.padstacks?.[1].hole?.shape).toBe("oval")
-  expect(reparsed.routes.library_out?.padstacks?.[2].hole?.shape).toBe("square")
+  const lib = reparsed.routes.library_out!
+  const origLib = sessionJson.routes.library_out!
+
+  // -- Images --
+  expect(lib.images?.length).toBe(1)
+  expect(lib.images?.[0].name).toBe("test_image")
+  expect(lib.images?.[0].outlines).toHaveLength(1)
+  expect(lib.images?.[0].outlines[0].path.layer).toBe("signal")
+  expect(lib.images?.[0].outlines[0].path.width).toBe(1)
+  expect(lib.images?.[0].outlines[0].path.coordinates).toEqual([0, 0, 10, 10])
+  expect(lib.images?.[0].pins).toHaveLength(1)
+  expect(lib.images?.[0].pins[0].padstack_name).toBe("padstack1")
+  expect(lib.images?.[0].pins[0].pin_number).toBe(1)
+  expect(lib.images?.[0].pins[0].x).toBe(0)
+  expect(lib.images?.[0].pins[0].y).toBe(0)
+
+  // -- Padstacks --
+  expect(lib.padstacks?.length).toBe(4)
+
+  // padstack1: polygon shape + circle hole
+  const ps1 = lib.padstacks![0]
+  expect(ps1.name).toBe("padstack1")
+  expect(ps1.attach).toBe("off")
+  expect(ps1.shapes).toHaveLength(1)
+  expect(ps1.shapes[0].shapeType).toBe("polygon")
+  if (ps1.shapes[0].shapeType === "polygon") {
+    expect(ps1.shapes[0].layer).toBe("signal")
+    expect(ps1.shapes[0].width).toBe(10)
+    expect(ps1.shapes[0].coordinates).toEqual([0, 0, 10, 0, 10, 10, 0, 10])
+  }
+  expect(ps1.hole?.shape).toBe("circle")
+  expect(ps1.hole?.diameter).toBe(5)
+  expect(ps1.hole?.width).toBeUndefined()
+  expect(ps1.hole?.height).toBeUndefined()
+
+  // padstack2: circle shape + oval hole
+  const ps2 = lib.padstacks![1]
+  expect(ps2.name).toBe("padstack2")
+  expect(ps2.attach).toBe("off")
+  expect(ps2.shapes).toHaveLength(1)
+  expect(ps2.shapes[0].shapeType).toBe("circle")
+  if (ps2.shapes[0].shapeType === "circle") {
+    expect(ps2.shapes[0].layer).toBe("signal")
+    expect(ps2.shapes[0].diameter).toBe(10)
+  }
+  expect(ps2.hole?.shape).toBe("oval")
+  expect(ps2.hole?.width).toBe(5)
+  expect(ps2.hole?.height).toBe(10)
+  expect(ps2.hole?.diameter).toBeUndefined()
+
+  // padstack3: rect shape + square hole
+  const ps3 = lib.padstacks![2]
+  expect(ps3.name).toBe("padstack3")
+  expect(ps3.attach).toBe("off")
+  expect(ps3.shapes).toHaveLength(1)
+  expect(ps3.shapes[0].shapeType).toBe("rect")
+  if (ps3.shapes[0].shapeType === "rect") {
+    expect(ps3.shapes[0].layer).toBe("signal")
+    expect(ps3.shapes[0].coordinates).toEqual([0, 0, 10, 10])
+  }
+  expect(ps3.hole?.shape).toBe("square")
+  expect(ps3.hole?.width).toBe(5)
+  expect(ps3.hole?.diameter).toBeUndefined()
+  expect(ps3.hole?.height).toBeUndefined()
+
+  // padstack4: path shape, no hole
+  const ps4 = lib.padstacks![3]
+  expect(ps4.name).toBe("padstack4")
+  expect(ps4.attach).toBe("off")
+  expect(ps4.shapes).toHaveLength(1)
+  expect(ps4.shapes[0].shapeType).toBe("path")
+  if (ps4.shapes[0].shapeType === "path") {
+    expect(ps4.shapes[0].layer).toBe("signal")
+    expect(ps4.shapes[0].width).toBe(1)
+    expect(ps4.shapes[0].coordinates).toEqual([0, 0, 10, 10])
+  }
+  expect(ps4.hole).toBeUndefined()
+
+  // Full round-trip structural equality
+  expect(reparsed.filename).toBe(sessionJson.filename)
+  expect(reparsed.placement.components).toEqual(sessionJson.placement.components)
+  expect(reparsed.routes.network_out.nets).toEqual(
+    sessionJson.routes.network_out.nets,
+  )
 })

--- a/tests/dsn-pcb/stringify-dsn-session-shapes-and-holes.test.ts
+++ b/tests/dsn-pcb/stringify-dsn-session-shapes-and-holes.test.ts
@@ -1,0 +1,59 @@
+import { expect, test } from "bun:test"
+import { parseDsnToDsnJson, stringifyDsnSession, type DsnSession } from "lib"
+
+const sessionDsn = `(session test.dsn
+  (base_design test.dsn)
+  (placement
+    (resolution um 10)
+  )
+  (was_is
+  )
+  (routes 
+    (resolution um 10)
+    (parser
+      (host_cad "test")
+      (host_version "1.0")
+    )
+    (library_out 
+      (image "test_image"
+        (outline (path signal 1 0 0 10 10))
+        (pin padstack1 1 0 0)
+      )
+      (padstack "padstack1"
+        (shape (polygon signal 10 0 0 10 0 10 10 0 10))
+        (attach off)
+        (hole (circle 5))
+      )
+      (padstack "padstack2"
+        (shape (circle signal 10 0 0))
+        (attach off)
+        (hole (oval 5 10))
+      )
+      (padstack "padstack3"
+        (shape (rect signal 0 0 10 10))
+        (attach off)
+        (hole (square 5))
+      )
+      (padstack "padstack4"
+        (shape (path signal 1 0 0 10 10))
+        (attach off)
+      )
+    )
+    (network_out 
+    )
+  )
+)
+`
+
+test("stringify-dsn-session-shapes-and-holes", () => {
+  const sessionJson = parseDsnToDsnJson(sessionDsn) as DsnSession
+  const stringified = stringifyDsnSession(sessionJson)
+  const reparsed = parseDsnToDsnJson(stringified) as DsnSession
+
+  expect(reparsed.routes.library_out?.images?.length).toBe(1)
+  expect(reparsed.routes.library_out?.images?.[0].name).toBe("test_image")
+  expect(reparsed.routes.library_out?.padstacks?.length).toBe(4)
+  expect(reparsed.routes.library_out?.padstacks?.[0].hole?.shape).toBe("circle")
+  expect(reparsed.routes.library_out?.padstacks?.[1].hole?.shape).toBe("oval")
+  expect(reparsed.routes.library_out?.padstacks?.[2].hole?.shape).toBe("square")
+})


### PR DESCRIPTION
Fixes the issue with padstack holes and shapes being lost during conversion. Also allows complex projects like Smoothie Board to be converted without errors. Fixes #54