### PR TITLE
fix: parse voltage-style net names (3.3V, 5V, 12VREG) and unique via IDs

### DIFF
--- a/lib/common/parse-sexpr.ts
+++ b/lib/common/parse-sexpr.ts
@@ -56,6 +56,25 @@ export function tokenizeDsn(input: string): Token[] {
         numStr += input[i]
         i++
       }
+      // Handle scientific notation (e.g. 2844.288e-03, 3594.9e+00)
+      if (i < length && /[eE]/.test(input[i])) {
+        const expStart = i
+        let expStr = input[i]
+        i++
+        if (i < length && /[+-]/.test(input[i])) {
+          expStr += input[i]
+          i++
+        }
+        if (i < length && /\d/.test(input[i])) {
+          while (i < length && /\d/.test(input[i])) {
+            expStr += input[i]
+            i++
+          }
+          numStr += expStr
+        } else {
+          i = expStart // backtrack — not valid scientific notation
+        }
+      }
       // If the next character is not a delimiter (whitespace, parens, quote, EOF),
       // the token is a symbol (e.g. "3.3V"), not a pure number
       if (i < length && !/[\s()"\\]/.test(input[i])) {

--- a/lib/common/parse-sexpr.ts
+++ b/lib/common/parse-sexpr.ts
@@ -45,7 +45,8 @@ export function tokenizeDsn(input: string): Token[] {
       i++ // Skip the closing quote
       tokens.push({ type: "String", value })
     } else if (char === "-" || /\d/.test(char)) {
-      // Parse number (integer or float)
+      // Parse number (integer or float), but fall back to symbol if followed
+      // by non-delimiter characters (e.g. voltage net names like "3.3V", "12VREG")
       let numStr = ""
       if (char === "-") {
         numStr += "-"
@@ -55,7 +56,19 @@ export function tokenizeDsn(input: string): Token[] {
         numStr += input[i]
         i++
       }
-      tokens.push({ type: "Number", value: parseFloat(numStr) })
+      // If the next character is not a delimiter (whitespace, parens, quote, EOF),
+      // the token is a symbol (e.g. "3.3V"), not a pure number
+      if (i < length && !/[\s()"\\]/.test(input[i])) {
+        // Continue reading as a symbol
+        let sym = numStr
+        while (i < length && !/[\s()"\\]/.test(input[i])) {
+          sym += input[i]
+          i++
+        }
+        tokens.push({ type: "Symbol", value: sym })
+      } else {
+        tokens.push({ type: "Number", value: parseFloat(numStr) })
+      }
     } else {
       // Parse symbol
       let sym = ""

--- a/lib/dsn-pcb/dsn-json-to-circuit-json/dsn-component-converters/convert-wires-to-traces.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/dsn-component-converters/convert-wires-to-traces.ts
@@ -42,7 +42,12 @@ export function convertWiresToPcbTraces(
       const viaIndex = viaCounters[netName] ?? 0
       viaCounters[netName] = viaIndex + 1
       tracesAndVias.push(
-        ...convertWiringViaToPcbVias({ wire, transformUmToMm, netName, viaIndex }),
+        ...convertWiringViaToPcbVias({
+          wire,
+          transformUmToMm,
+          netName,
+          viaIndex,
+        }),
       )
       return
     }

--- a/lib/dsn-pcb/dsn-json-to-circuit-json/dsn-component-converters/convert-wires-to-traces.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/dsn-component-converters/convert-wires-to-traces.ts
@@ -20,6 +20,7 @@ export function convertWiresToPcbTraces(
 ): AnyCircuitElement[] {
   const tracesAndVias: AnyCircuitElement[] = []
   const processedNets = new Set<string>()
+  const viaCounters: Record<string, number> = {}
 
   wiring.wires?.forEach((wire) => {
     debug("WIRE\n----\n", wire)
@@ -38,8 +39,10 @@ export function convertWiresToPcbTraces(
 
     if (wire.type === "via") {
       debug("wire is actually a via!")
+      const viaIndex = viaCounters[netName] ?? 0
+      viaCounters[netName] = viaIndex + 1
       tracesAndVias.push(
-        ...convertWiringViaToPcbVias({ wire, transformUmToMm, netName }),
+        ...convertWiringViaToPcbVias({ wire, transformUmToMm, netName, viaIndex }),
       )
       return
     }

--- a/lib/dsn-pcb/dsn-json-to-circuit-json/dsn-component-converters/convert-wiring-via-to-pcb-vias.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/dsn-component-converters/convert-wiring-via-to-pcb-vias.ts
@@ -9,10 +9,12 @@ export const convertWiringViaToPcbVias = ({
   wire,
   transformUmToMm,
   netName,
+  viaIndex = 0,
 }: {
   wire: Wiring["wires"][number]
   transformUmToMm: Matrix
   netName: string
+  viaIndex?: number
 }): PcbVia[] => {
   if (!wire.path?.coordinates || wire.path.coordinates.length < 2) {
     debug("Couldn't create via")
@@ -25,7 +27,7 @@ export const convertWiringViaToPcbVias = ({
   const via: PcbVia = {
     type: "pcb_via",
     layers: ["top", "bottom"],
-    pcb_via_id: `pcb_via_${netName}`,
+    pcb_via_id: `pcb_via_${netName}_${viaIndex}`,
     x: Number(circuitPoint.x.toFixed(4)),
     y: Number(circuitPoint.y.toFixed(4)),
     // TODO look up via size

--- a/tests/dsn-pcb/parse-voltage-net-names.test.ts
+++ b/tests/dsn-pcb/parse-voltage-net-names.test.ts
@@ -1,0 +1,46 @@
+import { expect, test } from "bun:test"
+import { tokenizeDsn } from "lib/common/parse-sexpr"
+import { parseDsnToDsnJson } from "lib"
+import type { DsnPcb } from "lib"
+
+// @ts-ignore
+import smoothieboardDsn from "../assets/repro/smoothieboard-repro.dsn" with {
+  type: "text",
+}
+
+test("tokenizer parses voltage-style net names as symbols, not number+symbol", () => {
+  const tokens = tokenizeDsn("(net 3.3V) (net 5V) (net 12VREG) (net -5.5V_REG)")
+
+  // Find the net name tokens (after the 'net' symbol in each group)
+  const netNameTokens = tokens.filter(
+    (t, i) =>
+      i > 0 &&
+      tokens[i - 1].type === "Symbol" &&
+      tokens[i - 1].value === "net",
+  )
+
+  expect(netNameTokens).toHaveLength(4)
+  expect(netNameTokens[0]).toEqual({ type: "Symbol", value: "3.3V" })
+  expect(netNameTokens[1]).toEqual({ type: "Symbol", value: "5V" })
+  expect(netNameTokens[2]).toEqual({ type: "Symbol", value: "12VREG" })
+  expect(netNameTokens[3]).toEqual({ type: "Symbol", value: "-5.5V_REG" })
+})
+
+test("tokenizer still parses plain numbers correctly", () => {
+  const tokens = tokenizeDsn("(x 3.5) (y -200) (z 0.0)")
+
+  const numberTokens = tokens.filter((t) => t.type === "Number")
+  expect(numberTokens).toHaveLength(3)
+  expect(numberTokens[0]).toEqual({ type: "Number", value: 3.5 })
+  expect(numberTokens[1]).toEqual({ type: "Number", value: -200 })
+  expect(numberTokens[2]).toEqual({ type: "Number", value: 0.0 })
+})
+
+test("smoothieboard DSN nets include voltage-style net names (3.3V, 5V, 12VREG)", () => {
+  const dsnJson = parseDsnToDsnJson(smoothieboardDsn) as DsnPcb
+  const netNames = dsnJson.network?.nets?.map((n: any) => n.name) ?? []
+
+  expect(netNames).toContain("3.3V")
+  expect(netNames).toContain("5V")
+  expect(netNames).toContain("12VREG")
+})

--- a/tests/dsn-pcb/parse-voltage-net-names.test.ts
+++ b/tests/dsn-pcb/parse-voltage-net-names.test.ts
@@ -14,9 +14,7 @@ test("tokenizer parses voltage-style net names as symbols, not number+symbol", (
   // Find the net name tokens (after the 'net' symbol in each group)
   const netNameTokens = tokens.filter(
     (t, i) =>
-      i > 0 &&
-      tokens[i - 1].type === "Symbol" &&
-      tokens[i - 1].value === "net",
+      i > 0 && tokens[i - 1].type === "Symbol" && tokens[i - 1].value === "net",
   )
 
   expect(netNameTokens).toHaveLength(4)


### PR DESCRIPTION
## Problem

The tokenizer in `lib/common/parse-sexpr.ts` (lines 47-58) reads numeric prefixes of tokens and stops when it encounters a non-numeric character. This caused voltage-style net names like `3.3V`, `5V`, and `12VREG` in the Smoothieboard DSN to be split into two separate tokens:

- `3.3V` → `Number(3.3)` + `Symbol("V")` 
- `12VREG` → `Number(12)` + `Symbol("VREG")`

This silently corrupted all connectivity for those nets, breaking routing for boards with voltage supply net names.

## Fix

After consuming digits/decimal in the number-reading branch, peek at the next character. If it is NOT a delimiter (whitespace, `(`, `)`, `"`, EOF), continue reading as a symbol — so `3.3V` is emitted as a single `Symbol("3.3V")` token instead of being split.

Also fixed duplicate `pcb_via_id` values: previously all vias for a net shared `pcb_via_<netName>`. Now includes a per-net counter: `pcb_via_<netName>_<index>`.

## Files Changed

- `lib/common/parse-sexpr.ts` — tokenizer fix
- `lib/dsn-pcb/dsn-json-to-circuit-json/dsn-component-converters/convert-wires-to-traces.ts` — pass via index counter
- `lib/dsn-pcb/dsn-json-to-circuit-json/dsn-component-converters/convert-wiring-via-to-pcb-vias.ts` — use via index in ID
- `tests/dsn-pcb/parse-voltage-net-names.test.ts` — new unit tests for tokenizer behavior and Smoothieboard parsing

## Verification

Manual verification confirms `parseDsnToDsnJson` now returns `3.3V`, `5V`, and `12VREG` as correct net names from the Smoothieboard DSN asset.

fixes part of #54, /claim #54