### PR TITLE
fix: preserve pcb parser options when stringifying dsn

### DIFF
--- a/lib/common/parse-sexpr.ts
+++ b/lib/common/parse-sexpr.ts
@@ -25,6 +25,9 @@ export function tokenizeDsn(input: string): Token[] {
     } else if (/\s/.test(char)) {
       // Ignore whitespace
       i++
+    } else if (char === '"' && input[i + 1] === ")") {
+      tokens.push({ type: "Symbol", value: '"' })
+      i++
     } else if (char === '"') {
       // Parse quoted string
       let value = ""

--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
@@ -15,6 +15,12 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
     return value.toString()
   }
 
+  const stringifyParserAtom = (value: string | undefined, fallback: string) =>
+    value && value.length > 0 ? value : fallback
+
+  const stringifyParserString = (value: string | undefined, fallback: string) =>
+    stringifyValue(value ?? fallback)
+
   // Helper function to stringify an array of coordinates
   const stringifyCoordinates = (coordinates: number[]): string => {
     return coordinates.join(" ")
@@ -31,10 +37,10 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
 
   // Parser section
   result += `${indent}(parser\n`
-  result += `${indent}${indent}(string_quote ")\n`
-  result += `${indent}${indent}(space_in_quoted_tokens on)\n`
-  result += `${indent}${indent}(host_cad "KiCad's Pcbnew")\n`
-  result += `${indent}${indent}(host_version "${dsnJson.parser.host_version}")\n`
+  result += `${indent}${indent}(string_quote ${stringifyParserAtom(dsnJson.parser.string_quote, '"')})\n`
+  result += `${indent}${indent}(space_in_quoted_tokens ${stringifyParserAtom(dsnJson.parser.space_in_quoted_tokens, "on")})\n`
+  result += `${indent}${indent}(host_cad ${stringifyParserString(dsnJson.parser.host_cad, "KiCad's Pcbnew")})\n`
+  result += `${indent}${indent}(host_version ${stringifyParserString(dsnJson.parser.host_version, "")})\n`
   result += `${indent})\n`
 
   // Resolution and unit

--- a/tests/dsn-pcb/stringify-dsn-json.test.ts
+++ b/tests/dsn-pcb/stringify-dsn-json.test.ts
@@ -17,3 +17,41 @@ test("stringify dsn json", () => {
   // Test that we can parse the generated string back to the same structure
   // expect(reparsedJson).toEqual(dsnJson)
 })
+
+test("stringify dsn json preserves pcb parser options", () => {
+  const dsn = `(pcb parser-options
+  (parser
+    (string_quote \`)
+    (space_in_quoted_tokens off)
+    (host_cad "Other CAD")
+    (host_version "1.2.3")
+  )
+  (resolution um 10)
+  (unit um)
+  (structure
+    (layer F.Cu
+      (type signal)
+      (property
+        (index 0)
+      )
+    )
+    (boundary
+      (path F.Cu 0 0 0 100 100)
+    )
+    (via Via_600)
+    (rule
+      (width 100)
+      (clearance 100)
+    )
+  )
+  (placement)
+  (library)
+  (network)
+  (wiring)
+)`
+
+  const dsnJson = parseDsnToDsnJson(dsn) as DsnPcb
+  const reparsedJson = parseDsnToDsnJson(stringifyDsnJson(dsnJson)) as DsnPcb
+
+  expect(reparsedJson.parser).toEqual(dsnJson.parser)
+})


### PR DESCRIPTION
Fixes a narrow PCB DSN parser round-trip gap under #54.

`parseDsnToDsnJson` already stores parser metadata, but `stringifyDsnJson` was hardcoding `string_quote`, `space_in_quoted_tokens`, and `host_cad` back to defaults. This preserves the parsed PCB parser options when stringifying, and adds a small tokenizer guard for the standard `(string_quote ")` atom so existing KiCad DSN parser metadata round-trips cleanly.

Scope is limited to PCB parser option round-tripping; no Circuit JSON conversion behavior changes.

Validation:
- `bun test`
- `bun run format:check`
- `bun run build`

/claim #54

AI-assisted with OpenAI Codex; I reviewed the patch and local verification before opening this PR.