### PR TITLE
fix: omit missing wiring net clauses

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
@@ -135,10 +135,12 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
   // Wiring section
   result += `${indent}(wiring\n`
   ;(dsnJson.wiring?.wires ?? []).forEach((wire) => {
+    const netClause =
+      wire.net === undefined ? "" : `(net ${stringifyValue(wire.net)})`
     if (wire.type === "via") {
-      result += `${indent}${indent}(via ${stringifyPath(wire.path, 3)}(net ${stringifyValue(wire.net)}))\n`
+      result += `${indent}${indent}(via ${stringifyPath(wire.path, 3)}${netClause})\n`
     } else {
-      result += `${indent}${indent}(wire ${stringifyPath(wire.path, 3)}(net ${stringifyValue(wire.net)})(type ${wire.type}))\n`
+      result += `${indent}${indent}(wire ${stringifyPath(wire.path, 3)}${netClause}(type ${wire.type}))\n`
     }
   })
   result += `${indent})\n`

--- a/tests/dsn-pcb/stringify-dsn-json.test.ts
+++ b/tests/dsn-pcb/stringify-dsn-json.test.ts
@@ -17,3 +17,58 @@ test("stringify dsn json", () => {
   // Test that we can parse the generated string back to the same structure
   // expect(reparsedJson).toEqual(dsnJson)
 })
+
+test("stringify dsn json preserves missing wiring net clauses", () => {
+  const dsnJson = parseDsnToDsnJson(`(pcb no-net-wires
+  (parser
+    (string_quote ")
+    (space_in_quoted_tokens on)
+    (host_cad "KiCad's Pcbnew")
+    (host_version "")
+  )
+  (resolution um 10)
+  (unit um)
+  (structure
+    (layer F.Cu
+      (type signal)
+      (property
+        (index 0)
+      )
+    )
+    (layer B.Cu
+      (type signal)
+      (property
+        (index 1)
+      )
+    )
+    (boundary
+      (path pcb 0  0 0 1000 0 1000 1000 0 1000)
+    )
+    (via "Via[0-1]_600:300_um")
+    (rule
+      (width 0)
+    )
+  )
+  (placement)
+  (library)
+  (network)
+  (wiring
+    (wire (path F.Cu 100  0 0 1000 0)(type route))
+    (via (path all 0  500 500))
+  )
+)`) as DsnPcb
+
+  expect(dsnJson.wiring.wires.map((wire) => wire.net === undefined)).toEqual([
+    true,
+    true,
+  ])
+
+  const dsnString = stringifyDsnJson(dsnJson)
+
+  expect(dsnString).not.toContain('(net "")')
+
+  const reparsedJson = parseDsnToDsnJson(dsnString) as DsnPcb
+  expect(
+    reparsedJson.wiring.wires.map((wire) => wire.net === undefined),
+  ).toEqual([true, true])
+})


### PR DESCRIPTION
Fixes a narrow DSN wiring round-trip gap under #54.

`processWire` and `processVia` can produce wiring records with no `net` when a DSN omits `(net ...)`, but `stringifyDsnJson` was emitting `(net "")`. That changes missing net metadata into an empty-string net after parse -> stringify -> parse.

This keeps the stringifier scoped: it emits a `(net ...)` child only when the parsed wire or via actually has `net`, and adds focused coverage for both a no-net wire and a no-net via.

Validation:
- `bun test tests/dsn-pcb/stringify-dsn-json.test.ts`
- `bun test`
- `bun run format:check`
- `bun run build`

/claim #54

AI-assisted with OpenAI Codex; I reviewed the patch and local verification before opening this PR.