### PR TITLE
fix: handle classes without circuit blocks

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
@@ -117,9 +117,11 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
   })
   dsnJson.network.classes.forEach((cls) => {
     result += `${indent}${indent}(class ${stringifyValue(cls.name)} ${stringifyValue(cls.description)}${cls.net_names.map((n) => ` ${stringifyValue(n)}`).join("")}\n`
-    result += `${indent}${indent}${indent}(circuit\n`
-    result += `${indent}${indent}${indent}${indent}(use_via ${stringifyValue(cls.circuit.use_via)})\n`
-    result += `${indent}${indent}${indent})\n`
+    if (cls.circuit) {
+      result += `${indent}${indent}${indent}(circuit\n`
+      result += `${indent}${indent}${indent}${indent}(use_via ${stringifyValue(cls.circuit.use_via)})\n`
+      result += `${indent}${indent}${indent})\n`
+    }
     if (cls.rule) {
       result += `${indent}${indent}${indent}(rule\n`
       result += `${indent}${indent}${indent}${indent}(width ${cls.rule.width})\n`

--- a/tests/dsn-pcb/stringify-dsn-json.test.ts
+++ b/tests/dsn-pcb/stringify-dsn-json.test.ts
@@ -17,3 +17,52 @@ test("stringify dsn json", () => {
   // Test that we can parse the generated string back to the same structure
   // expect(reparsedJson).toEqual(dsnJson)
 })
+
+test("stringify dsn json preserves classes without circuit blocks", () => {
+  const dsnJson = parseDsnToDsnJson(`(pcb optional_class_circuit
+  (parser
+    (string_quote ")
+    (space_in_quoted_tokens on)
+    (host_cad "KiCad's Pcbnew")
+    (host_version "8.0")
+  )
+  (resolution um 10)
+  (unit um)
+  (structure
+    (layer F.Cu
+      (type signal)
+      (property
+        (index 0)
+      )
+    )
+    (boundary
+      (path pcb 0  0 0 1000 0 1000 1000 0 1000)
+    )
+    (via "")
+    (rule
+      (width 100)
+    )
+  )
+  (placement)
+  (library)
+  (network
+    (class no_circuit "" "Net-(R1-Pad1)"
+      (rule
+        (width 100)
+      )
+    )
+  )
+  (wiring)
+)`) as DsnPcb
+
+  expect(dsnJson.network.classes[0].circuit).toBeUndefined()
+
+  const dsnString = stringifyDsnJson(dsnJson)
+
+  expect(dsnString).toContain('(class "no_circuit" "" "Net-(R1-Pad1)"')
+  expect(dsnString).not.toContain("(use_via")
+
+  const reparsedJson = parseDsnToDsnJson(dsnString) as DsnPcb
+  expect(reparsedJson.network.classes[0].circuit).toBeUndefined()
+  expect(reparsedJson.network.classes[0].net_names).toEqual(["Net-(R1-Pad1)"])
+})


### PR DESCRIPTION
Fixes a narrow DSN network class round-trip crash under #54.

`processClass` can parse a DSN `(class ...)` that has no `(circuit ...)` child, but `stringifyDsnJson` unconditionally read `cls.circuit.use_via`. That made parse -> stringify crash for valid class records that only carry net names and/or rule metadata.

This keeps the behavior scoped: emit a class `(circuit ...)` block only when the parsed class actually has circuit data, and add focused parse -> stringify -> parse coverage for a class without a circuit block.

Validation:
- `bun test tests/dsn-pcb/stringify-dsn-json.test.ts`
- `bunx tsc --noEmit`
- `bun run format:check`
- `bun test`
- `bun run build`

/claim #54

AI-assisted with OpenAI Codex; I reviewed the patch and local verification before opening this PR.
