### PR TITLE
fix: correct Specctra DSN via wiring format

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/process-pcb-traces/index.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/process-pcb-traces/index.ts
@@ -25,6 +25,7 @@ interface Wire {
   }
   net: string
   type: string
+  padstack_name?: string
 }
 
 function layerRefToDsnLayer(layer: LayerRef): string {
@@ -148,21 +149,22 @@ export function processPcbTraces(
               dsnWrapper.getStructure()!.via = viaPadstackName
             }
 
-            // Create wire segment for via placement
-            dsnWrapper.addWire({
-              path: {
-                layer: layerRefToDsnLayer(currentLayer as LayerRef),
-                width: DEFAULT_VIA_DIAMETER,
-                coordinates: [
-                  prevPoint.x * CJ_TO_DSN_SCALE,
-                  prevPoint.y * CJ_TO_DSN_SCALE,
-                ],
-              },
-              net: netName,
-              type: "via",
-            })
-          }
-          continue
+          // Create wire segment for via placement
+          dsnWrapper.addWire({
+            path: {
+              layer: layerRefToDsnLayer(currentLayer as LayerRef),
+              width: DEFAULT_VIA_DIAMETER,
+              coordinates: [
+                prevPoint.x * CJ_TO_DSN_SCALE,
+                prevPoint.y * CJ_TO_DSN_SCALE,
+              ],
+            },
+            net: netName,
+            type: "via",
+            padstack_name: viaPadstackName,
+          })
+        }
+        continue
         }
 
         if (point.route_type === "via") {
@@ -202,6 +204,7 @@ export function processPcbTraces(
             },
             net: netName,
             type: "via",
+            padstack_name: viaPadstackName,
           })
 
           currentLayer = point.to_layer

--- a/lib/dsn-pcb/circuit-json-to-dsn-json/process-pcb-traces/index.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/process-pcb-traces/index.ts
@@ -149,22 +149,22 @@ export function processPcbTraces(
               dsnWrapper.getStructure()!.via = viaPadstackName
             }
 
-          // Create wire segment for via placement
-          dsnWrapper.addWire({
-            path: {
-              layer: layerRefToDsnLayer(currentLayer as LayerRef),
-              width: DEFAULT_VIA_DIAMETER,
-              coordinates: [
-                prevPoint.x * CJ_TO_DSN_SCALE,
-                prevPoint.y * CJ_TO_DSN_SCALE,
-              ],
-            },
-            net: netName,
-            type: "via",
-            padstack_name: viaPadstackName,
-          })
-        }
-        continue
+            // Create wire segment for via placement
+            dsnWrapper.addWire({
+              path: {
+                layer: layerRefToDsnLayer(currentLayer as LayerRef),
+                width: DEFAULT_VIA_DIAMETER,
+                coordinates: [
+                  prevPoint.x * CJ_TO_DSN_SCALE,
+                  prevPoint.y * CJ_TO_DSN_SCALE,
+                ],
+              },
+              net: netName,
+              type: "via",
+              padstack_name: viaPadstackName,
+            })
+          }
+          continue
         }
 
         if (point.route_type === "via") {

--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
@@ -136,7 +136,9 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
   result += `${indent}(wiring\n`
   ;(dsnJson.wiring?.wires ?? []).forEach((wire) => {
     if (wire.type === "via") {
-      result += `${indent}${indent}(via ${stringifyPath(wire.path, 3)}(net ${stringifyValue(wire.net)}))\n`
+      const [vx, vy] = wire.path.coordinates
+      const padstackId = wire.padstack_name ?? wire.net ?? "default_via"
+      result += `${indent}${indent}(via ${stringifyValue(padstackId)} ${vx} ${vy} (net ${stringifyValue(wire.net ?? "")}))\n`
     } else {
       result += `${indent}${indent}(wire ${stringifyPath(wire.path, 3)}(net ${stringifyValue(wire.net)})(type ${wire.type}))\n`
     }

--- a/lib/dsn-pcb/types.ts
+++ b/lib/dsn-pcb/types.ts
@@ -282,6 +282,7 @@ export interface Wire {
   net?: string
   clearance_class?: string
   type?: string
+  padstack_name?: string
 }
 
 export interface Via {

--- a/lib/dsn-pcb/types.ts
+++ b/lib/dsn-pcb/types.ts
@@ -79,6 +79,7 @@ export interface DsnPcb {
       }
       net: string
       type: string
+      padstack_name?: string
     }>
   }
 }


### PR DESCRIPTION
Fixes tscircuit/tscircuit#3301

Changes via output from incorrect `(via (path ...)(net ...))` format to proper Specctra DSN format: `(via "padstackName" x y (net "netName"))`. Also adds `padstack_name` field to Wire types.

/claim #3301
