### PR TITLE
fix: declare @tscircuit/math-utils and transformation-matrix as runtime dependencies

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,15 +5,16 @@
     "": {
       "name": "dsn-converter",
       "dependencies": {
+        "@tscircuit/math-utils": "^0.0.36",
         "@tscircuit/soup-util": "^0.0.41",
         "debug": "^4.3.7",
+        "transformation-matrix": "^2.16.1",
         "uuid": "^10.0.0",
         "zod": "^3.23.8",
       },
       "devDependencies": {
         "@biomejs/biome": "^1.9.4",
         "@tscircuit/core": "^0.0.349",
-        "@tscircuit/math-utils": "^0.0.36",
         "@types/bun": "latest",
         "@types/debug": "^4.1.12",
         "@types/react": "^19.0.1",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",
     "@tscircuit/core": "^0.0.349",
-    "@tscircuit/math-utils": "^0.0.36",
     "@types/bun": "latest",
     "@types/debug": "^4.1.12",
     "@types/react": "^19.0.1",
@@ -30,8 +29,10 @@
     "typescript": "^5.0.0"
   },
   "dependencies": {
+    "@tscircuit/math-utils": "^0.0.36",
     "@tscircuit/soup-util": "^0.0.41",
     "debug": "^4.3.7",
+    "transformation-matrix": "^2.16.1",
     "uuid": "^10.0.0",
     "zod": "^3.23.8"
   }


### PR DESCRIPTION
## Problem

`npm install dsn-converter` + `import { parseDsnToCircuitJson } from "dsn-converter"` fails out of the box:

    Cannot find module '@tscircuit/math-utils' from '.../dsn-converter/dist/index.js'

`dist/index.js` imports `@tscircuit/math-utils` (declared only as a devDependency, so consumers never get it) and `transformation-matrix` (used by 10 files in the conversion core, not declared at all — it only resolves when another package happens to hoist it, and breaks under pnpm/isolated layouts).

This class of failure hits any downstream app that consumes the package — likely contributing to the DSN viewer's "Failed to process file" in #54's screenshot, even though `main` parses the Smoothie Board fine.

## Fix

Move `@tscircuit/math-utils` to `dependencies`; declare `transformation-matrix` explicitly. Two-line manifest change, lockfile synced.

## Verification

- Repro of the unfixed failure: clean dir, `bun add dsn-converter@0.0.91`, import → `Cannot find module '@tscircuit/math-utils'`.
- With this fix: `bun run build && bun pm pack`, installed the tarball in a clean project — import succeeds and `parseDsnToCircuitJson(smoothieboard.dsn)` converts the full Issue145 Smoothie Board from freerouting: 1 pcb_board, 836 pcb_smtpad, 219 pcb_plated_hole, 42 pcb_via, 322 source_component, 245 source_net. Can attach the circuit-to-svg render on request.
- `bun test` unaffected (failures on Windows checkouts are pre-existing CRLF snapshot noise, identical on pristine main).

Related note: `circuit-json`'s published dist has the same defect class (`format-si-unit` and `zod` imported but zero dependencies declared) — separate PR opened there.

/claim #54
