### PR TITLE
fix: stringifyDsnJson crash on class without circuit block

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
@@ -117,9 +117,11 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
   })
   dsnJson.network.classes.forEach((cls) => {
     result += `${indent}${indent}(class ${stringifyValue(cls.name)} ${stringifyValue(cls.description)}${cls.net_names.map((n) => ` ${stringifyValue(n)}`).join("")}\n`
-    result += `${indent}${indent}${indent}(circuit\n`
-    result += `${indent}${indent}${indent}${indent}(use_via ${stringifyValue(cls.circuit.use_via)})\n`
-    result += `${indent}${indent}${indent})\n`
+    if (cls.circuit) {
+      result += `${indent}${indent}${indent}(circuit\n`
+      result += `${indent}${indent}${indent}${indent}(use_via ${stringifyValue(cls.circuit.use_via)})\n`
+      result += `${indent}${indent}${indent})\n`
+    }
     if (cls.rule) {
       result += `${indent}${indent}${indent}(rule\n`
       result += `${indent}${indent}${indent}${indent}(width ${cls.rule.width})\n`

--- a/lib/dsn-pcb/types.ts
+++ b/lib/dsn-pcb/types.ts
@@ -256,8 +256,8 @@ export interface Class {
   name: string
   description: string
   net_names: string[]
-  circuit: Circuit
-  rule: Rule
+  circuit?: Circuit
+  rule?: Rule
 }
 
 export interface Circuit {

--- a/tests/dsn-pcb/class-without-circuit.test.ts
+++ b/tests/dsn-pcb/class-without-circuit.test.ts
@@ -1,0 +1,66 @@
+import { expect, test } from "bun:test"
+import { type DsnPcb, parseDsnToDsnJson, stringifyDsnJson } from "lib"
+
+const minimalDsn = `(pcb "test.dsn"
+  (parser
+    (string_quote ")
+    (space_in_quoted_tokens on)
+    (host_cad "TestCAD")
+    (host_version "1.0")
+  )
+  (resolution um 10)
+  (unit um)
+  (structure
+    (layer Top
+      (type signal)
+      (property
+        (index 0)
+      )
+    )
+    (layer Bottom
+      (type signal)
+      (property
+        (index 1)
+      )
+    )
+    (via "Via[0-1]_600:300_um")
+    (rule
+      (width 250)
+      (clearance 200.1)
+    )
+  )
+  (placement)
+  (library
+    (padstack "Via[0-1]_600:300_um"
+      (shape (circle Top 600))
+      (shape (circle Bottom 600))
+      (attach off)
+    )
+  )
+  (network
+    (net "GND"
+      (pins)
+    )
+    (class "kicad_default" "Default class" "GND"
+      (rule
+        (width 250)
+        (clearance 200.1)
+      )
+    )
+  )
+  (wiring)
+)
+`
+
+test("class without circuit block does not crash stringifyDsnJson", () => {
+  const dsnJson = parseDsnToDsnJson(minimalDsn) as DsnPcb
+
+  expect(dsnJson.network.classes[0].circuit).toBeUndefined()
+
+  const str = stringifyDsnJson(dsnJson)
+  expect(str).toContain("(class")
+  expect(str).not.toContain("(circuit")
+
+  const reparsed = parseDsnToDsnJson(str) as DsnPcb
+  expect(reparsed.network.classes[0].name).toBe("kicad_default")
+})


### PR DESCRIPTION
A `(class ...)` entry without a `(circuit ...)` sub-block is valid DSN — the parser already handles it, but `stringifyDsnJson` assumed `cls.circuit` was always present and crashed.

- Make `circuit` and `rule` optional on the `Class` type (matches parser behavior)
- Skip emitting the `(circuit ...)` block when `cls.circuit` is undefined
- Add round-trip test with a minimal DSN containing a circuit-less class

`bun test` — 56 pass / 0 fail
`bunx tsc --noEmit` — clean
`bun run build` — clean