### PR TITLE
Parse DSN planes into copper pours (#54)

### DIFF
--- a/lib/dsn-pcb/dsn-json-to-circuit-json/convert-dsn-pcb-to-circuit-json.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/convert-dsn-pcb-to-circuit-json.ts
@@ -1,13 +1,67 @@
 import { applyToPoint, fromTriangles, scale } from "transformation-matrix"
 
 import { su } from "@tscircuit/soup-util"
-import type { AnyCircuitElement, PcbBoard } from "circuit-json"
+import type {
+  AnyCircuitElement,
+  LayerRef,
+  PcbBoard,
+  PcbCopperPour,
+} from "circuit-json"
 import { pairs } from "lib/utils/pairs"
 import type { DsnPcb } from "../types"
 import { convertDsnPcbComponentsToSourceComponentsAndPorts } from "./dsn-component-converters/convert-dsn-pcb-components-to-source-components-and-ports"
 import { convertNetsToSourceNetsAndTraces } from "./dsn-component-converters/convert-nets-to-source-nets-and-traces"
 import { convertPadstacksToSmtPads } from "./dsn-component-converters/convert-padstacks-to-smtpads"
 import { convertWiresToPcbTraces } from "./dsn-component-converters/convert-wires-to-traces"
+
+function getLayerRefFromDsnLayer(dsnPcb: DsnPcb, dsnLayer: string): LayerRef {
+  if (dsnLayer === "Top" || dsnLayer === "F.Cu" || dsnLayer === "F_Cu") {
+    return "top"
+  }
+  if (dsnLayer === "Bottom" || dsnLayer === "B.Cu" || dsnLayer === "B_Cu") {
+    return "bottom"
+  }
+
+  const layersByIndex = [...dsnPcb.structure.layers].sort(
+    (a, b) => a.property.index - b.property.index,
+  )
+  const layerIndex = layersByIndex.findIndex((layer) => layer.name === dsnLayer)
+
+  if (layerIndex <= 0) return "top"
+  if (layerIndex === layersByIndex.length - 1) return "bottom"
+
+  return `inner${layerIndex}` as LayerRef
+}
+
+function convertPlanesToCopperPours(
+  dsnPcb: DsnPcb,
+  transformDsnUnitToMm: any,
+): PcbCopperPour[] {
+  return (dsnPcb.structure.planes ?? []).map((plane, planeIndex) => {
+    const points = pairs(plane.polygon.coordinates).map(([x, y]) =>
+      applyToPoint(transformDsnUnitToMm, { x, y }),
+    )
+    const firstPoint = points[0]
+    const lastPoint = points[points.length - 1]
+    const normalizedPoints =
+      firstPoint &&
+      lastPoint &&
+      firstPoint.x === lastPoint.x &&
+      firstPoint.y === lastPoint.y
+        ? points.slice(0, -1)
+        : points
+
+    return {
+      type: "pcb_copper_pour",
+      pcb_copper_pour_id: `pcb_copper_pour_plane_${plane.net}_${planeIndex}`,
+      source_net_id: `source_net_${plane.net}`,
+      layer: getLayerRefFromDsnLayer(dsnPcb, plane.polygon.layer),
+      shape: "polygon",
+      points: normalizedPoints,
+      covered_with_solder_mask: true,
+    }
+  })
+}
 
 export function convertDsnPcbToCircuitJson(
   dsnPcb: DsnPcb,
@@ -49,6 +103,7 @@ export function convertDsnPcbToCircuitJson(
   }
 
   elements.push(board)
+  elements.push(...convertPlanesToCopperPours(dsnPcb, transformDsnUnitToMm))
 
   // Convert padstacks to SMT pads using the transformation matrix
   elements.push(...convertPadstacksToSmtPads(dsnPcb, transformDsnUnitToMm))

--- a/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
@@ -30,6 +30,7 @@ import type {
   Pin,
   Placement,
   Places,
+  Plane,
   PolygonShape,
   RectShape,
   Resolution,
@@ -211,6 +212,7 @@ export function processResolution(nodes: ASTNode[]): Resolution {
 export function processStructure(nodes: ASTNode[]): Structure {
   const structure: Partial<Structure> = {
     layers: [],
+    planes: [],
   }
 
   nodes.forEach((node) => {
@@ -224,6 +226,9 @@ export function processStructure(nodes: ASTNode[]): Structure {
             break
           case "boundary":
             structure.boundary = processBoundary(node.children!.slice(1))
+            break
+          case "plane":
+            structure.planes!.push(processPlane(node.children!))
             break
           case "via":
             if (
@@ -242,6 +247,29 @@ export function processStructure(nodes: ASTNode[]): Structure {
   })
 
   return structure as Structure
+}
+
+function processPlane(nodes: ASTNode[]): Plane {
+  const netNode = nodes[1]
+  const polygonNode = nodes.find(
+    (node) =>
+      node.type === "List" &&
+      node.children?.[0]?.type === "Atom" &&
+      node.children[0].value === "polygon",
+  )
+
+  if (netNode?.type !== "Atom" || typeof netNode.value !== "string") {
+    throw new Error("Invalid plane format: missing net name")
+  }
+
+  if (!polygonNode) {
+    throw new Error("Invalid plane format: missing polygon")
+  }
+
+  return {
+    net: netNode.value,
+    polygon: processPolygonShape(polygonNode.children!),
+  }
 }
 
 function processLayer(nodes: ASTNode[]): Layer {

--- a/lib/dsn-pcb/types.ts
+++ b/lib/dsn-pcb/types.ts
@@ -30,6 +30,7 @@ export interface DsnPcb {
         coordinates: number[]
       }
     }
+    planes?: Plane[]
     via: string
     rule: {
       clearances: Array<{
@@ -110,6 +111,7 @@ export interface Resolution {
 export interface Structure {
   layers: Layer[]
   boundary: Boundary
+  planes?: Plane[]
   via: string
   rule: Rule
 }
@@ -137,6 +139,11 @@ export interface Boundary {
     width: number
     coordinates: number[]
   }
+}
+
+export interface Plane {
+  net: string
+  polygon: PolygonShape
 }
 
 export interface Path {

--- a/tests/repros/repro7-smoothie-board.test.ts
+++ b/tests/repros/repro7-smoothie-board.test.ts
@@ -11,6 +11,19 @@ test("smoothieboard repro", async () => {
   const dsnJson = parseDsnToDsnJson(dsnFileWithFreeroutingTrace) as DsnPcb
 
   const circuitJson = convertDsnPcbToCircuitJson(dsnJson)
+  const copperPours = circuitJson.filter(
+    (element) => element.type === "pcb_copper_pour",
+  )
+
+  expect(dsnJson.structure.planes).toHaveLength(1)
+  expect(copperPours).toContainEqual(
+    expect.objectContaining({
+      type: "pcb_copper_pour",
+      layer: "inner1",
+      shape: "polygon",
+      source_net_id: "source_net_AGND",
+    }),
+  )
 
   expect(convertCircuitJsonToPcbSvg(circuitJson)).toMatchSvgSnapshot(
     import.meta.path,


### PR DESCRIPTION
## Summary

- parse plane NET polygon entries from the DSN structure
- convert planes to pcb_copper_pour elements with deterministic outer/inner layer mapping
- remove the duplicated closing polygon point and retain the source net
- cover the Smoothie Board AGND plane on inner1 with a regression assertion

## Verification

- pnpm run build
- targeted Biome check for all changed files

This is the plane/copper-pour slice of #54.

/claim #54