### PR TITLE
feat: add Smoothie Board autoroute_settings and plane support

### DIFF
--- a/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
+++ b/lib/dsn-pcb/circuit-json-to-dsn-json/stringify-dsn-json.ts
@@ -63,6 +63,61 @@ export const stringifyDsnJson = (dsnJson: DsnPcb): string => {
     result += `${indent}${indent}${indent}(clearance ${clearance.value}${clearance.type ? ` (type ${clearance.type})` : ""})\n`
   })
   result += `${indent}${indent})\n`
+  // Autoroute settings section
+  if (dsnJson.structure.autoroute_settings) {
+    const settings = dsnJson.structure.autoroute_settings
+    result += `${indent}${indent}(autoroute_settings\n`
+
+    const emitStringSetting = (
+      key: "fanout" | "autoroute" | "postroute" | "vias",
+    ) => {
+      if (settings[key] !== undefined) {
+        result += `${indent}${indent}${indent}(${key} ${settings[key]})\n`
+      }
+    }
+
+    const emitNumberSetting = (
+      key: "start_ripup_costs" | "start_pass_no",
+    ) => {
+      if (settings[key] !== undefined) {
+        result += `${indent}${indent}${indent}(${key} ${settings[key]})\n`
+      }
+    }
+
+    emitStringSetting("fanout")
+    emitStringSetting("autoroute")
+    emitStringSetting("postroute")
+    emitStringSetting("vias")
+    emitNumberSetting("start_ripup_costs")
+    emitNumberSetting("start_pass_no")
+
+    settings.layer_rules?.forEach((layerRule) => {
+      result += `${indent}${indent}${indent}(layer_rule ${layerRule.layer}\n`
+      if (layerRule.active !== undefined) {
+        result += `${indent}${indent}${indent}${indent}(active ${layerRule.active})\n`
+      }
+      if (layerRule.preferred_direction !== undefined) {
+        result += `${indent}${indent}${indent}${indent}(preferred_direction ${layerRule.preferred_direction})\n`
+      }
+      if (layerRule.preferred_direction_trace_costs !== undefined) {
+        result += `${indent}${indent}${indent}${indent}(preferred_direction_trace_costs ${layerRule.preferred_direction_trace_costs})\n`
+      }
+      if (layerRule.against_preferred_direction_trace_costs !== undefined) {
+        result += `${indent}${indent}${indent}${indent}(against_preferred_direction_trace_costs ${layerRule.against_preferred_direction_trace_costs})\n`
+      }
+      result += `${indent}${indent}${indent})\n`
+    })
+
+    result += `${indent}${indent})\n`
+  }
+
+  // Plane section
+  if (dsnJson.structure.planes && dsnJson.structure.planes.length > 0) {
+    dsnJson.structure.planes.forEach((plane) => {
+      result += `${indent}${indent}(plane ${plane.name} (polygon ${plane.polygon.layer} ${plane.polygon.width} ${stringifyCoordinates(plane.polygon.coordinates)}))\n`
+    })
+  }
+
   result += `${indent})\n`
 
   // Placement section

--- a/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
+++ b/lib/dsn-pcb/dsn-json-to-circuit-json/parse-dsn-to-dsn-json.ts
@@ -7,6 +7,8 @@ import {
   tokenizeDsn,
 } from "../../common/parse-sexpr"
 import type {
+  AutorouteLayerRule,
+  AutorouteSettings,
   Boundary,
   CircleShape,
   Circuit,
@@ -30,6 +32,7 @@ import type {
   Pin,
   Placement,
   Places,
+  Plane,
   PolygonShape,
   RectShape,
   Resolution,
@@ -236,12 +239,129 @@ export function processStructure(nodes: ASTNode[]): Structure {
           case "rule":
             structure.rule = processRule(node.children!.slice(1))
             break
+          case "autoroute_settings":
+            structure.autoroute_settings = processAutorouteSettings(
+              node.children!.slice(1),
+            )
+            break
+          case "plane":
+            structure.planes ??= []
+            structure.planes.push(processPlane(node.children!))
+            break
         }
       }
     }
   })
 
   return structure as Structure
+}
+
+function processAutorouteSettings(nodes: ASTNode[]): AutorouteSettings {
+  const settings: AutorouteSettings = {}
+
+  nodes.forEach((node) => {
+    if (node.type !== "List") return
+
+    const [keyNode, ...rest] = node.children!
+    if (keyNode.type !== "Atom" || typeof keyNode.value !== "string") return
+
+    const key = keyNode.value
+    const first = rest[0]
+
+    switch (key) {
+      case "fanout":
+      case "autoroute":
+      case "postroute":
+      case "vias":
+        if (first?.type === "Atom" && typeof first.value === "string") {
+          settings[key] = first.value
+        }
+        break
+      case "start_ripup_costs":
+      case "start_pass_no":
+        if (first?.type === "Atom" && typeof first.value === "number") {
+          settings[key] = first.value
+        }
+        break
+      case "layer_rule":
+        settings.layer_rules ??= []
+        settings.layer_rules.push(processAutorouteLayerRule(rest))
+        break
+    }
+  })
+
+  return settings
+}
+
+function processAutorouteLayerRule(nodes: ASTNode[]): AutorouteLayerRule {
+  const layerRule: AutorouteLayerRule = {
+    layer:
+      nodes[0]?.type === "Atom" && typeof nodes[0].value === "string"
+        ? nodes[0].value
+        : "",
+  }
+
+  nodes.slice(1).forEach((node) => {
+    if (node.type !== "List") return
+
+    const [keyNode, valueNode] = node.children!
+    if (keyNode.type !== "Atom" || typeof keyNode.value !== "string") return
+
+    switch (keyNode.value) {
+      case "active":
+      case "preferred_direction":
+        if (valueNode?.type === "Atom" && typeof valueNode.value === "string") {
+          layerRule[keyNode.value] = valueNode.value
+        }
+        break
+      case "preferred_direction_trace_costs":
+      case "against_preferred_direction_trace_costs":
+        if (valueNode?.type === "Atom" && typeof valueNode.value === "number") {
+          layerRule[keyNode.value] = valueNode.value
+        }
+        break
+    }
+  })
+
+  return layerRule
+}
+
+function processPlane(nodes: ASTNode[]): Plane {
+  const plane: Partial<Plane> = {
+    name:
+      nodes[1]?.type === "Atom" && typeof nodes[1].value === "string"
+        ? nodes[1].value
+        : "",
+  }
+
+  // Find the polygon definition
+  for (let i = 2; i < nodes.length; i++) {
+    const node = nodes[i]
+    if (node.type === "List" && node.children?.[0]?.type === "Atom") {
+      const firstVal = node.children[0].value
+      if (firstVal === "polygon" && node.children.length >= 4) {
+        const layerNode = node.children[1]
+        const widthNode = node.children[2]
+        plane.polygon = {
+          layer:
+            layerNode.type === "Atom" && typeof layerNode.value === "string"
+              ? layerNode.value
+              : "",
+          width:
+            widthNode.type === "Atom" && typeof widthNode.value === "number"
+              ? widthNode.value
+              : 0,
+          coordinates: node.children
+            .slice(3)
+            .filter((n) => n.type === "Atom" && typeof n.value === "number")
+            .map((n) => n.value as number),
+        }
+        break
+      }
+    }
+  }
+
+  return plane as Plane
 }
 
 function processLayer(nodes: ASTNode[]): Layer {

--- a/lib/dsn-pcb/types.ts
+++ b/lib/dsn-pcb/types.ts
@@ -112,6 +112,35 @@ export interface Structure {
   boundary: Boundary
   via: string
   rule: Rule
+  autoroute_settings?: AutorouteSettings
+  planes?: Plane[]
+}
+
+export interface Plane {
+  name: string
+  polygon: {
+    layer: string
+    width: number
+    coordinates: number[]
+  }
+}
+
+export interface AutorouteSettings {
+  fanout?: string
+  autoroute?: string
+  postroute?: string
+  vias?: string
+  start_ripup_costs?: number
+  start_pass_no?: number
+  layer_rules?: AutorouteLayerRule[]
+}
+
+export interface AutorouteLayerRule {
+  layer: string
+  active?: string
+  preferred_direction?: string
+  preferred_direction_trace_costs?: number
+  against_preferred_direction_trace_costs?: number
 }
 
 export interface Layer {

--- a/tests/dsn-pcb/autoroute-and-plane.test.ts
+++ b/tests/dsn-pcb/autoroute-and-plane.test.ts
@@ -1,0 +1,258 @@
+import { expect, test } from "bun:test"
+import { parseDsnToDsnJson, stringifyDsnJson } from "lib"
+import type { DsnPcb } from "lib"
+import { readFileSync } from "fs"
+import { join } from "path"
+
+test("parse autoroute_settings from DSN", () => {
+  const dsnJson = parseDsnToDsnJson(`(pcb "autoroute-test.dsn"
+  (parser
+    (string_quote ")
+    (space_in_quoted_tokens on)
+    (host_cad "KiCad's Pcbnew")
+    (host_version "(8.0.0)")
+  )
+  (resolution um 10)
+  (unit um)
+  (structure
+    (layer F.Cu
+      (type signal)
+      (property (index 0))
+    )
+    (layer B.Cu
+      (type signal)
+      (property (index 1))
+    )
+    (boundary
+      (path pcb 0 0 0 1000 0 1000 1000 0 1000 0 0)
+    )
+    (via "Via[0-1]_600:300_um")
+    (rule
+      (width 200)
+      (clearance 200)
+    )
+    (autoroute_settings
+      (fanout off)
+      (autoroute on)
+      (postroute on)
+      (vias on)
+      (start_ripup_costs 100)
+      (start_pass_no 4)
+      (layer_rule F.Cu
+        (active on)
+        (preferred_direction horizontal)
+        (preferred_direction_trace_costs 1.0)
+        (against_preferred_direction_trace_costs 2.7)
+      )
+      (layer_rule B.Cu
+        (active on)
+        (preferred_direction vertical)
+        (preferred_direction_trace_costs 1.0)
+        (against_preferred_direction_trace_costs 1.6)
+      )
+    )
+  )
+  (placement)
+  (library)
+  (network)
+  (wiring)
+)`) as DsnPcb
+
+  expect(dsnJson.structure.autoroute_settings).toEqual({
+    fanout: "off",
+    autoroute: "on",
+    postroute: "on",
+    vias: "on",
+    start_ripup_costs: 100,
+    start_pass_no: 4,
+    layer_rules: [
+      {
+        layer: "F.Cu",
+        active: "on",
+        preferred_direction: "horizontal",
+        preferred_direction_trace_costs: 1,
+        against_preferred_direction_trace_costs: 2.7,
+      },
+      {
+        layer: "B.Cu",
+        active: "on",
+        preferred_direction: "vertical",
+        preferred_direction_trace_costs: 1,
+        against_preferred_direction_trace_costs: 1.6,
+      },
+    ],
+  })
+})
+
+test("stringify and round-trip autoroute_settings", () => {
+  const dsnJson = parseDsnToDsnJson(`(pcb "autoroute-roundtrip.dsn"
+  (parser
+    (string_quote ")
+    (space_in_quoted_tokens on)
+    (host_cad "KiCad's Pcbnew")
+    (host_version "(8.0.0)")
+  )
+  (resolution um 10)
+  (unit um)
+  (structure
+    (layer F.Cu
+      (type signal)
+      (property (index 0))
+    )
+    (layer B.Cu
+      (type signal)
+      (property (index 1))
+    )
+    (boundary
+      (path pcb 0 0 0 1000 0 1000 1000 0 1000 0 0)
+    )
+    (via "Via[0-1]_600:300_um")
+    (rule
+      (width 200)
+      (clearance 200)
+    )
+    (autoroute_settings
+      (fanout off)
+      (autoroute on)
+      (postroute on)
+      (vias on)
+      (start_ripup_costs 100)
+      (start_pass_no 4)
+      (layer_rule F.Cu
+        (active on)
+        (preferred_direction horizontal)
+        (preferred_direction_trace_costs 1.0)
+        (against_preferred_direction_trace_costs 2.7)
+      )
+    )
+  )
+  (placement)
+  (library)
+  (network)
+  (wiring)
+)`) as DsnPcb
+
+  const reparsedJson = parseDsnToDsnJson(stringifyDsnJson(dsnJson)) as DsnPcb
+
+  expect(reparsedJson.structure.autoroute_settings).toEqual(
+    dsnJson.structure.autoroute_settings,
+  )
+})
+
+test("parse plane from DSN structure", () => {
+  const dsnJson = parseDsnToDsnJson(`(pcb "plane-test.dsn"
+  (parser
+    (string_quote ")
+    (space_in_quoted_tokens on)
+    (host_cad "KiCad's Pcbnew")
+    (host_version "(5.1.9)-1")
+  )
+  (resolution um 10)
+  (unit um)
+  (structure
+    (layer Top
+      (type signal)
+      (property (index 0))
+    )
+    (layer Bottom
+      (type signal)
+      (property (index 1))
+    )
+    (boundary
+      (path pcb 0 0 0 1000 0 1000 1000 0 1000 0 0)
+    )
+    (plane AGND (polygon Route2 0 214249 -158877 82677 -159512 82550 -50673 214376 -50673 214249 -158877))
+    (via "Via[0-1]_600:300_um")
+    (rule
+      (width 200)
+      (clearance 200)
+    )
+  )
+  (placement)
+  (library)
+  (network)
+  (wiring)
+)`) as DsnPcb
+
+  expect(dsnJson.structure.planes).toEqual([
+    {
+      name: "AGND",
+      polygon: {
+        layer: "Route2",
+        width: 0,
+        coordinates: [
+          214249, -158877, 82677, -159512, 82550, -50673, 214376,
+          -50673, 214249, -158877,
+        ],
+      },
+    },
+  ])
+})
+
+test("stringify and round-trip plane", () => {
+  const dsnJson = parseDsnToDsnJson(`(pcb "plane-roundtrip.dsn"
+  (parser
+    (string_quote ")
+    (space_in_quoted_tokens on)
+    (host_cad "KiCad's Pcbnew")
+    (host_version "(5.1.9)-1")
+  )
+  (resolution um 10)
+  (unit um)
+  (structure
+    (layer Top
+      (type signal)
+      (property (index 0))
+    )
+    (layer Bottom
+      (type signal)
+      (property (index 1))
+    )
+    (boundary
+      (path pcb 0 0 0 1000 0 1000 1000 0 1000 0 0)
+    )
+    (plane AGND (polygon Route2 0 214249 -158877 82677 -159512 82550 -50673 214376 -50673 214249 -158877))
+    (via "Via[0-1]_600:300_um")
+    (rule
+      (width 200)
+      (clearance 200)
+    )
+  )
+  (placement)
+  (library)
+  (network)
+  (wiring)
+)`) as DsnPcb
+
+  const reparsedJson = parseDsnToDsnJson(stringifyDsnJson(dsnJson)) as DsnPcb
+
+  expect(reparsedJson.structure.planes).toEqual(
+    dsnJson.structure.planes,
+  )
+})
+
+test("smoothie board DSN round-trip preserves all structure fields", () => {
+  const dsnContent = readFileSync(
+    join(__dirname, "../assets/repro/smoothieboard-repro.dsn"),
+    "utf-8",
+  )
+
+  const dsnJson = parseDsnToDsnJson(dsnContent) as DsnPcb
+  const stringified = stringifyDsnJson(dsnJson)
+  const reparsedJson = parseDsnToDsnJson(stringified) as DsnPcb
+
+  // Verify plane is preserved in round-trip
+  expect(reparsedJson.structure.planes).toEqual(dsnJson.structure.planes)
+
+  // Verify all other structure fields are preserved
+  expect(reparsedJson.structure.layers).toEqual(dsnJson.structure.layers)
+  expect(reparsedJson.structure.boundary).toEqual(dsnJson.structure.boundary)
+  expect(reparsedJson.structure.via).toEqual(dsnJson.structure.via)
+  expect(reparsedJson.structure.rule).toEqual(dsnJson.structure.rule)
+
+  // Verify the plane was parsed correctly
+  expect(dsnJson.structure.planes).toBeDefined()
+  expect(dsnJson.structure.planes!.length).toBe(1)
+  expect(dsnJson.structure.planes![0].name).toBe("AGND")
+  expect(dsnJson.structure.planes![0].polygon.layer).toBe("Route2")
+})


### PR DESCRIPTION
## Summary

Implements parsing and stringification for two DSN structure features required to convert Smoothie Board DSN files to Circuit JSON:

### autoroute_settings
- Parses autoroute_settings block with fanout, autoroute, postroute, vias, start_ripup_costs, start_pass_no
- Parses layer_rule entries with active, preferred_direction, trace cost settings
- Full round-trip stringification back to DSN format

### Plane support
- Parses plane blocks with polygon (layer, width, coordinates)
- Full round-trip stringification back to DSN format

## Tests
- 5 new tests in tests/dsn-pcb/autoroute-and-plane.test.ts:
  - Parse autoroute_settings from DSN
  - Round-trip autoroute_settings through stringify → parse
  - Parse plane from DSN structure
  - Round-trip plane through stringify → parse
  - Smoothie Board DSN round-trip preserves all structure fields (reads from fixture)

Closes #54